### PR TITLE
bugfix: openmp private declarations

### DIFF
--- a/hamocc/blom2hamocc.F
+++ b/hamocc/blom2hamocc.F
@@ -67,7 +67,7 @@ c
 c --- calculate pressure at interfaces (necesarry since p has  
 c --- not been calculated at restart)
 c
-c$OMP PARALLEL DO PRIVATE(kn)
+c$OMP PARALLEL DO PRIVATE(k,kn,l,i)
       do j=1,jj
       do k=1,kk
       kn=k+nn
@@ -85,7 +85,7 @@ c --- ------------------------------------------------------------------
 c --- 2D fields
 c --- ------------------------------------------------------------------
 c
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(i)
       do j=1,jj
       do i=1,ii
 c
@@ -102,7 +102,7 @@ c --- ------------------------------------------------------------------
 c --- 3D fields
 c --- ------------------------------------------------------------------
 c
-c$OMP PARALLEL DO PRIVATE(kn,th,s,p1,p2,ldp,pa)
+c$OMP PARALLEL DO PRIVATE(k,kn,l,i,th,s,p1,p2,ldp,pa)
       do j=1,jj
       do k=1,kk
       kn=k+nn
@@ -147,7 +147,7 @@ c --- ------------------------------------------------------------------
 c --- pass tracer fields from ocean model; convert mol/kg -> kmol/m^3
 c --- ------------------------------------------------------------------
 c
-c$OMP PARALLEL DO PRIVATE(kn)
+c$OMP PARALLEL DO PRIVATE(k,kn,l,i)
       do j=1,jj
       do k=1,kk
       kn=k+nn
@@ -169,7 +169,7 @@ c
 #ifndef sedbypass
       nns=(n-1)*ks
 c
-c$OMP PARALLEL DO PRIVATE(kn)
+c$OMP PARALLEL DO PRIVATE(k,kn,l,i)
 c
       do j=1,jj
       do k=1,ks
@@ -192,7 +192,7 @@ c --- atmosphere fields is kept outside HAMOCC)
 c --- ------------------------------------------------------------------
 c
 #if defined(BOXATM)
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(i)
       do j=1,jj
       do i=1,ii
         atm(i,j,:) = atm2(i,j,n,:)

--- a/hamocc/carchm.F90
+++ b/hamocc/carchm.F90
@@ -193,7 +193,7 @@
 !$OMP  ,atco213,atco214,rco213,rco214,pco213,pco214,frac_aqg          &
 !$OMP  ,frac_dicg,flux13d,flux13u,flux14d,flux14u,dissol13,dissol14   &
 #endif
-!$OMP  )
+!$OMP  ,j,i)
       DO k=1,kpke
       DO j=1,kpje
       DO i=1,kpie
@@ -557,7 +557,7 @@
 #ifdef cisonew
 #ifndef sedbypass
         do k=1,ks
-!$OMP PARALLEL DO  
+!$OMP PARALLEL DO PRIVATE(i)
         do j=1,kpje
         do i=1,kpie
         if(omask(i,j).gt.0.5) then

--- a/hamocc/cyano.F90
+++ b/hamocc/cyano.F90
@@ -85,7 +85,7 @@
 ! it is assumed here that this process is limited to the mixed layer
 !
       DO k=1,kmle
-!$OMP PARALLEL DO PRIVATE(oldocetra,dano3) 
+!$OMP PARALLEL DO PRIVATE(i,oldocetra,dano3,ttemp,nfixtfac) 
       DO j=1,kpje
       DO i=1,kpie
         IF(omask(i,j).gt.0.5) THEN

--- a/hamocc/dipowa.F90
+++ b/hamocc/dipowa.F90
@@ -89,7 +89,7 @@ subroutine dipowa(kpie,kpje,kpke,omask)
   zcoeflo(ks) = 0.0                    ! diffusion coefficient for bottom sediment layer
 
 !$OMP PARALLEL DO                            &
-!$OMP&PRIVATE(bolven,tredsy,sedb1,aprior,iv_oc)
+!$OMP&PRIVATE(i,k,iv,l,bolven,tredsy,sedb1,aprior,iv_oc)
   j_loop: do j=1,kpje
 
 ! calculate bottom ventilation rate for scaling of sediment-water exchange

