### PR TITLE
Include links to documentation in README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ BLOM documetation is integrated in the general NorESM documentation on ReadTheDo
 - [BLOM model description](https://noresm-docs.readthedocs.io/en/noresm2/model-description/ocn_model.html)
 - [iHAMOCC model description](https://noresm-docs.readthedocs.io/en/noresm2/model-description/ocn_model.html)
 
+### Working with the BLOM git repository
+
+The [BLOM wiki](https://github.com/NorESMhub/BLOM/wiki) includes instructions on how to contribute to the BLOM/iHAMOCC model system, and how to work with the BLOM git repository with your own fork on gitHub.
+
 ## License
 
 BLOM is licensed under the GNU Lesser General Public License - see the

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This is the source code of BLOM and includes the ocean biogeochemistry
 model iHAMOCC. BLOM is the ocean component of the Norwegian Earth System
 Model (<https://github.com/NorESMhub/NorESM>).
 
+## BLOM documentation
+
+BLOM documetation is integrated in the general NorESM documentation on ReadTheDocs (<https://noresm-docs.readthedocs.io/en/noresm2/>).
+- [Running OMIP-type experiments](https://noresm-docs.readthedocs.io/en/noresm2/configurations/omips.html#blom)
+- [BLOM model description](https://noresm-docs.readthedocs.io/en/noresm2/model-description/ocn_model.html)
+- [iHAMOCC model description](https://noresm-docs.readthedocs.io/en/noresm2/model-description/ocn_model.html)
+
 ## License
 
 BLOM is licensed under the GNU Lesser General Public License - see the


### PR DESCRIPTION
Closes #16 
Links directly to noresm2 documentation pages, so these links must be updated with new releases of NorESM. Maybe change these links to 'latest' at some point, but at the moment noresm 'master' is behind 'noresm2'.