### PR TITLE
Update Github CI to run on all branches and simplify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,6 @@
 name: Continuous Integration testing
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
+
 env:
   # This version of Meson should be available as an EasyBuild on Fram and Betzy
   MESON_VERSION: '0.55.1'
@@ -17,6 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-10.15]
         mpi: [true, false]
+        fail-fast: false
 
     steps:
       - name: Checkout code
@@ -24,40 +20,31 @@ jobs:
         with:
           ref: meson
 
-      - name: Setup Python for newer version of Meson - Ubuntu
+      - name: Setup Python for newer version of Meson
         uses: actions/setup-python@v2
-        if: runner.os == 'Linux'
 
       - name: Install dependencies - Ubuntu
-        run: sudo apt-get install -y ninja-build libnetcdff-dev mpi-default-dev
+        run: |
+          sudo apt update
+          sudo apt install -y libnetcdff-dev mpi-default-dev
         if: runner.os == 'Linux'
 
       - name: Install dependencies - macOS
-        run: brew install meson netcdf open-mpi
+        run: brew install netcdf open-mpi
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         if: runner.os == 'macOS'
 
-      - name: Install Meson - Ubuntu
-        run: python -m pip install meson==${{ env.MESON_VERSION }}
-        if: runner.os == 'Linux'
-
-      - name: Setup build directory - Ubuntu
-        run: meson setup builddir
-        if: runner.os == 'Linux'
-
-      - name: Setup build directory - macOS
-        run: meson setup builddir
-        if: runner.os == 'macOS'
+      - name: Run Meson build step
+        uses: BSFishy/meson-build@v1.0.2
         env:
           CC: gcc-10
           FC: gfortran-10
-
-      - name: Configure build
-        run: meson configure builddir -Dmpi=${{ matrix.mpi }}
-
-      - name: Compile source code
-        run: meson compile -C builddir
+        with:
+          action: build
+          directory: builddir
+          setup-options: -Dmpi=${{ matrix.mpi }}
+          meson-version: ${{ env.MESON_VERSION }}
 
   intel:
     name: Build BLOM using Intel compilers
@@ -75,10 +62,10 @@ jobs:
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-          sudo apt-get update
+          sudo apt update
 
       - name: Install dependencies
-        run: sudo apt-get install -y ninja-build libnetcdf-dev intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-mpi-devel
+        run: sudo apt install -y ninja-build libnetcdf-dev intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-mpi-devel
 
       - name: Checkout netCDF for compiling with Intel
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     name: Build BLOM on Github provided OS
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15]
         mpi: [true, false]
-        fail-fast: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This update removes the branch notation from Github CI so that all pushes and pull requests are run through CI. This change simplifies CI and ensures that one can create feature branches separate from `master` and still have them tested.

In addition, this PR simplifies building on the default runners (`Ubuntu` and `macOS`) to use a preconfigured action with Meson.

I've also added `fail-fast: false` to the `strategy` so that if one of the default runners fails the others will not be aborted.