--- a/hamocc/hamocc2blom.F
+++ b/hamocc/hamocc2blom.F
@@ -63,7 +63,7 @@ c --- ------------------------------------------------------------------
 c --- pass tracer fields to ocean model; convert kmol/m^3 -> mol/kg
 c --- ------------------------------------------------------------------
 c
-c$OMP PARALLEL DO PRIVATE(kn)
+c$OMP PARALLEL DO PRIVATE(k,kn,l,i)
       do j=1,jj
       do k=1,kk
       kn=k+nn
@@ -86,7 +86,7 @@ c
       nns=(n-1)*ks
       mms=(m-1)*ks
 
-c$OMP PARALLEL DO PRIVATE(km,kn)
+c$OMP PARALLEL DO PRIVATE(k,km,kn,l,i)
       do j=1,jj
       do k=1,ks
       km=k+mms
@@ -107,8 +107,8 @@ c$OMP PARALLEL DO PRIVATE(km,kn)
       enddo
       enddo
 c$OMP END PARALLEL DO
-c    
-c$OMP PARALLEL DO PRIVATE(kn)
+c
+c$OMP PARALLEL DO PRIVATE(k,kn,l,i)
       do j=1,jj
       do k=1,ks
       kn=k+nns
@@ -129,7 +129,7 @@ c --- apply time smoothing for atmosphere fields if required
 c --- ------------------------------------------------------------------
 c
 #if defined(BOXATM)
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(i)
       do j=1,jj
       do i=1,ii                            ! time smoothing (analog to tmsmt2.F)
         atm2(i,j,m,:) = wts1*atm2(i,j,m,:) ! mid timelevel
@@ -139,7 +139,7 @@ c$OMP PARALLEL DO
       enddo
 c$OMP END PARALLEL DO
 c
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(i)
       do j=1,jj
       do i=1,ii
         atm2(i,j,n,:) = atm(i,j,:)  ! new time level replaces old time level here

--- a/hamocc/hamocc4bcm.F90
+++ b/hamocc/hamocc4bcm.F90
@@ -144,7 +144,7 @@
 !--------------------------------------------------------------------
 ! Pass net solar radiation 
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
       DO  j=1,kpje
       DO  i=1,kpie
         strahl(i,j)=pfswr(i,j)
@@ -157,7 +157,7 @@
 ! Pass atmospheric co2 if coupled to an active atmosphere model
 !
 #if defined(PROGCO2) || defined(DIAGCO2)
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
       DO  j=1,kpje
       DO  i=1,kpie
         atm(i,j,iatmco2)=patmco2(i,j)
@@ -203,7 +203,7 @@
  
       do l=1,nocetra
       do K=1,kpke
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
       do J=1,kpje
       do I=1,kpie
         if (OMASK(I,J) .gt. 0.5 ) then
@@ -312,7 +312,7 @@
 !--------------------------------------------------------------------
 ! Pass co2 flux. Convert unit from kmol/m^2 to kg/m^2/s.
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
       DO  j=1,kpje
       DO  i=1,kpie
         if(omask(i,j) .gt. 0.5) pflxco2(i,j)=-44.*atmflx(i,j,iatmco2)/dtbgc
