### PR TITLE
Make 'xchalt' signal error

### DIFF
--- a/phy/mod_xc_mp.inc
+++ b/phy/mod_xc_mp.inc
@@ -1012,7 +1012,7 @@ c
 #else
       call abort()
 #endif
-      stop '(xchalt)'
+      error stop '(xchalt)'
       end subroutine xchalt
 
       subroutine xclget(aline,nl, a, i1,j1,iinc,jinc, mnflg)

--- a/phy/mod_xc_sm.inc
+++ b/phy/mod_xc_sm.inc
@@ -210,7 +210,7 @@ c
         write(lp,*) '**************************************************'
         call flush(lp)
       endif
-      stop '(xchalt)'
+      error stop '(xchalt)'
       end subroutine xchalt
 
       subroutine xclget(aline,nl, a, i1,j1,iinc,jinc, mnflg)


### PR DESCRIPTION
It seems that `xchalt` is only called in exceptional circumstances (especially according to the subroutine's own documentation). To detect this in scripts (e.g. in Slurm scripts on clusters) or in automatic testing it would be nice if `xchalt` returned an error status and not just printed a short message. The motivation for this PR is to make BLOM compatible with unit testing.

If I have understood correctly this can be achieved in a few different ways in Fortran.
1) One could use `stop X` where `X` is the error code (so usually `1` on Linux systems to signal general error)
2) One could use `error stop` which seems to have been [introduced with `Fortran2008` and updated in `Fortran2018`](https://www.scivision.dev/fortran-stderr-stop-return-code/)
3) Use compiler dependent `abort` functions.

This PR introduces option number 2). The risks associated with this is that one of the compilers needed to compile BLOM in NorESM is not up-to-date enough to support this, and I'm hoping we can test this before accepting this PR.