### PR TITLE
Add multiple instance of CESM2 support.

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -26,6 +26,8 @@ set HAMOCC_CISO = `./xmlquery HAMOCC_CISO --value`
 set RUN_STARTDATE = `./xmlquery RUN_STARTDATE --value`
 set PIO_TYPENAME_OCN = `./xmlquery PIO_TYPENAME_OCN --value`
 set PIO_NETCDF_FORMAT_OCN = `./xmlquery PIO_NETCDF_FORMAT_OCN --value`
+## for multiple instance
+set NINST_OCN = `./xmlquery NINST_OCN --value`
 cd $EXEROOT/ocn/obj
 set CONFIG_OCN_DIR = $CONFIG_OCN_DIR1/../
 
@@ -684,20 +686,28 @@ else
   exit -1
 endif
 
-# modify namelist variables as specified in user_nl_blom
-foreach line ("`grep = $CASEROOT/user_nl_blom`")
-  if (`echo "$line" | tr -d ' ' | cut -c -1` != '#') then
-    set var = `echo "$line" | sed 's/=.*//' | tr '[a-z]' '[A-Z]'`
-    set val = `echo "$line" | sed 's/.*=//'`
-    eval 'set $var = "$val"'
-  endif
-end
 
 #------------------------------------------------------------------------------
 # Create resolved namelist
 #------------------------------------------------------------------------------
+## multiple instance
+foreach mem ("`seq $NINST_OCN`")
+    if ( ${NINST_OCN} == '1' ) then
+        set inststr = ''
+    else
+        set inststr = ("`printf '_%4.4d' $mem`")
+    endif
 
-cat >! $RUNDIR/ocn_in << EOF
+    # modify namelist variables as specified in user_nl_blom
+    foreach line ("`grep = $CASEROOT/user_nl_blom$inststr`")
+      if (`echo "$line" | tr -d ' ' | cut -c -1` != '#') then
+        set var = `echo "$line" | sed 's/=.*//' | tr '[a-z]' '[A-Z]'`
+        set val = `echo "$line" | sed 's/.*=//'`
+        eval 'set $var = "$val"'
+      endif
+    end
+
+cat >! $RUNDIR/ocn_in$inststr << EOF
 ! LIMITS NAMELIST
 !
 ! CONTENTS:
@@ -887,7 +897,7 @@ cat >! $RUNDIR/ocn_in << EOF
 EOF
 
 if ($?CWMTAG) then
-cat >>! $RUNDIR/ocn_in << EOF
+cat >>! $RUNDIR/ocn_in$inststr << EOF
  
 ! NAMELIST FOR CHANNEL WIDTH MODIFICATIONS
 !
@@ -910,7 +920,7 @@ cat >>! $RUNDIR/ocn_in << EOF
 EOF
 endif
 
-cat >>! $RUNDIR/ocn_in << EOF
+cat >>! $RUNDIR/ocn_in$inststr << EOF
 
 ! NAMELIST FOR MERIDIONAL OVERTURNING AND FLUX DIAGNOSTICS
 !
@@ -1268,7 +1278,7 @@ cat >>! $RUNDIR/ocn_in << EOF
 EOF
 
 if ($ecosys == TRUE) then
-cat >>! $RUNDIR/ocn_in << EOF
+cat >>! $RUNDIR/ocn_in$inststr << EOF
 
 ! NAMELIST FOR iHAMOCC OPTIONS
 !
@@ -1626,6 +1636,8 @@ cat >>! $RUNDIR/ocn_in << EOF
 /
 EOF
 endif
+
+end ## foreach mem ("`seq $NINST_OCN`")
 
 #------------------------------------------------------------------------------
 # Generate blom.input_data_list

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -26,7 +26,6 @@ set HAMOCC_CISO = `./xmlquery HAMOCC_CISO --value`
 set RUN_STARTDATE = `./xmlquery RUN_STARTDATE --value`
 set PIO_TYPENAME_OCN = `./xmlquery PIO_TYPENAME_OCN --value`
 set PIO_NETCDF_FORMAT_OCN = `./xmlquery PIO_NETCDF_FORMAT_OCN --value`
-## for multiple instance
 set NINST_OCN = `./xmlquery NINST_OCN --value`
 cd $EXEROOT/ocn/obj
 set CONFIG_OCN_DIR = $CONFIG_OCN_DIR1/../
@@ -690,22 +689,21 @@ endif
 #------------------------------------------------------------------------------
 # Create resolved namelist
 #------------------------------------------------------------------------------
-## multiple instance
 foreach mem ("`seq $NINST_OCN`")
-    if ( ${NINST_OCN} == '1' ) then
-        set inststr = ''
-    else
-        set inststr = ("`printf '_%4.4d' $mem`")
-    endif
+  if ( ${NINST_OCN} == '1' ) then
+    set inststr = ''
+  else
+    set inststr = ("`printf '_%4.4d' $mem`")
+  endif
 
