### PR TITLE
added feature for missing compsets from featureCESM2.1.0-OsloDevelopment

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -91,6 +91,8 @@
       <value compset="SSP126_CAM60%NORESM.*_BLOM%ECO"  >ssp126</value>
       <value compset="SSP245_CAM60%NORESM.*_BLOM%ECO"  >ssp245</value>
       <value compset="SSP370_CAM60%NORESM.*_BLOM%ECO"  >ssp370</value>
+      <value compset="SSP370LOWNTCF_CAM60%NORESM.*_BLOM%ECO"      >ssp370</value>
+      <value compset="SSP370REFGHGLOWNTCF_CAM60%NORESM.*_BLOM%ECO">ssp370</value>
       <value compset="SSP434_CAM60%NORESM.*_BLOM%ECO"  >ssp434</value>
       <value compset="SSP460_CAM60%NORESM.*_BLOM%ECO"  >ssp460</value>
       <value compset="SSP534OS_CAM60%NORESM.*_BLOM%ECO">ssp534os</value>


### PR DESCRIPTION
The two compsets NSSP370LOWNTCFfrc2 and NSSP370REFGHGLOWNTCFfrc2 (which existed in the old repository in the branch featureCESM2.1.0-OsloDevelopment) have been taken over to the new distributed git-repository structure.

To take into account the N-deposition, two lines have to be added in cime_config/config_component.xml.