### PR TITLE
Added a "dummy" testlist_blom.xml

### DIFF
--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<testlist version="2.0">
+  <test name="ERB" grid="T62_tn14" compset="NOIIA" testmods="blom/default">
+    <machines>
+      <machine name="fram" compiler="intel" category="blom"/>
+    </machines>
+  </test>
+</testlist>


### PR DESCRIPTION
Added a "dummy" testlist_blom.xml so that when unsupported compsets and grid combinations are used, a meaningful warning is displayed.