-    # modify namelist variables as specified in user_nl_blom
-    foreach line ("`grep = $CASEROOT/user_nl_blom$inststr`")
-      if (`echo "$line" | tr -d ' ' | cut -c -1` != '#') then
-        set var = `echo "$line" | sed 's/=.*//' | tr '[a-z]' '[A-Z]'`
-        set val = `echo "$line" | sed 's/.*=//'`
-        eval 'set $var = "$val"'
-      endif
-    end
+  # modify namelist variables as specified in user_nl_blom
+  foreach line ("`grep = $CASEROOT/user_nl_blom$inststr`")
+    if (`echo "$line" | tr -d ' ' | cut -c -1` != '#') then
+    set var = `echo "$line" | sed 's/=.*//' | tr '[a-z]' '[A-Z]'`
+    set val = `echo "$line" | sed 's/.*=//'`
+    eval 'set $var = "$val"'
+    endif
+  end
 
 cat >! $RUNDIR/ocn_in$inststr << EOF
 ! LIMITS NAMELIST

--- a/drivers/cpl_mct/ocn_comp_mct.F90
+++ b/drivers/cpl_mct/ocn_comp_mct.F90
@@ -48,7 +48,7 @@ module ocn_comp_mct
    use blom_cpl_indices
    use data_mct, only : runid_mct, runtyp_mct, ocn_cpl_dt_mct
    use mod_xc
-   use blom_instance, only: blom_instance_init
+   use mod_instance, only: blom_instance_init
 
    implicit none
 

--- a/drivers/cpl_mct/ocn_comp_mct.F90
+++ b/drivers/cpl_mct/ocn_comp_mct.F90
@@ -48,6 +48,7 @@ module ocn_comp_mct
    use blom_cpl_indices
    use data_mct, only : runid_mct, runtyp_mct, ocn_cpl_dt_mct
    use mod_xc
+   use blom_instance, only: blom_instance_init
 
    implicit none
 
@@ -108,6 +109,9 @@ module ocn_comp_mct
 
       ! Get file unit
       nfu = shr_file_getUnit()
+
+      ! multiple instance
+      call blom_instance_init(OCNID)
 
       ! ----------------------------------------------------------------
       ! Initialize the model run

--- a/drivers/cpl_mct/setlogunit.F
+++ b/drivers/cpl_mct/setlogunit.F
@@ -23,6 +23,7 @@
 
       use mod_xc
       use shr_file_mod, only: shr_file_getUnit, shr_file_setIO
+      use blom_instance, only: inst_suffix
 
       implicit none
 
@@ -32,10 +33,10 @@
       ! Redirect standard out to a log file if requested
       ! ----------------------------------------------------------------
       if (mnproc.eq.1) then
