### PR TITLE
Add pes layout for f19_tn14 resolution in cplhist mode

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -187,7 +187,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%0.9x1.25.+oi%tnx1v4">
+  <grid name="a%0.9x1.25.+oi%tnx1v4|a%1.9x2.5.+oi%tnx1v4">
     <mach name="any">
       <pes pesize="M" compset="_DATM%CPLHIST.*_BLOM">
         <comment>none</comment>


### PR DESCRIPTION
This fix makes the existing CPLHIST-compset work for the f19 resolution