### PR TITLE
Bugfix: write tracer restart files for all experiments.

### DIFF
--- a/hamocc/aufr_bgc.F90
+++ b/hamocc/aufr_bgc.F90
@@ -19,7 +19,7 @@
 
 
       SUBROUTINE AUFR_BGC(kpie,kpje,kpke,ntr,ntrbgc,itrbgc,trc,               &
-                          kplyear,kplmon,kplday,omask,rstfnm_ocn)
+                          kplyear,kplmon,kplday,omask,rstfnm)
 !******************************************************************************
 !
 !**** *AUFR_BGC* - reads marine bgc restart data.
@@ -97,7 +97,7 @@
 !     *INTEGER* *kplmon*     - month in ocean restart date
 !     *INTEGER* *kplday*     - day   in ocean restart date
 !     *REAL*    *omask*      - land/ocean mask
-!     *CHAR*    *rstfnm_ocn* - restart file name-informations
+!     *CHAR*    *rstfnm*     - restart file name-informations
 !
 !
 !**************************************************************************
@@ -109,7 +109,6 @@
       use mo_vgrid,     only: kbo
       USE mo_sedmnt,    only: sedhpl
       use mo_intfcblom, only: sedlay2,powtra2,burial2,atm2
-      USE mod_config,   only: inst_suffix
       use mod_xc,       only: nbdy,mnproc,iqr,jqr,xcbcst,xchalt
       use mod_dia,      only: iotype
 
@@ -117,18 +116,17 @@
 
       INTEGER          :: kpie,kpje,kpke,ntr,ntrbgc,itrbgc
       REAL             :: trc(1-nbdy:kpie+nbdy,1-nbdy:kpje+nbdy,2*kpke,ntr)
-      REAL             :: omask(kpie,kpje)    
+      REAL             :: omask(kpie,kpje)
       INTEGER          :: kplyear,kplmon,kplday
-      character(len=*) :: rstfnm_ocn
+      character(len=*) :: rstfnm
 
       ! Local variables
-      REAL      :: locetra(kpie,kpje,2*kpke,nocetra) ! local array for reading 
+      REAL      :: locetra(kpie,kpje,2*kpke,nocetra) ! local array for reading
       INTEGER   :: restyear                          !  year of restart file
       INTEGER   :: restmonth                         !  month of restart file
       INTEGER   :: restday                           !  day of restart file
       INTEGER   :: restdtoce                         !  time step number from bgc ocean file
       INTEGER   :: idate(5),i,j,k
-      character :: rstfnm*256
       logical   :: lread_cfc,lread_nat,lread_iso,lread_atm
 #ifdef cisonew
       REAL :: rco213,rco214,alpha14,beta13,beta14,d13C_atm,d14cat
@@ -154,25 +152,7 @@
 ! Open netCDF data file
 !
       testio=0
-      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
       IF(mnproc==1 .AND. IOTYPE==0) THEN
-
-        i=1
-        do while (rstfnm_ocn(i:i+leninrstfn).ne.'.blom'//trim(inst_suffix)//'.r.' .AND.              &
-     &            rstfnm_ocn(i:i+8).ne.'.micom.r.')
-          i=i+1
-          if (i+8.gt.len(rstfnm_ocn)) then
-            write (io_stdo_bgc,*)                                    &
-     &        'Could not generate restart file name!'
-            call xchalt('(aufr_bgc)')
-            stop '(aufr_bgc)'
-          endif
-        enddo
-        if (rstfnm_ocn(i:i+leninrstfn).eq.'.blom'//trim(inst_suffix)  //'.r.') then
-          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
-        else
-          rstfnm=rstfnm_ocn(1:i-1)//'.micom.rbgc.'//rstfnm_ocn(i+9:)
-        endif
         ncstat = NF90_OPEN(rstfnm,NF90_NOWRITE, ncid)
         IF ( ncstat .NE. NF90_NOERR ) THEN
              CALL xchalt('(AUFR: Problem with netCDF1)')
@@ -203,22 +183,6 @@
       ELSE IF(IOTYPE==1) THEN
 #ifdef PNETCDF
         testio=1
-        i=1
-        do while (rstfnm_ocn(i:i+leninrstfn).ne.'.blom'//trim(inst_suffix)//'.r.' .AND.              &
-     &            rstfnm_ocn(i:i+8).ne.'.micom.r.')
-          i=i+1
-          if (i+8.gt.len(rstfnm_ocn)) then
-            write (io_stdo_bgc,*)                                    &
-     &        'Could not generate restart file name!'
-            call xchalt('(aufr_bgc)')
-            stop '(aufr_bgc)'
-          endif
-        enddo
-        if (rstfnm_ocn(i:i+leninrstfn).eq.'.blom'//trim(inst_suffix)//   '.r.') then
-          rstfnm=rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
-        else
-          rstfnm=rstfnm_ocn(1:i-1)//'.micom.rbgc.'//rstfnm_ocn(i+9:)
-        endif
         write(stripestr,('(i3)')) 16
         write(stripestr2,('(i9)')) 1024*1024
         call mpi_info_create(info,ierr)

--- a/hamocc/hamocc_init.F
+++ b/hamocc/hamocc_init.F
@@ -17,7 +17,7 @@ c You should have received a copy of the GNU Lesser General Public License
 c along with BLOM. If not, see https://www.gnu.org/licenses/.
 
 
-      subroutine hamocc_init(read_rest,rstfnm_ocn)
+      subroutine hamocc_init(read_rest,rstfnm_hamocc)
 c******************************************************************************
 c
 c  HAMOCC_INIT - initialize HAMOCC and its interface to BLOM.
@@ -33,8 +33,8 @@ c
 c
 c  Interface to ocean model (parameter list):
 c  -----------------------------------------
-c  *INTEGER*   *read_rest*  - flag indicating whether to read restart files.
-c  *INTEGER*   *rstfnm_ocn* - restart filename.
+c  *INTEGER*   *read_rest*     - flag indicating whether to read restart files.
+c  *INTEGER*   *rstfnm_hamocc* - restart filename.
 c
 c******************************************************************************
       use mod_time,      only: date,baclin
@@ -62,7 +62,7 @@ c
       implicit none
 c
       integer,          intent(in) :: read_rest
-      character(len=*), intent(in) :: rstfnm_ocn
+      character(len=*), intent(in) :: rstfnm_hamocc
 
       integer :: i,j,k,l,nt
       integer :: iounit
@@ -174,7 +174,7 @@ c     two-time-level counterpart
 c
       IF(read_rest.eq.1) THEN
          CALL AUFR_BGC(idm,jdm,kdm,ntr,ntrbgc,itrbgc,trc,
-     .                 date%year,date%month,date%day,omask,rstfnm_ocn)
+     .        date%year,date%month,date%day,omask,rstfnm_hamocc)
       ELSE
          trc(1:idm,1:jdm,1:kdm,      itrbgc:itrbgc+ntrbgc-1) =
      .     ocetra(:,:,:,:)

--- a/trc/meson.build
+++ b/trc/meson.build
@@ -1,3 +1,3 @@
 sources += files('initrc.F', 'mod_tracers.F90', 'ocntrc_init.F',
-'restart_ocntrcrd.F', 'restart_ocntrcwt.F', 'restart_trcrd.F',
-'restart_trcwt.F', 'updtrc.F')
+'restart_getfile.F90', 'restart_ocntrcrd.F', 'restart_ocntrcwt.F',
+'restart_trcrd.F', 'restart_trcwt.F', 'updtrc.F')