@@ -324,7 +324,7 @@
 !--------------------------------------------------------------------
 ! Pass dms flux. Convert unit from kmol/m^2 to kg/m^2/s.
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
       DO  j=1,kpje
       DO  i=1,kpie
         if(omask(i,j) .gt. 0.5) pflxdms(i,j)=-62.13*atmflx(i,j,iatmdms)/dtbgc

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -1064,7 +1064,7 @@
 ! --- Check whether field should be initialised
       IF (pos.EQ.0) RETURN
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
       DO j=1,jj
         DO l=1,isp(j)
           DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1099,7 +1099,7 @@
       IF (pos.EQ.0) RETURN
 !
       DO k=1,kdm
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1135,7 +1135,7 @@
       IF (pos.EQ.0) RETURN
 !
       DO k=1,ddm
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1171,7 +1171,7 @@
       IF (pos.EQ.0) RETURN
 !
       DO k=1,ks
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1206,7 +1206,7 @@
 ! --- Check whether field should be initialised
       IF (pos.EQ.0) RETURN
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
       DO j=1,jj
         DO l=1,isp(j)
           DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1243,7 +1243,7 @@
         IF (pos(o).EQ.0) cycle
 !
           IF (wghtsflg.eq.0) then 
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
             DO j=1,jj
               DO l=1,isp(j)
                 DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1253,7 +1253,7 @@
             ENDDO
 !$OMP END PARALLEL DO
           ELSE
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
             DO j=1,jj
               DO l=1,isp(j)
                 DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1295,7 +1295,7 @@
 !
           IF (wghtsflg.eq.0) then 
             DO k=1,kk
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
               DO j=1,jj
                 DO l=1,isp(j)
                   DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1308,7 +1308,7 @@
             ENDDO
           ELSE
             DO k=1,kk
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
               DO j=1,jj
                 DO l=1,isp(j)
                   DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1353,7 +1353,7 @@
       DO o=1,nbgc
         IF (pos(o).EQ.0) cycle
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i,d)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1393,7 +1393,7 @@
         IF (pos(o).EQ.0) cycle
 !
         DO k=1,ks
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
           DO j=1,jj
             DO l=1,isp(j)
               DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1430,7 +1430,7 @@
       DO o=1,nbgc
         IF (pos(o).EQ.0) cycle
 !
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1465,7 +1465,7 @@
 ! --- Check whether field should be initialised
       IF (posacc.EQ.0) RETURN
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
       DO j=1,jj
         DO l=1,isp(j)
           DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1501,7 +1501,7 @@
       IF (posacc.EQ.0) RETURN
 !
       DO k=1,kk
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1953,7 +1953,7 @@
 ! --- Check whether field should be processed
       IF (pos.EQ.0) RETURN
 !
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
       DO j=1,jj
         DO l=1,isp(j)
           DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -1994,7 +1994,7 @@
       IF (pos.EQ.0) RETURN
 !
       DO k=1,kdm
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2036,7 +2036,7 @@
       IF (pos.EQ.0) RETURN
 !
       DO k=1,ddm
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2079,7 +2079,7 @@
       IF (pos.EQ.0) RETURN
 !
       DO k=1,ks
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2119,7 +2119,7 @@
 ! --- Check whether field should be initia
       IF (pos.EQ.0) RETURN
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(l,i)
       DO j=1,jj
         DO l=1,isp(j)
           DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2160,7 +2160,7 @@
 ! --- Prepare index fields for masking
 
       IF (iniflg) THEN
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
         DO j=1,jj
           DO i=1,ii
             kmax(i,j)=0
@@ -2168,7 +2168,7 @@
         ENDDO
 !$OMP END PARALLEL DO
         DO k=1,ddm
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
           DO j=1,jj
             DO i=1,ii
               IF (depths(i,j).GT.depthslev_bnds(1,k)) kmax(i,j)=k
@@ -2179,7 +2179,7 @@
         iniflg=.false.
       ENDIF
 !
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i,k)
       DO j=1,jj
         DO i=1,ii
           DO k=kmax(i,j)+1,ddm
@@ -2214,7 +2214,7 @@
 ! --- Adjust bounds of levitus levels according to model bathymetry
       IF (iniflg) THEN
         DO d=1,ddm
-!$OMP PARALLEL DO  
+!$OMP PARALLEL DO PRIVATE(l,i)
           DO j=1,jj
             DO l=1,isp(j)
               DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2230,7 +2230,7 @@
 !
 ! --- Compute top and bottom depths of density layers 
       IF (kin.EQ.1) THEN       
-!$OMP PARALLEL DO  
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2240,7 +2240,7 @@
         ENDDO
 !$OMP END PARALLEL DO
         DO k=2,kk
-!$OMP PARALLEL DO  
+!$OMP PARALLEL DO PRIVATE(l,i)
           DO j=1,jj
             DO l=1,isp(j)
               DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2250,7 +2250,7 @@
           ENDDO
 !$OMP END PARALLEL DO
         ENDDO
-!$OMP PARALLEL DO  
+!$OMP PARALLEL DO PRIVATE(l,i)
         DO j=1,jj
           DO l=1,isp(j)
             DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2262,7 +2262,7 @@
         ENDDO
 !$OMP END PARALLEL DO
         DO k=2,kk
-!$OMP PARALLEL DO  
+!$OMP PARALLEL DO PRIVATE(l,i)
           DO j=1,jj
             DO l=1,isp(j)
               DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -2276,7 +2276,7 @@
       ENDIF
 !
 ! --- Compute interpolation weights 
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(l,i,d)
       DO j=1,jj
         DO l=1,isp(j)
           DO i=max(1,ifp(j,l)),min(ii,ilp(j,l))

