### PR TITLE
Change reading of BGC namelist

### DIFF
--- a/hamocc/hamocc_init.F
+++ b/hamocc/hamocc_init.F
@@ -65,6 +65,9 @@ c
       character(len=*), intent(in) :: rstfnm_ocn
 
       integer :: i,j,k,l,nt
+      integer :: iounit
+
+      character(len=256) :: bgc_nemalist_file
 
       namelist /bgcnml/ atm_co2,do_rivinpt,do_ndep,
      .                  ndepfile,fedepfile,rivinfile,
@@ -75,7 +78,6 @@ c
 c --- Set io units and some control parameters
 c
       io_stdo_bgc = lp              !  standard out.
-      io_nml = nfu                  !  namelist
       dtbgc = nphys*baclin          !  time step length [sec].
       ndtdaybgc=NINT(86400./dtbgc)  !  time steps per day [No].
       dtb=1./ndtdaybgc              !  time step length [days].
@@ -96,16 +98,17 @@ c
 c
 c --- Read the HAMOCC BGCNML namelist.
 c
-      open (unit=io_nml,file='ocn_in'//trim(inst_suffix),status='old'
+      call get_bgc_namelist(bgc_namelist_file)
+      open (newunit=iounit, file=trim(bgc_namelist_file), status='old'
      .                 ,action='read')
-      read (unit=io_nml,nml=BGCNML)
-      close (unit=io_nml)
+      read (unit=iounit, nml=BGCNML)
+      close (unit=iounit)
       IF (mnproc.eq.1) THEN
         write(io_stdo_bgc,*)
         write(io_stdo_bgc,*) 'iHAMOCC: reading namelist BGCNML'
         write(io_stdo_bgc,nml=BGCNML)
       ENDIF
-c                        
+c
 c --- Memory allocation 
 c
       CALL ALLOC_MEM_INTFCBLOM(idm,jdm,kdm)

--- a/hamocc/hamocc_init.F
+++ b/hamocc/hamocc_init.F
@@ -37,7 +37,6 @@ c  *INTEGER*   *read_rest*  - flag indicating whether to read restart files.
 c  *INTEGER*   *rstfnm_ocn* - restart filename.
 c
 c******************************************************************************
-      USE mod_config,    only: inst_suffix
       use mod_time,      only: date,baclin
       use mod_xc,        only: ii,jj,kk,idm,jdm,kdm,nbdy,isp,ifp,ilp,
      .                         mnproc,lp,nfu
@@ -67,7 +66,7 @@ c
       integer :: i,j,k,l,nt
       integer :: iounit
 
-      character(len=256) :: bgc_nemalist_file
+      character(len=256) :: bgc_namelist_file
 
       namelist /bgcnml/ atm_co2,do_rivinpt,do_ndep,
      .                  ndepfile,fedepfile,rivinfile,

--- a/hamocc/hamocc_init.F
+++ b/hamocc/hamocc_init.F
@@ -66,8 +66,6 @@ c
       integer :: i,j,k,l,nt
       integer :: iounit
 
-      character(len=256) :: bgc_namelist_file
-
       namelist /bgcnml/ atm_co2,do_rivinpt,do_ndep,
      .                  ndepfile,fedepfile,rivinfile,
      .                  inidic,inialk,inipo4,inioxy,inino3,inisil,
@@ -97,8 +95,8 @@ c
 c
 c --- Read the HAMOCC BGCNML namelist.
 c
-      call get_bgc_namelist(bgc_namelist_file)
-      open (newunit=iounit, file=trim(bgc_namelist_file), status='old'
+      if(.not. allocated(bgc_namelist)) call get_bgc_namelist
+      open (newunit=iounit, file=bgc_namelist, status='old'
      .                 ,action='read')
       read (unit=iounit, nml=BGCNML)
       close (unit=iounit)

--- a/hamocc/mo_Gdata_read.F90
+++ b/hamocc/mo_Gdata_read.F90
@@ -72,7 +72,7 @@ module mo_Gdata_read
 
 use netcdf
 use mod_xc,         only: mnproc,xchalt
-use mo_control_bgc, only: io_stdo_bgc,io_nml
+use mo_control_bgc, only: io_stdo_bgc
 
 implicit none
 

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -461,12 +461,11 @@
       INTEGER, intent(in) :: kpie,kpje,kpke
 
       INTEGER             :: m,n,errstat,iounit,checkdp(nbgcmax)
-      CHARACTER(LEN=256)  :: bgc_namelist_file
 
 !     Read namelist for diagnostic output
       GLB_AVEPERIO=0
-      call get_bgc_namelist(bgc_namelist_file)
-      OPEN (newunit=iounit, file=trim(bgc_namelist_file),               &
+      if(.not. allocated(bgc_namelist)) call get_bgc_namelist
+      OPEN (newunit=iounit, file=bgc_namelist,                          &
            status='old', action='read', recl=80)
       READ (iounit,nml=diabgc)
       CLOSE (iounit)

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -53,7 +53,6 @@
 !     - declaration of auxiliary functions  
 !
 !**********************************************************************
-      USE mod_config, only: inst_suffix
       USE mod_xc, only: ii,jj,kk,idm,jdm,kdm,nbdy,ifp,isp,ilp
       USE mod_dia, only: ddm,depthslev,depthslev_bnds,nstepinday,pbath
       USE mod_nctools
@@ -462,26 +461,13 @@
       INTEGER, intent(in) :: kpie,kpje,kpke
 
       INTEGER             :: m,n,errstat,iounit,checkdp(nbgcmax)
-      LOGICAL             :: isopen,exists      
+      CHARACTER(LEN=256)  :: bgc_namelist_file
 
-!     Read namelist for diagnostic output 
-      GLB_AVEPERIO=0 
-      DO iounit=10,99
-        INQUIRE(unit=iounit,opened=isopen)
-        IF (.NOT.isopen) EXIT
-      ENDDO
-      INQUIRE(file='ocn_in'//trim(inst_suffix),exist=exists)
-      IF (exists) THEN
-        OPEN (iounit,file='ocn_in'//trim(inst_suffix),status='old',action='read',recl=80)
-      ELSE   
-        INQUIRE(file='limits',exist=exists)
-        IF (exists) THEN
-          OPEN (iounit,file='limits',status='old',action='read',      &
-     &      recl=80)
-        ELSE
-          STOP 'cannot find limits file' 
-        ENDIF 
-      ENDIF  
+!     Read namelist for diagnostic output
+      GLB_AVEPERIO=0
+      call get_bgc_namelist(bgc_namelist_file)
+      OPEN (newunit=iounit, file=trim(bgc_namelist_file),               &
+           status='old', action='read', recl=80)
       READ (iounit,nml=diabgc)
       CLOSE (iounit)
 

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -40,7 +40,9 @@
 ! Logical unit number for I/O.
 
       INTEGER :: io_stdo_bgc           !  standard out.
-      INTEGER :: io_nml                !  namelist
+
+! File containing namelists
+      CHARACTER(LEN=:), ALLOCATABLE, PROTECTED :: bgc_namelist
 
 ! Control variables
 
@@ -60,5 +62,40 @@
 ! Logical switches
       LOGICAL, SAVE :: do_ndep=.true.    ! apply n-deposition   (set via namelist)
       LOGICAL, SAVE :: do_rivinpt=.true. ! apply riverine input (set via namelist)
-      
+
+    contains
+
+      subroutine get_bgc_namelist(fname)
+      !-------------------------------------------------------------------------
+      ! Get filename for namelist file
+      !-------------------------------------------------------------------------
+        use mod_config, only: inst_suffix
+        use mod_xc, only: xchalt
+
+        implicit none
+
+        character(len=*), intent(out) :: fname
+        logical :: exists
+
+        if (.not. allocated(bgc_namelist)) then
+           inquire (file='ocn_in'//trim(inst_suffix), exist=exists)
+           if (exists) then
+              allocate(character(len=len('ocn_in'//trim(inst_suffix))) ::       &
+                   bgc_namelist)
+              bgc_namelist = 'ocn_in'//trim(inst_suffix)
+           else
+              inquire (file='limits', exist=exists)
+              if (exists) then
+                 allocate(character(len=len('limits')) :: bgc_namelist)
+                 bgc_namelist = 'limits'
+              else
+                 call xchalt('cannot find limits file')
+                 stop 'cannot find limits file'
+              endif
+           endif
+        endif
+
+        fname = bgc_namelist
+      end subroutine get_bgc_namelist
+
       END MODULE mo_control_bgc

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -65,7 +65,7 @@
 
     contains
 
-      subroutine get_bgc_namelist(fname)
+      subroutine get_bgc_namelist
       !-------------------------------------------------------------------------
       ! Get filename for namelist file
       !-------------------------------------------------------------------------
@@ -74,7 +74,6 @@
 
         implicit none
 
-        character(len=*), intent(out) :: fname
         logical :: exists
 
         if (.not. allocated(bgc_namelist)) then
@@ -94,8 +93,6 @@
               endif
            endif
         endif
-
-        fname = bgc_namelist
       end subroutine get_bgc_namelist
 
       END MODULE mo_control_bgc


### PR DESCRIPTION
Change reading of BGC namelist to accept (1) ocn_in file or (2) limits file.

- Use the "newunit" option when opening namelist file, do not reserve io_nml unit for namelist.
- New subroutine in mo_control_bgc : get_bgc_namelist

This change will be convenient if implementing any stand-alone test cases with activated HAMOCC component using "limits" file.