--- a/trc/restart_getfile.F90
+++ b/trc/restart_getfile.F90
@@ -40,13 +40,13 @@ subroutine restart_getfile(rstfnm_in, rstlabel, rstfnm_out, rstfnm_err)
      ! Assume file format: <str_restart.>'r'<.str_timestamp><.str_suffix>
      ! Search for '.' starting from end of "rstfnm_in" filename
      !-- File suffix
-     i_suffix = index(rstfnm_in, '.', .true.)
+     i_suffix = index(rstfnm_in, '.', back=.true.)
      str_suffix = trim(rstfnm_in(i_suffix:))
      !-- File timestamp
-     i_time = index(rstfnm_in(:(i_suffix-1)), '.', .true.)
+     i_time = index(rstfnm_in(:(i_suffix-1)), '.', back=.true.)
      str_time = rstfnm_in(i_time:(i_suffix-1))
      !-- File without original restart label
-     i_restart = index(rstfnm_in(:(i_time-1)), '.', .true.)
+     i_restart = index(rstfnm_in(:(i_time-1)), '.', back=.true.)
      str_restart = rstfnm_in(:i_restart)
 
      if (i_suffix == 0 .or. i_time == 0 .or. i_restart == 0) then
@@ -58,10 +58,10 @@ subroutine restart_getfile(rstfnm_in, rstlabel, rstfnm_out, rstfnm_err)
      ! Assume file format: <str_restart_>'restphy'<_str_suffix>
      ! Search for '_' starting from end of "rstfnm_in" filename
      !-- File suffix
-     i_suffix = index(rstfnm_in, '_', .true.)
+     i_suffix = index(rstfnm_in, '_', back=.true.)
      str_suffix = trim(rstfnm_in(i_suffix:))
      !-- File without original restart label
-     i_restart = index(rstfnm_in(:(i_suffix-1)), '_', .true.)
+     i_restart = index(rstfnm_in(:(i_suffix-1)), '_', back=.true.)
      str_restart = rstfnm_in(:i_restart)
 
      if (i_suffix == 0 .or. i_restart == 0) then

--- a/trc/restart_getfile.F90
+++ b/trc/restart_getfile.F90
@@ -1,0 +1,73 @@
+! ------------------------------------------------------------------------------
+! Copyright (C) 2007-2021 T. Torsvik
+!
+! This file is part of BLOM.
+!
+! BLOM is free software: you can redistribute it and/or modify it under the
+! terms of the GNU Lesser General Public License as published by the Free
+! Software Foundation, either version 3 of the License, or (at your option)
+! any later version.
+!
+! BLOM is distributed in the hope that it will be useful, but WITHOUT ANY
+! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+! FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+! more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with BLOM. If not, see <https://www.gnu.org/licenses/>.
+! ------------------------------------------------------------------------------
+
+subroutine restart_getfile(rstfnm_in, rstlabel, rstfnm_out, rstfnm_err)
+  !-----------------------------------------------------------------------------
+  ! Generate filename for restart files to read or write tracer fields
+  !-----------------------------------------------------------------------------
+
+  use mod_config, only: expcnf
+
+  implicit none
+
+  character(len=*), intent(in)  :: rstfnm_in     ! Original restart file name
+  character(len=*), intent(in)  :: rstlabel      ! Label to insert in new file
+  character(len=*), intent(out) :: rstfnm_out    ! New restart file name
+  logical,          intent(out) :: rstfnm_err    ! Error flag
+
+  integer :: i_suffix, i_time, i_restart
+  character(len=:), allocatable  :: str_suffix, str_time, str_restart
+
+  rstfnm_err = .false.
+
+  if (expcnf.eq.'cesm') then
+     ! Assume file format: <str_restart.>'r'<.str_timestamp><.str_suffix>
+     ! Search for '.' starting from end of "rstfnm_in" filename
+     !-- File suffix
+     i_suffix = index(rstfnm_in, '.', .true.)
+     str_suffix = trim(rstfnm_in(i_suffix:))
+     !-- File timestamp
+     i_time = index(rstfnm_in(:(i_suffix-1)), '.', .true.)
+     str_time = rstfnm_in(i_time:(i_suffix-1))
+     !-- File without original restart label
+     i_restart = index(rstfnm_in(:(i_time-1)), '.', .true.)
+     str_restart = rstfnm(:i_restart)
+
+     if (i_suffix == 0 .or. i_time == 0 .or. i_restart == 0) then
+        rstfnm_err = .true.
+     else
+        rstfnm_out = str_restart // trim(rstlabel) // str_time // str_suffix
+     end if
+  else
+     ! Assume file format: <str_restart_>'restphy'<_str_suffix>
+     ! Search for '_' starting from end of "rstfnm_in" filename
+     !-- File suffix
+     i_suffix = index(rstfnm_in, '_', .true.)
+     str_suffix = trim(rstfnm_in(i_suffix:))
+     !-- File without original restart label
+     i_restart = index(rstfnm_in(:(i_suffix-1)), '_', .true.)
+     str_restart = rstfnm(:i_restart)
+
+     if (i_suffix == 0 .or. i_restart == 0) then
+        rstfnm_err = .true.
+     else
+        rstfnm_out = str_restart // trim(rstlabel) // str_suffix
+     end if
+  end if
+end subroutine restart_getfile