--- a/hamocc/mo_riverinpt.F90
+++ b/hamocc/mo_riverinpt.F90
@@ -230,7 +230,7 @@ subroutine riverinpt(kpie,kpje,kpke,pddpo,omask,rivin)
 
   if (.not. do_rivinpt) return
 
-!$OMP PARALLEL DO PRIVATE(fdt,volij)
+!$OMP PARALLEL DO PRIVATE(i,k,fdt,volij)
   DO j=1,kpje
   DO i=1,kpie
     IF(omask(i,j).GT.0.5) THEN

--- a/hamocc/mo_vgrid.F90
+++ b/hamocc/mo_vgrid.F90
@@ -98,7 +98,7 @@ subroutine set_vgrid(kpie,kpje,kpke,pddpo)
   ! --- depth of layer kpke+1 centre
   ptiestu(:,:,kpke+1)=9000.
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(j,i)
   do k=1,kpke
     do j=1,kpje
     do i=1,kpie
@@ -117,7 +117,7 @@ subroutine set_vgrid(kpie,kpje,kpke,pddpo)
   kbo(:,:)  =1
   bolay(:,:)=0.0
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i,k)
   DO j=1,kpje
   DO i=1,kpie
 
@@ -134,7 +134,7 @@ subroutine set_vgrid(kpie,kpje,kpke,pddpo)
 !$OMP END PARALLEL DO
 
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i,k)
   DO j=1,kpje
   DO i=1,kpie
 
@@ -156,7 +156,7 @@ subroutine set_vgrid(kpie,kpje,kpke,pddpo)
   k2000(:,:)=0
   k4000(:,:)=0
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i,k)
   DO j=1,kpje
   DO i=1,kpie
 

--- a/hamocc/powach.F90
+++ b/hamocc/powach.F90
@@ -110,7 +110,8 @@ subroutine powach(kpie,kpje,kpke,kbnd,prho,omask,psao)
 !$OMP&        umfa,denit,saln,rrho,alk,c,sit,pt,                        &
 !$OMP&        K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,                       &
 !$OMP&        ah1,ac,cu,cb,cc,satlev,bolven,                            &
-!$OMP&        ratc13,ratc14,rato13,rato14,poso13,poso14)
+!$OMP&        ratc13,ratc14,rato13,rato14,poso13,poso14,                &
+!$OMP&        k,i)
 
   j_loop: do j = 1, kpje
 
@@ -561,7 +562,7 @@ subroutine powach(kpie,kpje,kpke,kbnd,prho,omask,psao)
 !ik this is currently assumed to depend on total and corg sedimentation:
 !ik f(POC) [kg C] / f(total) [kg] = 0.05
 !ik thus it is
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
   do j = 1, kpje
      do i = 1, kpie
         sedlay(i,j,1,issster) = sedlay(i,j,1,issster)                          &
@@ -571,7 +572,7 @@ subroutine powach(kpie,kpje,kpke,kbnd,prho,omask,psao)
 !$OMP END PARALLEL DO
 
 
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
   do j = 1, kpje
      do i = 1, kpie
         silpro(i,j) = 0.

--- a/hamocc/preftrc.F90
+++ b/hamocc/preftrc.F90
@@ -55,7 +55,7 @@
       INTEGER :: i,j,k
 
       do k=1,kmle
-!$OMP PARALLEL DO
+!$OMP PARALLEL DO PRIVATE(i)
       do j=1,kpje
       do i=1,kpie
         if (omask(i,j) .gt. 0.5 ) then

--- a/hamocc/sedshi.F90
+++ b/hamocc/sedshi.F90
@@ -73,7 +73,7 @@
 
       do k=1,ks-1
 
-!$OMP PARALLEL DO PRIVATE(sedlo) 
+!$OMP PARALLEL DO PRIVATE(i,sedlo)
         do j=1,kpje
         do i=1,kpie
           if(omask(i,j).gt.0.5) then
@@ -91,7 +91,7 @@
 
 ! filling downward  (accumulation)
         do iv=1,nsedtra