-         inquire(file = 'ocn_modelio.nml', exist = exists)
+         inquire(file = 'ocn_modelio.nml'// trim(inst_suffix), exist = exists)
          if (exists) then
             lp = shr_file_getUnit()
-            call shr_file_setIO('ocn_modelio.nml', lp)
+            call shr_file_setIO('ocn_modelio.nml'// trim(inst_suffix), lp)
          endif
       endif
 

--- a/drivers/cpl_mct/setlogunit.F
+++ b/drivers/cpl_mct/setlogunit.F
@@ -23,7 +23,7 @@
 
       use mod_xc
       use shr_file_mod, only: shr_file_getUnit, shr_file_setIO
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 
       implicit none
 
@@ -33,10 +33,10 @@
       ! Redirect standard out to a log file if requested
       ! ----------------------------------------------------------------
       if (mnproc.eq.1) then
-         inquire(file = 'ocn_modelio.nml'// trim(inst_suffix), exist = exists)
+         inquire(file = 'ocn_modelio.nml'//trim(inst_suffix), exist = exists)
          if (exists) then
             lp = shr_file_getUnit()
-            call shr_file_setIO('ocn_modelio.nml'// trim(inst_suffix), lp)
+            call shr_file_setIO('ocn_modelio.nml'//trim(inst_suffix), lp)
          endif
       endif
 

--- a/drivers/cpl_mct/sumsbuff_mct.F
+++ b/drivers/cpl_mct/sumsbuff_mct.F
@@ -84,6 +84,8 @@
             sbuff(i,j,index_o2x_So_dhdx) =
      .         sbuff(i,j,index_o2x_So_dhdx)
      .       + (sealv(i,j)-sealv(i-1,j))*scuxi(i,j)*baclin
+!         write(*,*)'sealv(i,j)',sealv(i,j),scuxi(i,j),u(i,j,k1n)
+!         write(*,*)'sealv(i,j)1',ubflxs(i,j,m),pbu(i,j,n),scuy(i,j)
          enddo
          enddo
       enddo

--- a/drivers/cpl_mct/sumsbuff_mct.F
+++ b/drivers/cpl_mct/sumsbuff_mct.F
@@ -84,8 +84,6 @@
             sbuff(i,j,index_o2x_So_dhdx) =
      .         sbuff(i,j,index_o2x_So_dhdx)
      .       + (sealv(i,j)-sealv(i-1,j))*scuxi(i,j)*baclin
-!         write(*,*)'sealv(i,j)',sealv(i,j),scuxi(i,j),u(i,j,k1n)
-!         write(*,*)'sealv(i,j)1',ubflxs(i,j,m),pbu(i,j,n),scuy(i,j)
          enddo
          enddo
       enddo

--- a/drivers/noforc/blom.F
+++ b/drivers/noforc/blom.F
@@ -25,7 +25,7 @@ c --- ------------------------------------------------------------------
 c
       use mod_xc
       use data_mct
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 c
       implicit none
 c
@@ -41,7 +41,7 @@ c
       mpicom_external=mpi_comm_world
 #endif
 c
-      open (unit=nfu,file='ocn_in'// trim(inst_suffix),status='old',action='read')
+      open (unit=nfu,file='ocn_in'//trim(inst_suffix),status='old',action='read')
       read (nfu,'(i6)') i
       read (nfu,*)
       read (nfu,*)

--- a/drivers/noforc/blom.F
+++ b/drivers/noforc/blom.F
@@ -25,6 +25,7 @@ c --- ------------------------------------------------------------------
 c
       use mod_xc
       use data_mct
+      use blom_instance, only: inst_suffix
 c
       implicit none
 c
@@ -40,7 +41,7 @@ c
       mpicom_external=mpi_comm_world
 #endif
 c
-      open (unit=nfu,file='ocn_in',status='old',action='read')
+      open (unit=nfu,file='ocn_in'// trim(inst_suffix),status='old',action='read')
       read (nfu,'(i6)') i
       read (nfu,*)
       read (nfu,*)

--- a/hamocc/aufr_bgc.F90
+++ b/hamocc/aufr_bgc.F90
@@ -111,6 +111,7 @@
       USE mo_sedmnt,    only: sedhpl
       use mod_dia,      only : iotype
       use mo_intfcblom, only: sedlay2,powtra2,burial2,atm2
+      use blom_instance, only: inst_suffix
       implicit none
 #ifdef PNETCDF
 #include <pnetcdf.inc>
@@ -145,16 +146,18 @@
       character(len=3) :: stripestr
       character(len=9) :: stripestr2
       integer :: ierr,testio
+      INTEGER :: lenInRstfn
 
       locetra(:,:,:,:) = 0.0
 !
 ! Open netCDF data file
 !
       testio=0
+      lenInRstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
       IF(mnproc==1 .AND. IOTYPE==0) THEN
 
         i=1
-        do while (rstfnm_ocn(i:i+7).ne.'.blom.r.' .AND.              &
+        do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(inst_suffix)//'.r.' .AND.              &
      &            rstfnm_ocn(i:i+8).ne.'.micom.r.')
           i=i+1
           if (i+8.gt.len(rstfnm_ocn)) then
@@ -164,12 +167,11 @@
             stop '(aufr_bgc)'
           endif
         enddo
-        if (rstfnm_ocn(i:i+7).eq.'.blom.r.') then
-          rstfnm=rstfnm_ocn(1:i-1)//'.blom.rbgc.'//rstfnm_ocn(i+8:)
+        if (rstfnm_ocn(i:i+lenInRstfn).eq.'.blom'//trim(inst_suffix)  //'.r.') then
+          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
         else
           rstfnm=rstfnm_ocn(1:i-1)//'.micom.rbgc.'//rstfnm_ocn(i+9:)
         endif
-
         ncstat = NF90_OPEN(rstfnm,NF90_NOWRITE, ncid)
         IF ( ncstat .NE. NF90_NOERR ) THEN
              CALL xchalt('(AUFR: Problem with netCDF1)')
@@ -201,7 +203,7 @@
 #ifdef PNETCDF
         testio=1
         i=1
-        do while (rstfnm_ocn(i:i+7).ne.'.blom.r.' .AND.              &
+        do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(lenInRstfn)//'.r.' .AND.              &
      &            rstfnm_ocn(i:i+8).ne.'.micom.r.')
           i=i+1
           if (i+8.gt.len(rstfnm_ocn)) then
@@ -211,8 +213,8 @@
             stop '(aufr_bgc)'
           endif
         enddo
-        if (rstfnm_ocn(i:i+7).eq.'.blom.r.') then
-          rstfnm=rstfnm_ocn(1:i-1)//'.blom.rbgc.'//rstfnm_ocn(i+8:)
+        if (rstfnm_ocn(i:i+lenInRstfn).eq.'.blom'//trim(lenInRstfn)//   '.r.') then
+          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(lenInRstfn)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
         else
           rstfnm=rstfnm_ocn(1:i-1)//'.micom.rbgc.'//rstfnm_ocn(i+9:)
         endif

--- a/hamocc/aufr_bgc.F90
+++ b/hamocc/aufr_bgc.F90
@@ -111,7 +111,7 @@
       USE mo_sedmnt,    only: sedhpl
       use mod_dia,      only : iotype
       use mo_intfcblom, only: sedlay2,powtra2,burial2,atm2
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
       implicit none
 #ifdef PNETCDF
 #include <pnetcdf.inc>
@@ -146,18 +146,18 @@
       character(len=3) :: stripestr
       character(len=9) :: stripestr2
       integer :: ierr,testio
-      INTEGER :: lenInRstfn
+      INTEGER :: leninrstfn
 
       locetra(:,:,:,:) = 0.0
 !
 ! Open netCDF data file
 !
       testio=0
-      lenInRstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
+      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
       IF(mnproc==1 .AND. IOTYPE==0) THEN
 
         i=1
-        do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(inst_suffix)//'.r.' .AND.              &
+        do while (rstfnm_ocn(i:i+leninrstfn).ne.'.blom'//trim(inst_suffix)//'.r.' .AND.              &
      &            rstfnm_ocn(i:i+8).ne.'.micom.r.')
           i=i+1
           if (i+8.gt.len(rstfnm_ocn)) then
@@ -167,8 +167,8 @@
             stop '(aufr_bgc)'
           endif
         enddo
-        if (rstfnm_ocn(i:i+lenInRstfn).eq.'.blom'//trim(inst_suffix)  //'.r.') then
-          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
+        if (rstfnm_ocn(i:i+leninrstfn).eq.'.blom'//trim(inst_suffix)  //'.r.') then
+          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
         else
           rstfnm=rstfnm_ocn(1:i-1)//'.micom.rbgc.'//rstfnm_ocn(i+9:)
         endif
@@ -203,7 +203,7 @@
 #ifdef PNETCDF
         testio=1
         i=1
-        do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(lenInRstfn)//'.r.' .AND.              &
+        do while (rstfnm_ocn(i:i+leninrstfn).ne.'.blom'//trim(inst_suffix)//'.r.' .AND.              &
      &            rstfnm_ocn(i:i+8).ne.'.micom.r.')
           i=i+1
           if (i+8.gt.len(rstfnm_ocn)) then
@@ -213,8 +213,8 @@
             stop '(aufr_bgc)'
           endif
         enddo
-        if (rstfnm_ocn(i:i+lenInRstfn).eq.'.blom'//trim(lenInRstfn)//   '.r.') then
-          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(lenInRstfn)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
+        if (rstfnm_ocn(i:i+leninrstfn).eq.'.blom'//trim(inst_suffix)//   '.r.') then
+          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
         else
           rstfnm=rstfnm_ocn(1:i-1)//'.micom.rbgc.'//rstfnm_ocn(i+9:)
         endif

--- a/hamocc/aufw_bgc.F90
+++ b/hamocc/aufw_bgc.F90
@@ -105,7 +105,7 @@
       use mod_xc,       only: nbdy,itdm,jtdm,mnproc,xchalt
       use mo_intfcblom, only: sedlay2,powtra2,burial2,atm2
       use mod_dia
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 
       implicit none
 
@@ -119,7 +119,7 @@
       INTEGER             :: i,j
       REAL                :: locetra(kpie,kpje,2*kpke,nocetra)
       CHARACTER(LEN=256)  :: rstfnm
-      INTEGER             :: lenInRstfn
+      INTEGER             :: leninrstfn
 
       ! Variables for netcdf
       INTEGER             :: ncid,ncvarid,ncstat,ncoldmod,ncdimst(4)
@@ -163,20 +163,20 @@
 !
 ! Open netCDF data file
 !
-      lenInRstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
+      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
       IF(mnproc==1 .AND. IOTYPE==0) THEN
 
       i=1
-      do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(inst_suffix)//'.r.')
+      do while (rstfnm_ocn(i:i+leninrstfn).ne.'.blom'//trim(inst_suffix)//'.r.')
         i=i+1
-        if (i+lenInRstfn.gt.len(rstfnm_ocn)) then
+        if (i+leninrstfn.gt.len(rstfnm_ocn)) then
           write (io_stdo_bgc,*)                                      &
      &      'Could not generate restart file name!'
           call xchalt('(aufw_bgc)')
           stop '(aufw_bgc)'
         endif
       enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
+      rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
 
       write(io_stdo_bgc,*) 'BGC RESTART   ',rstfnm
       ncstat = NF90_CREATE(rstfnm,NF90_64BIT_OFFSET,ncid)
@@ -188,16 +188,16 @@
 #ifdef PNETCDF
       testio=1
       i=1
-      do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(inst_suffix)//'.r.')
+      do while (rstfnm_ocn(i:i+leninrstfn).ne.'.blom'//trim(inst_suffix)//'.r.')
         i=i+1
-        if (i+lenInRstfn.gt.len(rstfnm_ocn)) then
+        if (i+leninrstfn.gt.len(rstfnm_ocn)) then
           write (io_stdo_bgc,*)                                      &
      &      'Could not generate restart file name!'
           call xchalt('(aufw_bgc)')
           stop '(aufw_bgc)'
         endif
       enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
+      rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
 
       IF(mnproc==1) write(io_stdo_bgc,*) 'BGC RESTART   ',rstfnm
       write(stripestr,('(i3)')) 16

--- a/hamocc/aufw_bgc.F90
+++ b/hamocc/aufw_bgc.F90
@@ -105,6 +105,7 @@
       use mod_xc,       only: nbdy,itdm,jtdm,mnproc,xchalt
       use mo_intfcblom, only: sedlay2,powtra2,burial2,atm2
       use mod_dia
+      use blom_instance, only: inst_suffix
 
       implicit none
 
@@ -118,6 +119,7 @@
       INTEGER             :: i,j
       REAL                :: locetra(kpie,kpje,2*kpke,nocetra)
       CHARACTER(LEN=256)  :: rstfnm
+      INTEGER             :: lenInRstfn
 
       ! Variables for netcdf
       INTEGER             :: ncid,ncvarid,ncstat,ncoldmod,ncdimst(4)
@@ -161,19 +163,20 @@
 !
 ! Open netCDF data file
 !
+      lenInRstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
       IF(mnproc==1 .AND. IOTYPE==0) THEN
 
       i=1
-      do while (rstfnm_ocn(i:i+7).ne.'.blom.r.')
+      do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(inst_suffix)//'.r.')
         i=i+1
-        if (i+7.gt.len(rstfnm_ocn)) then
+        if (i+lenInRstfn.gt.len(rstfnm_ocn)) then
           write (io_stdo_bgc,*)                                      &
      &      'Could not generate restart file name!'
           call xchalt('(aufw_bgc)')
           stop '(aufw_bgc)'
         endif
       enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'.blom.rbgc.'//rstfnm_ocn(i+8:)
+      rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
 
       write(io_stdo_bgc,*) 'BGC RESTART   ',rstfnm
       ncstat = NF90_CREATE(rstfnm,NF90_64BIT_OFFSET,ncid)
@@ -185,16 +188,16 @@
 #ifdef PNETCDF
       testio=1
       i=1
-      do while (rstfnm_ocn(i:i+7).ne.'.blom.r.')
+      do while (rstfnm_ocn(i:i+lenInRstfn).ne.'.blom'//trim(inst_suffix)//'.r.')
         i=i+1
-        if (i+7.gt.len(rstfnm_ocn)) then
+        if (i+lenInRstfn.gt.len(rstfnm_ocn)) then
           write (io_stdo_bgc,*)                                      &
      &      'Could not generate restart file name!'
           call xchalt('(aufw_bgc)')
           stop '(aufw_bgc)'
         endif
       enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'.blom.rbgc.'//rstfnm_ocn(i+8:)
+      rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+lenInRstfn+1:)
 
       IF(mnproc==1) write(io_stdo_bgc,*) 'BGC RESTART   ',rstfnm
       write(stripestr,('(i3)')) 16

--- a/hamocc/hamocc_init.F
+++ b/hamocc/hamocc_init.F
@@ -53,7 +53,7 @@ c******************************************************************************
       use mo_intfcblom,  only: alloc_mem_intfcblom,nphys,
      .                         bgc_dx,bgc_dy,bgc_dp,bgc_rho,
      .                         omask,sedlay2,powtra2,burial2
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 c
       implicit none
 c
@@ -98,7 +98,7 @@ c
 c
 c --- Read the HAMOCC BGCNML namelist.
 c
-      open (unit=io_nml,file='ocn_in'// trim(inst_suffix),status='old',action='read')
+      open (unit=io_nml,file='ocn_in'//trim(inst_suffix),status='old',action='read')
       read (unit=io_nml,nml=BGCNML)
       close (unit=io_nml)
       IF (mnproc.eq.1) THEN

--- a/hamocc/hamocc_init.F
+++ b/hamocc/hamocc_init.F
@@ -53,6 +53,7 @@ c******************************************************************************
       use mo_intfcblom,  only: alloc_mem_intfcblom,nphys,
      .                         bgc_dx,bgc_dy,bgc_dp,bgc_rho,
      .                         omask,sedlay2,powtra2,burial2
+      use blom_instance, only: inst_suffix
 c
       implicit none
 c
@@ -97,7 +98,7 @@ c
 c
 c --- Read the HAMOCC BGCNML namelist.
 c
-      open (unit=io_nml,file='ocn_in',status='old',action='read')
+      open (unit=io_nml,file='ocn_in'// trim(inst_suffix),status='old',action='read')
       read (unit=io_nml,nml=BGCNML)
       close (unit=io_nml)
       IF (mnproc.eq.1) THEN

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -56,6 +56,7 @@
       USE mod_dia, only: ddm,depthslev,depthslev_bnds,nstepinday,pbath
       USE mod_nctools
       USE mo_param1_bgc, only: ks 
+      use blom_instance, only: inst_suffix
 
       IMPLICIT NONE
 
@@ -468,9 +469,9 @@
         INQUIRE(unit=iounit,opened=isopen)
         IF (.NOT.isopen) EXIT
       ENDDO
-      INQUIRE(file='ocn_in',exist=exists)
+      INQUIRE(file='ocn_in'// trim(inst_suffix),exist=exists)
       IF (exists) THEN
-        OPEN (iounit,file='ocn_in',status='old',action='read',recl=80)
+        OPEN (iounit,file='ocn_in'// trim(inst_suffix),status='old',action='read',recl=80)
       ELSE   
         INQUIRE(file='limits',exist=exists)
         IF (exists) THEN

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -56,7 +56,7 @@
       USE mod_dia, only: ddm,depthslev,depthslev_bnds,nstepinday,pbath
       USE mod_nctools
       USE mo_param1_bgc, only: ks 
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 
       IMPLICIT NONE
 
@@ -469,9 +469,9 @@
         INQUIRE(unit=iounit,opened=isopen)
         IF (.NOT.isopen) EXIT
       ENDDO
-      INQUIRE(file='ocn_in'// trim(inst_suffix),exist=exists)
+      INQUIRE(file='ocn_in'//trim(inst_suffix),exist=exists)
       IF (exists) THEN
-        OPEN (iounit,file='ocn_in'// trim(inst_suffix),status='old',action='read',recl=80)
+        OPEN (iounit,file='ocn_in'//trim(inst_suffix),status='old',action='read',recl=80)
       ELSE   
         INQUIRE(file='limits',exist=exists)
         IF (exists) THEN

--- a/phy/geoenv_file.F
+++ b/phy/geoenv_file.F
@@ -26,7 +26,7 @@ c --- ------------------------------------------------------------------
 c
       use mod_xc
       use netcdf
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 c
       implicit none
 c
@@ -699,9 +699,9 @@ c --- Apply channel width modifications if specified in namelist
 c --- ------------------------------------------------------------------
 c
       if (mnproc.eq.1) then
-        inquire(file='ocn_in'// trim(inst_suffix) ,exist=fexist)
+        inquire(file='ocn_in'//trim(inst_suffix) ,exist=fexist)
         if (fexist) then
-          open (unit=nfu,file='ocn_in'// trim(inst_suffix) ,status='old',action='read')
+          open (unit=nfu,file='ocn_in'//trim(inst_suffix) ,status='old',action='read')
         else
           inquire(file='limits',exist=fexist)
           if (fexist) then

--- a/phy/geoenv_file.F
+++ b/phy/geoenv_file.F
@@ -26,6 +26,7 @@ c --- ------------------------------------------------------------------
 c
       use mod_xc
       use netcdf
+      use blom_instance, only: inst_suffix
 c
       implicit none
 c
@@ -698,9 +699,9 @@ c --- Apply channel width modifications if specified in namelist
 c --- ------------------------------------------------------------------
 c
       if (mnproc.eq.1) then
-        inquire(file='ocn_in',exist=fexist)
+        inquire(file='ocn_in'// trim(inst_suffix) ,exist=fexist)
         if (fexist) then
-          open (unit=nfu,file='ocn_in',status='old',action='read')
+          open (unit=nfu,file='ocn_in'// trim(inst_suffix) ,status='old',action='read')
         else
           inquire(file='limits',exist=fexist)
           if (fexist) then

--- a/phy/mod_dia.F
+++ b/phy/mod_dia.F
@@ -23,6 +23,7 @@ c
       use mod_xc 
       use mod_nctools
       use netcdf, only : nf90_fill_double
+      use blom_instance, only: inst_suffix
 c
       implicit none
 c
@@ -317,16 +318,16 @@ c
         elseif (expcnf.eq.'cesm') then
           if (diagmon) then
             call pstdat(ny,nm,nd,1)
-            write(fname,'(4a,i4.4,a,i2.2,a)')
-     .        runid(1:runid_len),'.blom.',ctag,'.',ny,'-',nm,'.nc'
+            write(fname,'(6a,i4.4,a,i2.2,a)')
+     .        runid(1:runid_len),'.blom',trim(inst_suffix),'.',ctag,'.',ny,'-',nm,'.nc'
           elseif (diagann) then
             call pstdat(ny,nm,nd,1)
-            write(fname,'(4a,i4.4,a)')
-     .        runid(1:runid_len),'.blom.',ctag,'.',ny,'.nc'
+            write(fname,'(6a,i4.4,a)')
+     .        runid(1:runid_len),'.blom',trim(inst_suffix),'.',ctag,'.',ny,'.nc'
           else
             call pstdat(ny,nm,nd,nint(diagfq))
-            write(fname,'(4a,i4.4,a,i2.2,a,i2.2,a)')
-     .        runid(1:runid_len),'.blom.',ctag,'.',ny,'-',nm,'-',nd,
+            write(fname,'(6a,i4.4,a,i2.2,a,i2.2,a)')
+     .        runid(1:runid_len),'.blom',trim(inst_suffix),'.',ctag,'.',ny,'-',nm,'-',nd,
      .        '.nc'
           endif
         else
@@ -344,8 +345,8 @@ c
         ns=nint(nint(mod(nstep+.5-diagfq,real(nstep_in_day))/diagfq)
      .          *diagfq/nstep_in_day*86400)
         if (expcnf.eq.'cesm') then
-          write(fname,'(4a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)')
-     .      runid(1:runid_len),'.blom.',ctag,'.',ny,'-',nm,'-',nd,'-',
+          write(fname,'(6a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)')
+     .      runid(1:runid_len),'.blom',trim(inst_suffix),'.',ctag,'.',ny,'-',nm,'-',nd,'-',
      .      ns,'.nc'
         else
           write(fname,'(4a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)')

--- a/phy/mod_dia.F
+++ b/phy/mod_dia.F
@@ -23,7 +23,7 @@ c
       use mod_xc 
       use mod_nctools
       use netcdf, only : nf90_fill_double
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 c
       implicit none
 c

--- a/phy/mod_instance.F90
+++ b/phy/mod_instance.F90
@@ -1,0 +1,36 @@
+!!  This file is modified from cam_instance.F90 in CAM component.
+!!  Intent to provide multiple-instance support of BLOM component in NorESM2.
+!!                                                      Ping-Gin Jul 2020 
+
+module blom_instance
+
+use seq_comm_mct, only: seq_comm_suffix, seq_comm_inst, seq_comm_name
+
+implicit none
+private
+save
+
+public :: blom_instance_init
+
+integer,           public :: ocn_id
+integer,           public :: inst_index
+character(len=16), public :: inst_name
+character(len=16), public :: inst_suffix
+
+!===============================================================================
+CONTAINS
+!===============================================================================
+
+subroutine blom_instance_init(in_ocn_id)
+
+   integer, intent(in) :: in_ocn_id
+
+   ocn_id      = in_ocn_id
+   inst_name   = seq_comm_name(ocn_id)
+   inst_index  = seq_comm_inst(ocn_id)
+   inst_suffix = seq_comm_suffix(ocn_id)
+   print*,'ocn_id,name,index,suffix: ',ocn_id,trim(inst_name),inst_index,trim(inst_suffix)
+
+end subroutine blom_instance_init
+
+end module blom_instance

--- a/phy/mod_instance.F90
+++ b/phy/mod_instance.F90
@@ -1,8 +1,24 @@
-!!  This file is modified from cam_instance.F90 in CAM component.
-!!  Intent to provide multiple-instance support of BLOM component in NorESM2.
-!!                                                      Ping-Gin Jul 2020 
+! ------------------------------------------------------------------------------
+! Copyright (C) 2010-2020 Ingo Bethke, Mats Bentsen, Mehmet Ilicak,
+!                         Alok Kumar Gupta, Jörg Schwinger
+!
+! This file is part of BLOM.
+!
+! BLOM is free software: you can redistribute it and/or modify it under the
+! terms of the GNU Lesser General Public License as published by the Free
+! Software Foundation, either version 3 of the License, or (at your option)
+! any later version.
+!
+! BLOM is distributed in the hope that it will be useful, but WITHOUT ANY
+! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+! FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+! more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with BLOM. If not, see <https://www.gnu.org/licenses/>.
+! ------------------------------------------------------------------------------
 
-module blom_instance
+module mod_instance
 
 use seq_comm_mct, only: seq_comm_suffix, seq_comm_inst, seq_comm_name
 
@@ -29,8 +45,7 @@ subroutine blom_instance_init(in_ocn_id)
    inst_name   = seq_comm_name(ocn_id)
    inst_index  = seq_comm_inst(ocn_id)
    inst_suffix = seq_comm_suffix(ocn_id)
-   print*,'ocn_id,name,index,suffix: ',ocn_id,trim(inst_name),inst_index,trim(inst_suffix)
 
 end subroutine blom_instance_init
 
-end module blom_instance
+end module mod_instance

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -28,6 +28,7 @@ c
       use mod_dia
       use mod_ben02, only: atm_path, atm_path_len
       use data_mct, only: runid_mct, ocn_cpl_dt_mct
+      use blom_instance, only: inst_suffix
 c
       implicit none
 c
@@ -53,9 +54,9 @@ c --- read namelists
       if (mnproc.eq.1) then
 c
         GLB_AVEPERIO=-999
-        inquire(file='ocn_in',exist=fexist)
+        inquire(file='ocn_in'// trim(inst_suffix) ,exist=fexist)
         if (fexist) then
-          open (unit=nfu,file='ocn_in',status='old',action='read',
+          open (unit=nfu,file='ocn_in'// trim(inst_suffix) ,status='old',action='read',
      .          recl=80)
         else
           inquire(file='limits',exist=fexist)
@@ -678,7 +679,7 @@ c --- --- 'rpointer.ocn' file containing the path to a valid restart
 c --- --- file is expected and integration time is retrieved from
 c --- --- restart file
 c
-          if (mnproc.eq.1) inquire(file='rpointer.ocn',exist=fexist)
+          if (mnproc.eq.1) inquire(file='rpointer.ocn'// trim(inst_suffix),exist=fexist)
           call xcbcst(fexist)
           if (.not.fexist) then
             if (mnproc.eq.1) then
@@ -688,7 +689,7 @@ c
                    stop '(rdlim)'
           endif
           if (mnproc.eq.1) then
-            open (unit=nfu,file='rpointer.ocn')
+            open (unit=nfu,file='rpointer.ocn'// trim(inst_suffix))
             read (nfu,'(a)') rstfnm
             close (unit=nfu)
             inquire(file=rstfnm,exist=fexist)

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -28,7 +28,7 @@ c
       use mod_dia
       use mod_ben02, only: atm_path, atm_path_len
       use data_mct, only: runid_mct, ocn_cpl_dt_mct
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 c
       implicit none
 c
@@ -54,9 +54,9 @@ c --- read namelists
       if (mnproc.eq.1) then
 c
         GLB_AVEPERIO=-999
-        inquire(file='ocn_in'// trim(inst_suffix) ,exist=fexist)
+        inquire(file='ocn_in'//trim(inst_suffix) ,exist=fexist)
         if (fexist) then
-          open (unit=nfu,file='ocn_in'// trim(inst_suffix) ,status='old',action='read',
+          open (unit=nfu,file='ocn_in'//trim(inst_suffix) ,status='old',action='read',
      .          recl=80)
         else
           inquire(file='limits',exist=fexist)
@@ -679,7 +679,7 @@ c --- --- 'rpointer.ocn' file containing the path to a valid restart
 c --- --- file is expected and integration time is retrieved from
 c --- --- restart file
 c
-          if (mnproc.eq.1) inquire(file='rpointer.ocn'// trim(inst_suffix),exist=fexist)
+          if (mnproc.eq.1) inquire(file='rpointer.ocn'//trim(inst_suffix),exist=fexist)
           call xcbcst(fexist)
           if (.not.fexist) then
             if (mnproc.eq.1) then
@@ -689,7 +689,7 @@ c
                    stop '(rdlim)'
           endif
           if (mnproc.eq.1) then
-            open (unit=nfu,file='rpointer.ocn'// trim(inst_suffix))
+            open (unit=nfu,file='rpointer.ocn'//trim(inst_suffix))
             read (nfu,'(a)') rstfnm
             close (unit=nfu)
             inquire(file=rstfnm,exist=fexist)

--- a/phy/restart_rd.F
+++ b/phy/restart_rd.F
@@ -30,6 +30,8 @@ c
      .                     cd_m,ch_m,ce_m,wg2_m,rhoa,
      .                     tsi_tda,tml_tda,sml_tda,alb_tda,fice_tda,ntda
       use mod_thdysi, only: tsrfm,ticem
+      use blom_instance, only: inst_suffix
+
 c
       implicit none
 c
@@ -85,18 +87,18 @@ c
       elseif (expcnf.eq.'cesm') then
 c
 c --- - get restart file name from rpointer.ocn
-        if (mnproc.eq.1) inquire(file='rpointer.ocn',exist=fexist)
+        if (mnproc.eq.1) inquire(file='rpointer.ocn'// trim(inst_suffix),exist=fexist)
         call xcbcst(fexist)
         if (fexist) then
           if (mnproc.eq.1) then
-            open (unit=nfu,file='rpointer.ocn')
+            open (unit=nfu,file='rpointer.ocn'// trim(inst_suffix))
             read (nfu,'(a)') rstfnm
             close (unit=nfu)
           endif
           call xcbcst(rstfnm)
         else
           if (mnproc.eq.1) then
-            write (lp,*) 'restart_rd: could not find file rpointer.ocn!'
+            write (lp,*) 'restart_rd: could not find file rpointer.ocn'// trim(inst_suffix)//'!'
           endif
           call xcstop('(restart_rd)')
                  stop '(restart_rd)'

--- a/phy/restart_rd.F
+++ b/phy/restart_rd.F
@@ -30,7 +30,7 @@ c
      .                     cd_m,ch_m,ce_m,wg2_m,rhoa,
      .                     tsi_tda,tml_tda,sml_tda,alb_tda,fice_tda,ntda
       use mod_thdysi, only: tsrfm,ticem
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 
 c
       implicit none
@@ -87,18 +87,18 @@ c
       elseif (expcnf.eq.'cesm') then
 c
 c --- - get restart file name from rpointer.ocn
-        if (mnproc.eq.1) inquire(file='rpointer.ocn'// trim(inst_suffix),exist=fexist)
+        if (mnproc.eq.1) inquire(file='rpointer.ocn'//trim(inst_suffix),exist=fexist)
         call xcbcst(fexist)
         if (fexist) then
           if (mnproc.eq.1) then
-            open (unit=nfu,file='rpointer.ocn'// trim(inst_suffix))
+            open (unit=nfu,file='rpointer.ocn'//trim(inst_suffix))
             read (nfu,'(a)') rstfnm
             close (unit=nfu)
           endif
           call xcbcst(rstfnm)
         else
           if (mnproc.eq.1) then
-            write (lp,*) 'restart_rd: could not find file rpointer.ocn'// trim(inst_suffix)//'!'
+            write (lp,*) 'restart_rd: could not find file rpointer.ocn'//trim(inst_suffix)//'!'
           endif
           call xcstop('(restart_rd)')
                  stop '(restart_rd)'

--- a/phy/restart_wt.F
+++ b/phy/restart_wt.F
@@ -30,7 +30,7 @@ c
      .                     cd_m,ch_m,ce_m,wg2_m,rhoa,
      .                     tsi_tda,tml_tda,sml_tda,alb_tda,fice_tda,ntda
       use mod_thdysi, only: tsrfm,ticem
-      use blom_instance, only: inst_suffix
+      use mod_instance, only: inst_suffix
 c
       implicit none
 c
@@ -762,7 +762,7 @@ c
 c
 c --- - write restart filename to rpointer.ocn
         if (mnproc.eq.1) then
-          open (unit=nfu,file='rpointer.ocn'// trim(inst_suffix))
+          open (unit=nfu,file='rpointer.ocn'//trim(inst_suffix))
           write (nfu,'(a)') rstfnm
           close (unit=nfu)
         endif

--- a/phy/restart_wt.F
+++ b/phy/restart_wt.F
@@ -30,6 +30,7 @@ c
      .                     cd_m,ch_m,ce_m,wg2_m,rhoa,
      .                     tsi_tda,tml_tda,sml_tda,alb_tda,fice_tda,ntda
       use mod_thdysi, only: tsrfm,ticem
+      use blom_instance, only: inst_suffix
 c
       implicit none
 c
@@ -71,8 +72,8 @@ c
 c --- formulate restart name and open restart file
 c
       if (expcnf.eq.'cesm') then
-        write (rstfnm,'(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)')
-     .    runid(1:runid_len),'.blom.r.',nyear,'-',nmonth,'-',nday,
+        write (rstfnm,'(4a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)')
+     .    runid(1:runid_len),'.blom',trim(inst_suffix),'.r.',nyear,'-',nmonth,'-',nday,
      .    '-',mod(nstep,nstep_in_day)*86400,'.nc'
       else
         if (nday_of_year-max(1,nint(rstfrq/nstep_in_day)).le.0) then
@@ -761,7 +762,7 @@ c
 c
 c --- - write restart filename to rpointer.ocn
         if (mnproc.eq.1) then
-          open (unit=nfu,file='rpointer.ocn')
+          open (unit=nfu,file='rpointer.ocn'// trim(inst_suffix))
           write (nfu,'(a)') rstfnm
           close (unit=nfu)
         endif


### PR DESCRIPTION
The multiple instance support is added.
Following the method of CAM, the phy/mod_instance.F90 is add to get instance suffix string ( '_0001', '_0002' and so on).
The cime_config/buildnml is also modified to generate the namelists for correspond instance.

Tested multi-instance setting:
./xmlchange NINST_ATM=2
./xmlchange NINST_LND=2
./xmlchange NINST_ICE=2
./xmlchange NINST_ROF=2
./xmlchange NINST_GLC=2
./xmlchange NINST_OCN=2
./xmlchange NINST_WAV=2
./xmlchange NINST_ESP=2
./xmlchange MULTI_DRIVER=TRUE

Total tasks will be original NTASKS * NINST with MULTI_DRIVER=TRUE.