--- a/trc/restart_getfile.F90
+++ b/trc/restart_getfile.F90
@@ -47,7 +47,7 @@ subroutine restart_getfile(rstfnm_in, rstlabel, rstfnm_out, rstfnm_err)
      str_time = rstfnm_in(i_time:(i_suffix-1))
      !-- File without original restart label
      i_restart = index(rstfnm_in(:(i_time-1)), '.', .true.)
-     str_restart = rstfnm(:i_restart)
+     str_restart = rstfnm_in(:i_restart)
 
      if (i_suffix == 0 .or. i_time == 0 .or. i_restart == 0) then
         rstfnm_err = .true.
@@ -62,7 +62,7 @@ subroutine restart_getfile(rstfnm_in, rstlabel, rstfnm_out, rstfnm_err)
      str_suffix = trim(rstfnm_in(i_suffix:))
      !-- File without original restart label
      i_restart = index(rstfnm_in(:(i_suffix-1)), '_', .true.)
-     str_restart = rstfnm(:i_restart)
+     str_restart = rstfnm_in(:i_restart)
 
      if (i_suffix == 0 .or. i_restart == 0) then
         rstfnm_err = .true.

--- a/trc/restart_ocntrcrd.F
+++ b/trc/restart_ocntrcrd.F
@@ -17,7 +17,7 @@
 ! along with BLOM. If not, see <https://www.gnu.org/licenses/>.
 ! ------------------------------------------------------------------------------
 
-      subroutine restart_ocntrcrd(rstfnm_ocn)
+      subroutine restart_ocntrcrd(rstfnm)
 c
 c --- ------------------------------------------------------------------
 c --- Read ocean tracer state from restart file
@@ -32,13 +32,13 @@ c
 c
       implicit none
 c
-      character rstfnm_ocn*(*)
+      character rstfnm*(*)
 c
       type(date_type) :: date_rest
-      integer i,nt,nat
+      integer nt,nat
       real time0r,timer
       logical fexist
-      character(len=256) :: rstfnm,trcnm
+      character(len=256) :: trcnm
 c
 c --- ------------------------------------------------------------------
 c --- If no ocean tracers are defined, return
@@ -47,41 +47,9 @@ c
       if (ntrocn.eq.0) return
 c
 c --- ------------------------------------------------------------------
-c --- Generate file name and check for file existence
+c --- Check for file existence
 c --- ------------------------------------------------------------------
 c
-#ifdef CCSMCOUPLED
-      i=1
-      do while (rstfnm_ocn(i:i+7).ne.'.blom.r.'.and.
-     .          rstfnm_ocn(i:i+8).ne.'.micom.r.')
-        i=i+1
-        if (i+8.gt.len(rstfnm_ocn)) then
-          if (mnproc.eq.1) 
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_ocntrcrd)')
-          stop '(restart_ocntrcrd)'
-        endif
-      enddo
-      if (rstfnm_ocn(i:i+7).eq.'.blom.r.') then
-        rstfnm=rstfnm_ocn(1:i-1)//'.blom.rtrc.'//rstfnm_ocn(i+8:)
-      else
-        rstfnm=rstfnm_ocn(1:i-1)//'.micom.rtrc.'//rstfnm_ocn(i+9:)
-      endif
-#else
-      i=1
-      do while (rstfnm_ocn(i:i+8).ne.'_restphy_')
-        i=i+1
-        if (i+8.gt.len(rstfnm_ocn)) then
-          if (mnproc.eq.1) 
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_ocntrcrd)')
-          stop '(restart_ocntrcrd)'
-        endif
-      enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'_resttrc_'//rstfnm_ocn(i+9:)
-#endif
       inquire(file=rstfnm,exist=fexist)
 c
       call xcbcst(fexist)

--- a/trc/restart_ocntrcwt.F
+++ b/trc/restart_ocntrcwt.F
@@ -17,7 +17,7 @@
 ! along with BLOM. If not, see <https://www.gnu.org/licenses/>.
 ! ------------------------------------------------------------------------------
 
-      subroutine restart_ocntrcwt(rstfnm_ocn)
+      subroutine restart_ocntrcwt(rstfnm)
 c
 c --- ------------------------------------------------------------------
 c --- Write ocean tracer state to restart file
@@ -31,10 +31,10 @@ c
 c
       implicit none
 c
-      character rstfnm_ocn*(*)
+      character rstfnm*(*)
 c
-      integer i,nt,nat
-      character(len=256) :: rstfnm,trcnm
+      integer nt,nat
+      character(len=256) :: trcnm
 c
 c --- ------------------------------------------------------------------
 c --- if no ocean tracers are defined, return
