### PR TITLE
OpenMP fix and disabling answer changing optimizations

### DIFF
--- a/fuk95/mod_fuk95.F90
+++ b/fuk95/mod_fuk95.F90
@@ -328,7 +328,7 @@ contains
 
       ! Set layer velocity.
       call xctilr(z, 1, kk + 1, 1, 1, halo_ps)
-   !$omp parallel do private(k, l, i, zm)
+   !$omp parallel do private(k, l, i, x, zm)
       do j = 1, jj
          do k = 1, kk - 1
             do l = 1, isv(j)

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,9 @@ elif fcc.get_id() == 'intel'
                            '-init=snan,arrays', '-fpe0','-ftrapuv'],
                           language: 'fortran')
   endif
+  if get_option('buildtype') == 'release'
+    add_project_arguments('-fp-model precise'.split(),language: 'fortran')
+  endif
   if get_option('processors') == 1 and get_option('grid') == 'channel'
     add_project_arguments('-mcmodel=medium', language: 'fortran')
   endif

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -866,7 +866,7 @@ c --- - model is to be integrated from time step 'nstep1' to 'nstep2'
         nstep2=nday2*nstep_in_day
 c
         if (csdiag) then
-          nstep2=nstep1+2
+          nstep2=nstep1+5
         endif
 c
       endif
@@ -905,7 +905,6 @@ c --- represent time between diagnostics in time steps
 c
         if (GLB_AVEPERIO(n).lt.0) then
           diagfq_phy(n)=-real(nstep_in_day)/GLB_AVEPERIO(n)
-          write (*,*) 'diagfq',diagfq_phy(n)
         else
           diagfq_phy(n)=nstep_in_day*max(1,GLB_AVEPERIO(n))
         endif


### PR DESCRIPTION
Corrected an OpenMP directive and added an Intel compiler flag that disables optimizations changing floating point results.