-!$OMP PARALLEL DO PRIVATE(uebers) 
+!$OMP PARALLEL DO PRIVATE(i,uebers)
         do j=1,kpje
         do i=1,kpie
           if(omask(i,j).gt.0.5) then
@@ -116,7 +116,7 @@
 ! to surface layers in the long range. Can be supplied again if a 
 ! sediment column has a deficiency in volume.
 
-!$OMP PARALLEL DO PRIVATE(sedlo)  
+!$OMP PARALLEL DO PRIVATE(i,sedlo)
        do j=1,kpje
        do i=1,kpie
           if(omask(i,j).gt.0.5) then
@@ -132,7 +132,7 @@
 !$OMP END PARALLEL DO
 
       do iv=1,nsedtra
-!$OMP PARALLEL DO PRIVATE(uebers)  
+!$OMP PARALLEL DO PRIVATE(i,uebers)
       do j=1,kpje
       do i=1,kpie
           if(omask(i,j).gt.0.5) then
@@ -158,7 +158,7 @@
 ! then, successively, the following layers are filled upwards.
 ! if there is not enough solid matter to fill the column, add clay.
 
-!$OMP PARALLEL DO 
+!$OMP PARALLEL DO PRIVATE(i)
       do j=1,kpje
       do i=1,kpie
         fulsed(i,j)=0.
@@ -168,7 +168,7 @@
       
 ! determine how the total sediment column is filled 
       do k=1,ks
-!$OMP PARALLEL DO PRIVATE(sedlo) 
+!$OMP PARALLEL DO PRIVATE(i,sedlo)
       do j=1,kpje
       do i=1,kpie
         if(omask(i,j).gt.0.5) then
@@ -187,7 +187,7 @@
 ! shift the sediment deficiency from the deepest (burial) 
 ! layer into layer ks
 !$OMP PARALLEL DO                                          &
-!$OMP&PRIVATE(seddef,spresent,buried,refill,frac) 
+!$OMP&PRIVATE(i,seddef,spresent,buried,refill,frac)
       do j=1,kpje
       do i=1,kpie
       if(omask(i,j).gt.0.5) then
@@ -246,7 +246,7 @@
 
 !     redistribute overload of layer ks
       do  k=ks,2,-1
-!$OMP PARALLEL DO PRIVATE(sedlo) 
+!$OMP PARALLEL DO PRIVATE(i,sedlo)
       do j=1,kpje
       do i=1,kpie
         if(omask(i,j).gt.0.5) then
@@ -262,7 +262,7 @@
 !$OMP END PARALLEL DO
 
       do iv=1,4
-!$OMP PARALLEL DO PRIVATE(uebers,frac) 
+!$OMP PARALLEL DO PRIVATE(i,uebers,frac)
       do j=1,kpje
       do i=1,kpie
         if(omask(i,j).gt.0.5) then

--- a/hamocc/trc_limitc.F
+++ b/hamocc/trc_limitc.F
@@ -65,7 +65,7 @@ c
 c
         util1(:,:)=0.
 c
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(l,i)
         do j=1,jj
           do l=1,isp(j)
           do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -85,7 +85,7 @@ c --- ------------------------------------------------------------------
 c --- - remove negative tracer values in the surface layer
 c --- ------------------------------------------------------------------
 c
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(j,l,i)
       do nt=itrbgc,itrbgc+ntrbgc-1
         do j=1,jj
           do l=1,isp(j)
@@ -106,7 +106,7 @@ c
 c
         util1(:,:)=0.
 c
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(l,i)
         do j=1,jj
           do l=1,isp(j)
           do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
@@ -120,7 +120,7 @@ c
         call xcsum(trbudn,util1,ips)
         q=trbudo(nt)/max(1.e-14,trbudn)
 c
-c$OMP PARALLEL DO
+c$OMP PARALLEL DO PRIVATE(l,i)
         do j=1,jj
           do l=1,isp(j)
           do i=max(1,ifp(j,l)),min(ii,ilp(j,l))


### PR DESCRIPTION
Declare indices of do loops (e.g. i,j,k) as private when using
$OMP PARALLEL DO PRIVATE(...)

This makes it possible to compile iHAMOCC with openMP. I have not run any test cases with this version yet, I guess this should be done either on Fram or Betzy. Is there a setup for running BLOM/iHAMOCC stand-alone (without using the NorESM framework)? I have been able to run BLOM stand-alone without the iHAMOCC part.