@@ -43,41 +43,14 @@ c
       if (ntrocn.eq.0) return
 c
 c --- ------------------------------------------------------------------
-c --- Generate file name and create file 
+c --- Create file
 c --- ------------------------------------------------------------------
 c
-#ifdef CCSMCOUPLED
-      i=1
-      do while (rstfnm_ocn(i:i+7).ne.'.blom.r.')
-        i=i+1
-        if (i+7.gt.len(rstfnm_ocn)) then
-          if (mnproc.eq.1)
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_ocntrcrd)')
-          stop '(restart_ocntrcrd)'
-        endif
-      enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'.blom.rtrc.'//rstfnm_ocn(i+8:)
-#else
-      i=1
-      do while (rstfnm_ocn(i:i+8).ne.'_restphy_')
-        i=i+1
-        if (i+8.gt.len(rstfnm_ocn)) then
-          if (mnproc.eq.1)
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_ocntrcrd)')
-          stop '(restart_ocntrcrd)'
-        endif
-      enddo
-      rstfnm=rstfnm_ocn(1:i-1)//'_resttrc_'//rstfnm_ocn(i+9:)
-#endif
       if (mnproc.eq.1) then
         write (lp,'(2a)') ' saving ocean tracer restart file ',
      .                    trim(rstfnm)
       endif
-      if (rstfmt.eq.1) then 
+      if (rstfmt.eq.1) then
         call ncfopn(rstfnm,'w','6',1,iotype)
       elseif (rstfmt.eq.2) then
         call ncfopn(rstfnm,'w','h',1,iotype)

--- a/trc/restart_trcrd.F
+++ b/trc/restart_trcrd.F
@@ -23,14 +23,13 @@ c --- ------------------------------------------------------------------
 c --- Read tracer state from restart files
 c --- ------------------------------------------------------------------
 c
-      use mod_config,   only: inst_suffix
+      use mod_config, only: expcnf, runid, inst_suffix
       use mod_xc
 c
       implicit none
 c
       character rstfnm_ocn*(*)
 c
-      integer :: i, leninrstfn, maxstr
       character(len=256) :: rstfnm_ocntrc
 #ifdef HAMOCC
       character(len=256) :: rstfnm_hamocc
@@ -40,56 +39,21 @@ c --- ------------------------------------------------------------------
 c --- Generate file name
 c --- ------------------------------------------------------------------
 c
-#ifdef CCSMCOUPLED
-      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
-      maxstr = max(leninrstfn, 8)
-      i=1
-      do while (rstfnm_ocn(i:i+leninrstfn) .ne.
-     .     '.blom'//trim(inst_suffix)//'.r.' .and.
-     .     rstfnm_ocn(i:i+8).ne.'.micom.r.')
-        i=i+1
-        if (i+maxstr .gt. len(rstfnm_ocn)) then
-          if (mnproc.eq.1)
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_trcrd)')
-          stop '(restart_trcrd)'
-        endif
-      enddo
-      if (rstfnm_ocn(i:i+7).eq.'.blom.r.') then
-         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.blom.rtrc.'//
-     .        rstfnm_ocn(i+8:)
-      else
-         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.micom.rtrc.'//
-     .        rstfnm_ocn(i+9:)
-      endif
+      if (expcnf.eq.'cesm') then
+         rstfnm_ocntrc = trim(runid)//
+     .        '.blom.rtrc.'//rstfnm(len_trim(runid)+10:)
 #ifdef HAMOCC
-      if (rstfnm_ocn(i:i+leninrstfn) .eq.
-     .     '.blom'//trim(inst_suffix)  //'.r.') then
-         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.blom'//
-     .        trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
+         rstfnm_hamocc = trim(runid)//
+     .        '.blom.rbgc.'//rstfnm(len_trim(runid)+10:)
+#endif
       else
-         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.micom.rbgc.'//
-     .        rstfnm_ocn(i+9:)
-      endif
-#endif
-#else
-      i=1
-      do while (rstfnm_ocn(i:i+8) .ne. '_restphy_')
-        i=i+1
-        if (i+8 .gt. len(rstfnm_ocn)) then
-          if (mnproc.eq.1)
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_trcrd)')
-          stop '(restart_trcrd)'
-        endif
-      enddo
-      rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'_resttrc_'//rstfnm_ocn(i+9:)
+         rstfnm_ocntrc = trim(runid)//
+     .        '_resttrc_'//rstfnm(len_trim(runid)+10:)
 #ifdef HAMOCC
-      rstfnm_hamocc = rstfnm_ocn(1:i-1)//'_restbgc_'//rstfnm_ocn(i+9:)
+         rstfnm_hamocc = trim(runid)//
+     .        '_restbgc_'//rstfnm(len_trim(runid)+10:)
 #endif
-#endif
+      endif
 c
 c --- ------------------------------------------------------------------
 c --- Read restart files

--- a/trc/restart_trcrd.F
+++ b/trc/restart_trcrd.F
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2007-2018 Mats Bentsen
+! Copyright (C) 2007-2021 Mats Bentsen, Tomas Torsvik
 !
 ! This file is part of BLOM.
 !
@@ -23,13 +23,14 @@ c --- ------------------------------------------------------------------
 c --- Read tracer state from restart files
 c --- ------------------------------------------------------------------
 c
-      use mod_config, only: expcnf, runid, inst_suffix
+      use mod_config, only: expcnf
       use mod_xc
 c
       implicit none
 c
       character rstfnm_ocn*(*)
 c
+      logical :: error
       character(len=256) :: rstfnm_ocntrc
 #ifdef HAMOCC
       character(len=256) :: rstfnm_hamocc
@@ -39,36 +40,53 @@ c --- ------------------------------------------------------------------
 c --- Generate file name
 c --- ------------------------------------------------------------------
 c
-      if (expcnf.eq.'cesm') then
-         if (index(rstfnm_ocn, 'blom') > 0) then
-            rstfnm_ocntrc = trim(runid)//
-     .           '.blom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
-#ifdef HAMOCC
-            rstfnm_hamocc = trim(runid)//
-     .           '.blom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
-#endif
-         elseif (index(rstfnm_ocn, 'micom') > 0) then
-            rstfnm_ocntrc = trim(runid)//
-     .           '.micom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
-#ifdef HAMOCC
-            rstfnm_hamocc = trim(runid)//
-     .           '.micom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
-#endif
-         else
-            if (mnproc.eq.1) then
-               write (lp,'(a)') 'Could not generate restart file name!'
-               call xchalt('(restart_trcrd)')
+      if (mnproc.eq.1) then
+         if (expcnf.eq.'cesm') then
+            call restart_getfile(
+     .           rstfnm_ocn, 'rtrc', rstfnm_ocntrc, error)
+            if (error) then
+               write(lp,*) 'restart_trcrd: '//
+     .              'could not generate rstfnm_ocntrc file!'
+               call xcstop('(restat_trcrd)')
                stop '(restart_trcrd)'
             endif
-         endif
-      else
-         rstfnm_ocntrc = trim(runid)//
-     .        '_resttrc_'//rstfnm_ocn(len_trim(runid)+10:)
 #ifdef HAMOCC
-         rstfnm_hamocc = trim(runid)//
-     .        '_restbgc_'//rstfnm_ocn(len_trim(runid)+10:)
+            call restart_getfile(
+     .           rstfnm_ocn, 'rbgc', rstfnm_hamocc, error)
+            if (error) then
+               write(lp,*) 'restart_trcrd: '//
+     .              'could not generate rstfnm_hamocc file!'
+               call xcstop('(restat_trcrd)')
+               stop '(restart_trcrd)'
+            endif
 #endif
+         else
+            call restart_getfile(
+     .           rstfnm_ocn, 'resttrc', rstfnm_ocntrc, error)
+            if (error) then
+               write(lp,*) 'restart_trcrd: '//
+     .              'could not generate rstfnm_ocntrc file!'
+               call xcstop('(restat_trcrd)')
+               stop '(restart_trcrd)'
+            endif
+#ifdef HAMOCC
+            call restart_getfile(
+     .           rstfnm_ocn, 'restbgc', rstfnm_hamocc, error)
+            if (error) then
+               write(lp,*) 'restart_trcrd: '//
+     .              'could not generate rstfnm_hamocc file!'
+               call xcstop('(restat_trcrd)')
+               stop '(restart_trcrd)'
+            endif
+#endif
+         endif
       endif
+
+      call xcbcst(rstfn_ocntrc)
+#ifdef HAMOCC
+      call xcbcst(rstfn_hamocc)
+#endif
+
 c
 c --- ------------------------------------------------------------------
 c --- Read restart files

--- a/trc/restart_trcrd.F
+++ b/trc/restart_trcrd.F
@@ -40,12 +40,27 @@ c --- Generate file name
 c --- ------------------------------------------------------------------
 c
       if (expcnf.eq.'cesm') then
-         rstfnm_ocntrc = trim(runid)//
-     .        '.blom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
+         if (index(rstfnm_ocn, 'blom') > 0) then
+            rstfnm_ocntrc = trim(runid)//
+     .           '.blom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
 #ifdef HAMOCC
-         rstfnm_hamocc = trim(runid)//
-     .        '.blom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
+            rstfnm_hamocc = trim(runid)//
+     .           '.blom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
 #endif
+         elseif (index(rstfnm_ocn, 'micom') > 0) then
+            rstfnm_ocntrc = trim(runid)//
+     .           '.micom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
+#ifdef HAMOCC
+            rstfnm_hamocc = trim(runid)//
+     .           '.micom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
+#endif
+         else
+            if (mnproc.eq.1) then
+               write (lp,'(a)') 'Could not generate restart file name!'
+               call xchalt('(restart_trcrd)')
+               stop '(restart_trcrd)'
+            endif
+         endif
       else
          rstfnm_ocntrc = trim(runid)//
      .        '_resttrc_'//rstfnm_ocn(len_trim(runid)+10:)

--- a/trc/restart_trcrd.F
+++ b/trc/restart_trcrd.F
@@ -41,17 +41,17 @@ c --- ------------------------------------------------------------------
 c
       if (expcnf.eq.'cesm') then
          rstfnm_ocntrc = trim(runid)//
-     .        '.blom.rtrc.'//rstfnm(len_trim(runid)+10:)
+     .        '.blom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
 #ifdef HAMOCC
          rstfnm_hamocc = trim(runid)//
-     .        '.blom.rbgc.'//rstfnm(len_trim(runid)+10:)
+     .        '.blom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
 #endif
       else
          rstfnm_ocntrc = trim(runid)//
-     .        '_resttrc_'//rstfnm(len_trim(runid)+10:)
+     .        '_resttrc_'//rstfnm_ocn(len_trim(runid)+10:)
 #ifdef HAMOCC
          rstfnm_hamocc = trim(runid)//
-     .        '_restbgc_'//rstfnm(len_trim(runid)+10:)
+     .        '_restbgc_'//rstfnm_ocn(len_trim(runid)+10:)
 #endif
       endif
 c

--- a/trc/restart_trcrd.F
+++ b/trc/restart_trcrd.F
@@ -82,9 +82,9 @@ c
          endif
       endif
 
-      call xcbcst(rstfn_ocntrc)
+      call xcbcst(rstfnm_ocntrc)
 #ifdef HAMOCC
-      call xcbcst(rstfn_hamocc)
+      call xcbcst(rstfnm_hamocc)
 #endif
 
 c

--- a/trc/restart_trcrd.F
+++ b/trc/restart_trcrd.F
@@ -23,16 +23,82 @@ c --- ------------------------------------------------------------------
 c --- Read tracer state from restart files
 c --- ------------------------------------------------------------------
 c
+      use mod_config,   only: inst_suffix
       use mod_xc
 c
       implicit none
 c
       character rstfnm_ocn*(*)
 c
-      call restart_ocntrcrd(rstfnm_ocn)
+      integer :: i, leninrstfn, maxstr
+      character(len=256) :: rstfnm_ocntrc
+#ifdef HAMOCC
+      character(len=256) :: rstfnm_hamocc
+#endif
+c
+c --- ------------------------------------------------------------------
+c --- Generate file name
+c --- ------------------------------------------------------------------
+c
+#ifdef CCSMCOUPLED
+      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
+      maxstr = max(leninrstfn, 8)
+      i=1
+      do while (rstfnm_ocn(i:i+leninrstfn) .ne.
+     .     '.blom'//trim(inst_suffix)//'.r.' .and.
+     .     rstfnm_ocn(i:i+8).ne.'.micom.r.')
+        i=i+1
+        if (i+maxstr .gt. len(rstfnm_ocn)) then
+          if (mnproc.eq.1)
+     .      write (lp,*)
+     .        'Could not generate ocean tracer restart file name!'
+          call xchalt('(restart_trcrd)')
+          stop '(restart_trcrd)'
+        endif
+      enddo
+      if (rstfnm_ocn(i:i+7).eq.'.blom.r.') then
+         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.blom.rtrc.'//
+     .        rstfnm_ocn(i+8:)
+      else
+         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.micom.rtrc.'//
+     .        rstfnm_ocn(i+9:)
+      endif
+#ifdef HAMOCC
+      if (rstfnm_ocn(i:i+leninrstfn) .eq.
+     .     '.blom'//trim(inst_suffix)  //'.r.') then
+         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.blom'//
+     .        trim(inst_suffix)//'.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
+      else
+         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.micom.rbgc.'//
+     .        rstfnm_ocn(i+9:)
+      endif
+#endif
+#else
+      i=1
+      do while (rstfnm_ocn(i:i+8) .ne. '_restphy_')
+        i=i+1
+        if (i+8 .gt. len(rstfnm_ocn)) then
+          if (mnproc.eq.1)
+     .      write (lp,*)
+     .        'Could not generate ocean tracer restart file name!'
+          call xchalt('(restart_trcrd)')
+          stop '(restart_trcrd)'
+        endif
+      enddo
+      rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'_resttrc_'//rstfnm_ocn(i+9:)
+#ifdef HAMOCC
+      rstfnm_hamocc = rstfnm_ocn(1:i-1)//'_restbgc_'//rstfnm_ocn(i+9:)
+#endif
+#endif
+c
+c --- ------------------------------------------------------------------
+c --- Read restart files
+c --- ------------------------------------------------------------------
+c
+      call restart_ocntrcrd(rstfnm_ocntrc)
 c
 #ifdef HAMOCC
-      call hamocc_init(1,rstfnm_ocn)
+      call hamocc_init(1,rstfnm_hamocc)
 #endif
 c
       return

--- a/trc/restart_trcwt.F
+++ b/trc/restart_trcwt.F
@@ -23,14 +23,13 @@ c --- ------------------------------------------------------------------
 c --- Write tracer state to restart files
 c --- ------------------------------------------------------------------
 c
-      use mod_config,   only: inst_suffix
+      use mod_config, only: expcnf, runid, inst_suffix
       use mod_xc
 c
       implicit none
 c
       character rstfnm_ocn*(*)
 c
-      integer            :: i, leninrstfn
       character(len=256) :: rstfnm_ocntrc
 #ifdef HAMOCC
       character(len=256) :: rstfnm_hamocc
@@ -40,43 +39,19 @@ c --- ------------------------------------------------------------------
 c --- Generate file name
 c --- ------------------------------------------------------------------
 c
-      if (mnproc.eq.1) then
-#ifdef CCSMCOUPLED
-         leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
-         i=1
-         do while (rstfnm_ocn(i:i+leninrstfn) .ne.
-     .        '.blom'//trim(inst_suffix)//'.r.')
-            i=i+1
-            if (i+leninrstfn .gt. len(rstfnm_ocn)) then
-               write (lp,*)
-     .              'Could not generate ocean tracer restart file name!'
-               call xchalt('(restart_trcwt)')
-               stop '(restart_trcwt)'
-            endif
-         enddo
-         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
-     .        '.rtrc.'//rstfnm_ocn(i+leninrstfn+1:)
+      if (expcnf.eq.'cesm') then
+         rstfnm_ocntrc = trim(runid)//
+     .        '.blom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
 #ifdef HAMOCC
-         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
-     .        '.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
+         rstfnm_hamocc = trim(runid)//
+     .        '.blom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
 #endif
-#else
-         i=1
-         do while (rstfnm_ocn(i:i+8) .ne. '_restphy_')
-            i=i+1
-            if (i+8 .gt. len(rstfnm_ocn)) then
-               write (lp,*)
-     .              'Could not generate ocean tracer restart file name!'
-               call xchalt('(restart_trcwt)')
-               stop '(restart_trcwt)'
-            endif
-         enddo
-         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'_resttrc_'//
-     .        rstfnm_ocn(i+9:)
+      else
+         rstfnm_ocntrc = trim(runid)//
+     .        '_resttrc_'//rstfnm(len_trim(runid)+10:)
 #ifdef HAMOCC
-         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'_restbgc_'//
-     .        rstfnm_ocn(i+9:)
-#endif
+         rstfnm_hamocc = trim(runid)//
+     .        '_restbgc_'//rstfnm(len_trim(runid)+10:)
 #endif
       endif
 c
@@ -84,11 +59,9 @@ c --- ------------------------------------------------------------------
 c --- Write restart files
 c --- ------------------------------------------------------------------
 c
-      call xcbcst(rstfnm_ocntrc)
       call restart_ocntrcwt(rstfnm_ocntrc)
 c
 #ifdef HAMOCC
-      call xcbcst(rstfnm_hamocc)
       call restart_hamoccwt(rstfnm_hamocc)
 #endif
 c

--- a/trc/restart_trcwt.F
+++ b/trc/restart_trcwt.F
@@ -48,10 +48,10 @@ c
 #endif
       else
          rstfnm_ocntrc = trim(runid)//
-     .        '_resttrc_'//rstfnm(len_trim(runid)+10:)
+     .        '_resttrc_'//rstfnm_ocn(len_trim(runid)+10:)
 #ifdef HAMOCC
          rstfnm_hamocc = trim(runid)//
-     .        '_restbgc_'//rstfnm(len_trim(runid)+10:)
+     .        '_restbgc_'//rstfnm_ocn(len_trim(runid)+10:)
 #endif
       endif
 c

--- a/trc/restart_trcwt.F
+++ b/trc/restart_trcwt.F
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2007-2015 Mats Bentsen
+! Copyright (C) 2007-2021 Mats Bentsen, Tomas Torsvik
 !
 ! This file is part of BLOM.
 !
@@ -23,13 +23,14 @@ c --- ------------------------------------------------------------------
 c --- Write tracer state to restart files
 c --- ------------------------------------------------------------------
 c
-      use mod_config, only: expcnf, runid, inst_suffix
+      use mod_config, only: expcnf
       use mod_xc
 c
       implicit none
 c
       character rstfnm_ocn*(*)
 c
+      logical :: error
       character(len=256) :: rstfnm_ocntrc
 #ifdef HAMOCC
       character(len=256) :: rstfnm_hamocc
@@ -39,21 +40,53 @@ c --- ------------------------------------------------------------------
 c --- Generate file name
 c --- ------------------------------------------------------------------
 c
-      if (expcnf.eq.'cesm') then
-         rstfnm_ocntrc = trim(runid)//
-     .        '.blom.rtrc.'//rstfnm_ocn(len_trim(runid)+10:)
+      if (mnproc.eq.1) then
+         if (expcnf.eq.'cesm') then
+            call restart_getfile(
+     .           rstfnm_ocn, 'rtrc', rstfnm_ocntrc, error)
+            if (error) then
+               write(lp,*) 'restart_trcwt: '//
+     .              'could not generate rstfnm_ocntrc file!'
+               call xcstop('(restat_trcwt)')
+               stop '(restart_trcwt)'
+            endif
 #ifdef HAMOCC
-         rstfnm_hamocc = trim(runid)//
-     .        '.blom.rbgc.'//rstfnm_ocn(len_trim(runid)+10:)
+            call restart_getfile(
+     .           rstfnm_ocn, 'rbgc', rstfnm_hamocc, error)
+            if (error) then
+               write(lp,*) 'restart_trcwt: '//
+     .              'could not generate rstfnm_hamocc file!'
+               call xcstop('(restat_trcwt)')
+               stop '(restart_trcwt)'
+            endif
 #endif
-      else
-         rstfnm_ocntrc = trim(runid)//
-     .        '_resttrc_'//rstfnm_ocn(len_trim(runid)+10:)
+         else
+            call restart_getfile(
+     .           rstfnm_ocn, 'resttrc', rstfnm_ocntrc, error)
+            if (error) then
+               write(lp,*) 'restart_trcwt: '//
+     .              'could not generate rstfnm_ocntrc file!'
+               call xcstop('(restat_trcwt)')
+               stop '(restart_trcwt)'
+            endif
 #ifdef HAMOCC
-         rstfnm_hamocc = trim(runid)//
-     .        '_restbgc_'//rstfnm_ocn(len_trim(runid)+10:)
+            call restart_getfile(
+     .           rstfnm_ocn, 'restbgc', rstfnm_hamocc, error)
+            if (error) then
+               write(lp,*) 'restart_trcwt: '//
+     .              'could not generate rstfnm_hamocc file!'
+               call xcstop('(restat_trcwt)')
+               stop '(restart_trcwt)'
+            endif
 #endif
+         endif
       endif
+
+      call xcbcst(rstfn_ocntrc)
+#ifdef HAMOCC
+      call xcbcst(rstfn_hamocc)
+#endif
+
 c
 c --- ------------------------------------------------------------------
 c --- Write restart files

--- a/trc/restart_trcwt.F
+++ b/trc/restart_trcwt.F
@@ -35,56 +35,60 @@ c
 #ifdef HAMOCC
       character(len=256) :: rstfnm_hamocc
 #endif
-
+c
 c --- ------------------------------------------------------------------
 c --- Generate file name
 c --- ------------------------------------------------------------------
 c
+      if (mnproc.eq.1) then
 #ifdef CCSMCOUPLED
-      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
-      i=1
-      do while (rstfnm_ocn(i:i+leninrstfn) .ne.
-     .          '.blom'//trim(inst_suffix)//'.r.')
-        i=i+1
-        if (i+leninrstfn .gt. len(rstfnm_ocn)) then
-          if (mnproc.eq.1)
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_trcwt)')
-          stop '(restart_trcwt)'
-        endif
-      enddo
-      rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
-     .     '.rtrc.'//rstfnm_ocn(i+leninrstfn+1:)
+         leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
+         i=1
+         do while (rstfnm_ocn(i:i+leninrstfn) .ne.
+     .        '.blom'//trim(inst_suffix)//'.r.')
+            i=i+1
+            if (i+leninrstfn .gt. len(rstfnm_ocn)) then
+               write (lp,*)
+     .              'Could not generate ocean tracer restart file name!'
+               call xchalt('(restart_trcwt)')
+               stop '(restart_trcwt)'
+            endif
+         enddo
+         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
+     .        '.rtrc.'//rstfnm_ocn(i+leninrstfn+1:)
 #ifdef HAMOCC
-      rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
-     .     '.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
+         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
+     .        '.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
 #endif
 #else
-      i=1
-      do while (rstfnm_ocn(i:i+8) .ne. '_restphy_')
-        i=i+1
-        if (i+8 .gt. len(rstfnm_ocn)) then
-          if (mnproc.eq.1)
-     .      write (lp,*)
-     .        'Could not generate ocean tracer restart file name!'
-          call xchalt('(restart_trcwt)')
-          stop '(restart_trcwt)'
-        endif
-      enddo
-      rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'_resttrc_'//rstfnm_ocn(i+9:)
+         i=1
+         do while (rstfnm_ocn(i:i+8) .ne. '_restphy_')
+            i=i+1
+            if (i+8 .gt. len(rstfnm_ocn)) then
+               write (lp,*)
+     .              'Could not generate ocean tracer restart file name!'
+               call xchalt('(restart_trcwt)')
+               stop '(restart_trcwt)'
+            endif
+         enddo
+         rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'_resttrc_'//
+     .        rstfnm_ocn(i+9:)
 #ifdef HAMOCC
-      rstfnm_hamocc = rstfnm_ocn(1:i-1)//'_restbgc_'//rstfnm_ocn(i+9:)
+         rstfnm_hamocc = rstfnm_ocn(1:i-1)//'_restbgc_'//
+     .        rstfnm_ocn(i+9:)
 #endif
 #endif
+      endif
 c
 c --- ------------------------------------------------------------------
 c --- Write restart files
 c --- ------------------------------------------------------------------
 c
+      call xcbcst(rstfnm_ocntrc)
       call restart_ocntrcwt(rstfnm_ocntrc)
 c
 #ifdef HAMOCC
+      call xcbcst(rstfnm_hamocc)
       call restart_hamoccwt(rstfnm_hamocc)
 #endif
 c

--- a/trc/restart_trcwt.F
+++ b/trc/restart_trcwt.F
@@ -23,16 +23,69 @@ c --- ------------------------------------------------------------------
 c --- Write tracer state to restart files
 c --- ------------------------------------------------------------------
 c
+      use mod_config,   only: inst_suffix
       use mod_xc
 c
       implicit none
 c
       character rstfnm_ocn*(*)
 c
-      call restart_ocntrcwt(rstfnm_ocn)
+      integer            :: i, leninrstfn
+      character(len=256) :: rstfnm_ocntrc
+#ifdef HAMOCC
+      character(len=256) :: rstfnm_hamocc
+#endif
+
+c --- ------------------------------------------------------------------
+c --- Generate file name
+c --- ------------------------------------------------------------------
+c
+#ifdef CCSMCOUPLED
+      leninrstfn = len('.blom'//trim(inst_suffix)//'.r.')-1
+      i=1
+      do while (rstfnm_ocn(i:i+leninrstfn) .ne.
+     .          '.blom'//trim(inst_suffix)//'.r.')
+        i=i+1
+        if (i+leninrstfn .gt. len(rstfnm_ocn)) then
+          if (mnproc.eq.1)
+     .      write (lp,*)
+     .        'Could not generate ocean tracer restart file name!'
+          call xchalt('(restart_trcwt)')
+          stop '(restart_trcwt)'
+        endif
+      enddo
+      rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
+     .     '.rtrc.'//rstfnm_ocn(i+leninrstfn+1:)
+#ifdef HAMOCC
+      rstfnm_hamocc = rstfnm_ocn(1:i-1)//'.blom'//trim(inst_suffix)//
+     .     '.rbgc.'//rstfnm_ocn(i+leninrstfn+1:)
+#endif
+#else
+      i=1
+      do while (rstfnm_ocn(i:i+8) .ne. '_restphy_')
+        i=i+1
+        if (i+8 .gt. len(rstfnm_ocn)) then
+          if (mnproc.eq.1)
+     .      write (lp,*)
+     .        'Could not generate ocean tracer restart file name!'
+          call xchalt('(restart_trcwt)')
+          stop '(restart_trcwt)'
+        endif
+      enddo
+      rstfnm_ocntrc = rstfnm_ocn(1:i-1)//'_resttrc_'//rstfnm_ocn(i+9:)
+#ifdef HAMOCC
+      rstfnm_hamocc = rstfnm_ocn(1:i-1)//'_restbgc_'//rstfnm_ocn(i+9:)
+#endif
+#endif
+c
+c --- ------------------------------------------------------------------
+c --- Write restart files
+c --- ------------------------------------------------------------------
+c
+      call restart_ocntrcwt(rstfnm_ocntrc)
 c
 #ifdef HAMOCC
-      call restart_hamoccwt(rstfnm_ocn)
+      call restart_hamoccwt(rstfnm_hamocc)
 #endif
 c
       return

--- a/trc/restart_trcwt.F
+++ b/trc/restart_trcwt.F
@@ -82,9 +82,9 @@ c
          endif
       endif
 
-      call xcbcst(rstfn_ocntrc)
+      call xcbcst(rstfnm_ocntrc)
 #ifdef HAMOCC
-      call xcbcst(rstfn_hamocc)
+      call xcbcst(rstfnm_hamocc)
 #endif
 
 c


### PR DESCRIPTION
Suggestion for bugfix. This prevents call to `restart_trcwt` if `expcnf` is not `'cesm'`.

It would probably be better to make the tracer restart file generation more general, but this may require some restructuring of the restart writing procedure. At the moment there are dependencies between `restart_wt`, `restart_ocntrcwt` and `aufw_bgc` in terms of the restart filename.