### PR TITLE
Modified CIME interface to work with both CESM2.1 and CESM2.2 based NorESM versions

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+"""
+Set BLOM cppdefs
+"""
+import os, sys, filecmp, shutil
+
+_CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT is None:
+    raise SystemExit("ERROR: must set CIMEROOT environment variable")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+
+from CIME.case import Case
+from CIME.utils import run_cmd, expect
+from CIME.buildnml import parse_input
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def create_dimmod(case):
+###############################################################################
+    """
+    Create dimension Fortran module consistent with ocn tasks
+    """
+
+    # create $CASEROOT/Buildconf/blomconf if it does not exist
+    caseroot = case.get_value("CASEROOT")
+    blomconf_dir = os.path.join(caseroot, "Buildconf", "blomconf")
+    if not os.path.exists(blomconf_dir):
+        os.makedirs(blomconf_dir)
+
+    # create dimension module in $CASEROOT/Buildconf/blomconf
+
+    comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
+    ocn_grid = case.get_value("OCN_GRID")
+    ntasks_ocn = case.get_value("NTASKS_OCN")
+    objroot = case.get_value("OBJROOT")
+
+    gridconf_dir = os.path.join(comp_root_dir_ocn, "bld", ocn_grid)
+    kdm_file = os.path.join(gridconf_dir, "kdm")
+    blom_dimensions_script = os.path.join(comp_root_dir_ocn, "bld", "blom_dimensions")
+
+    try:
+        with open(kdm_file, "r") as kdm_file_obj:
+            kdm = kdm_file_obj.read().strip()
+    except:
+        expect(False, "Failed to read kdm from file {}".format(kdm_file))
+
+    cmd = "{} -n {} -k {} -d {}".format(blom_dimensions_script, ntasks_ocn, kdm, gridconf_dir)
+    rc, out, err = run_cmd(cmd, from_dir=blomconf_dir)
+    expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
+
+    # copy dimension module to $OBJROOT/ocn/src if identical dimension module does not already exist
+
+    dimmod_dir = os.path.join(objroot, "ocn", "src")
+    if not os.path.exists(dimmod_dir):
+        os.makedirs(dimmod_dir)
+
+    dimmod_new_file = os.path.join(blomconf_dir, "dimensions.F")
+    dimmod_file = os.path.join(dimmod_dir, "dimensions.F")
+    if not os.path.exists(dimmod_file) or not filecmp.cmp(dimmod_new_file, dimmod_file):
+        shutil.copy2(dimmod_new_file, dimmod_dir)
+
+
+###############################################################################
+def buildcpp(case):
+###############################################################################
+    """
+    Set build time options
+    """
+
+    # Create dimension Fortran module consistent with ocn tasks
+    create_dimmod(case)
+
+    # Determine the CPP flags values needed to build the blom component
+
+    ocn_grid = case.get_value("OCN_GRID")
+    turbclo = case.get_value("BLOM_TURBULENT_CLOSURE")
+    tracers = case.get_value("BLOM_TRACER_MODULES")
+    co2type = case.get_value("OCN_CO2_TYPE")
+    hamocc_cfc = case.get_value("HAMOCC_CFC")
+    hamocc_nattrc = case.get_value("HAMOCC_NATTRC")
+    hamocc_sedbypass = case.get_value("HAMOCC_SEDBYPASS")
+    hamocc_ciso = case.get_value("HAMOCC_CISO")
+
+    blom_cppdefs = ""
+
+    if ocn_grid in ["tnx2v1", "tnx1.5v1", "tnx1v1", "tnx1v3", "tnx1v4", "tnx0.25v1", "tnx0.25v3", "tnx0.25v4", "tnx0.125v4"]:
+        blom_cppdefs = blom_cppdefs + " -DARCTIC"
+
+    if ocn_grid in ["gx1v5", "gx1v6", "tnx2v1", "tnx1v1", "tnx1v3", "tnx1v4", "tnx0.25v1", "tnx0.25v3", "tnx0.25v4", "tnx0.125v4"]:
+        blom_cppdefs = blom_cppdefs + " -DLEVITUS2X"
+
+    if turbclo != 0 or tracers != 0:
+        blom_cppdefs = blom_cppdefs + " -DTRC"
+
+    if turbclo != 0:
+        twoeq = False
+        oneeq = False
+        for option in turbclo.split():
+            if option == "twoeq":
+                blom_cppdefs = blom_cppdefs + " -DTKE -DGLS"
+                twoeq = True
+            elif option == "oneeq":
+                blom_cppdefs = blom_cppdefs + " -DTKE"
+                oneeq = True
+            elif option == "advection":
+                blom_cppdefs = blom_cppdefs + " -DTKEADV"
+            elif option == "isodif":
+                blom_cppdefs = blom_cppdefs + " -DTKEIDF"
+            else:
+                expect(False, "Turbulent closure option {} is not recognized".format(option))
+        expect(twoeq or oneeq, "For turbulent closure either twoeq or oneeq must be provided as options")
+        expect(not twoeq or not oneeq, "Do not use both twoeq and oneeq as options for turbulent closure")
+
+    if tracers != 0:
+        for module in tracers.split():
+            if module == "iage":
+                blom_cppdefs = blom_cppdefs + " -DIDLAGE"
+            elif module == "ecosys":
+                blom_cppdefs = blom_cppdefs + " -DHAMOCC -DRESTART_BGC -DWLIN"
+                if hamocc_cfc:
+                    blom_cppdefs = blom_cppdefs + " -DCFC"
+                if hamocc_nattrc:
+                    blom_cppdefs = blom_cppdefs + " -DnatDIC"
+                if hamocc_sedbypass:
+                    blom_cppdefs = blom_cppdefs + " -Dsedbypass"
+                if hamocc_ciso:
+                    expect(hamocc_sedbypass, "HAMOCC C-isotopes currently not supported in the sediment module. Use HAMOCC_SEDBYPASS=TRUE")
+                    blom_cppdefs = blom_cppdefs + " -Dcisonew"
+                if co2type == "prognostic":
+                    blom_cppdefs = blom_cppdefs + " -DPROGCO2"
+                elif co2type == "diagnostic":
+                    blom_cppdefs = blom_cppdefs + " -DDIAGCO2"
+                elif co2type != "constant":
+                    expect(False, "CO2 type {} is not recognized".format(co2type))
+            else:
+                expect(False, "tracer module {} is not recognized".format(module))
+
+    blom_cppdefs = "-DMPI" + blom_cppdefs
+
+    # update the xml variable BLOM_CPPDEFS with the above definition
+    #case.set_value("BLOM_CPPDEFS", blom_cppdefs)
+
+    return blom_cppdefs
+
+###############################################################################
+
+def _main_func():
+
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot, read_only=False) as case:
+        blom_cppdefs = buildcpp(case)
+    logger.info("BLOM_CPPDEFS: %s", blom_cppdefs)
+
+if __name__ == "__main__":
+    _main_func()

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,140 +1,45 @@
-#! /bin/csh -f 
-cd $1
-set CONFIG_OCN_FILE = `./xmlquery CONFIG_OCN_FILE --value`
-set CASEROOT = `./xmlquery CASEROOT --value`
-set SRCROOT = `./xmlquery  SRCROOT --value`
-set EXEROOT = `./xmlquery  EXEROOT --value`
-set OBJROOT = `./xmlquery  OBJROOT --value`
-set OCN_GRID = `./xmlquery OCN_GRID --value`
-set CONFIG_OCN_DIR = `dirname $CONFIG_OCN_FILE`
-set NTASKS_OCN = `./xmlquery NTASKS_OCN --value`
-set DIN_LOC_ROOT = `./xmlquery DIN_LOC_ROOT --value`
-set RUN_TYPE = `./xmlquery RUN_TYPE --value`
-set CASEBUILD = `./xmlquery CASEBUILD --value`
-set CCSM_CO2_PPMV = `./xmlquery CCSM_CO2_PPMV --value`
-set OCN_NCPL = `./xmlquery OCN_NCPL --value`
-set BLOM_COUPLING = `./xmlquery BLOM_COUPLING --value`
-set RUNDIR = `./xmlquery  RUNDIR --value`
-set BLOM_TRACER_MODULES = `./xmlquery BLOM_TRACER_MODULES --value`
-set BLOM_TURBULENT_CLOSURE = `./xmlquery BLOM_TURBULENT_CLOSURE --value`
-set HAMOCC_CFC = `./xmlquery HAMOCC_CFC --value`
-set HAMOCC_NATTRC = `./xmlquery HAMOCC_NATTRC --value`
-set HAMOCC_SEDBYPASS = `./xmlquery HAMOCC_SEDBYPASS --value`
-set HAMOCC_CISO = `./xmlquery HAMOCC_CISO --value`
-set GMAKE = `./xmlquery GMAKE --value`
-set GMAKE_J = `./xmlquery  GMAKE_J --value`
-set OCN_CO2_TYPE = `./xmlquery OCN_CO2_TYPE --value`
-set RUN_STARTDATE = `./xmlquery RUN_STARTDATE --value`
+#!/usr/bin/env python
 
-cd $OBJROOT/ocn/obj
+"""
+build blom library
+"""
+import os, shutil, sys, glob, imp
 
-#------------------------------------------------------------------------------
-# Set list of file paths and resolve C preprocessor macros
-#------------------------------------------------------------------------------
+_CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT is None:
+    raise SystemExit("ERROR: must set CIMEROOT environment variable")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
-cat >! Filepath << EOF1
-$OBJROOT/ocn/obj/dimensions
-$CASEROOT/SourceMods/src.blom
-$SRCROOT/components/blom/ben02
-$SRCROOT/components/blom/cesm
-$SRCROOT/components/blom/fuk95
-$SRCROOT/components/blom/channel
-$SRCROOT/components/blom/single_column
-$SRCROOT/components/blom/drivers/cpl_share
-$SRCROOT/components/blom/drivers/cpl_mct
-$SRCROOT/components/blom/phy
-EOF1
+from standard_script_setup import *
 
-set turbclo = (`echo $BLOM_TURBULENT_CLOSURE`)
-set tracers = (`echo $BLOM_TRACER_MODULES`)
-set co2type = (`echo $OCN_CO2_TYPE`)
+from CIME.case import Case
+from CIME.utils import run_cmd, expect
+from CIME.buildlib import parse_input
 
-set cpp_ocn = "-DMPI"
-if ($OCN_GRID == tnx2v1 || $OCN_GRID == tnx1.5v1 || $OCN_GRID == tnx1v1 || $OCN_GRID == tnx1v3 || $OCN_GRID == tnx1v4 || $OCN_GRID == tnx0.25v1 || $OCN_GRID == tnx0.25v3 || $OCN_GRID == tnx0.25v4 || $OCN_GRID == tnx0.125v4) then
-  set cpp_ocn = "$cpp_ocn -DARCTIC"
-endif
-if ($OCN_GRID == gx1v5 || $OCN_GRID == gx1v6 || $OCN_GRID == tnx1v1 || $OCN_GRID == tnx1v3 || $OCN_GRID == tnx1v4  ||$OCN_GRID == tnx0.25v1 || $OCN_GRID == tnx0.25v3 || $OCN_GRID == tnx0.25v4 || $OCN_GRID == tnx0.125v4) then
-  set cpp_ocn = "$cpp_ocn -DLEVITUS2X"
-endif
-if ($#turbclo != 0 || $#tracers != 0) then
-  echo $SRCROOT/components/blom/trc >> Filepath
-  set cpp_ocn = "$cpp_ocn -DTRC"
-endif
-if ($#turbclo != 0) then
-  set twoeq = FALSE
-  set oneeq = FALSE
-  foreach option ($turbclo)
-    if      ($option == twoeq) then
-      set cpp_ocn = "$cpp_ocn -DTKE -DGLS"
-      set twoeq = TRUE
-    else if ($option == oneeq) then
-      set cpp_ocn = "$cpp_ocn -DTKE"
-      set oneeq = TRUE
-    else if ($option == advection) then
-      set cpp_ocn = "$cpp_ocn -DTKEADV"
-    else if ($option == isodif) then
-      set cpp_ocn = "$cpp_ocn -DTKEIDF"
-    else
-      echo $0": Turbulent closure option $option is not recognized!"
-      exit -1
-    endif
-  end
-  if ($twoeq == 'FALSE' && $oneeq == 'FALSE') then
-    echo $0": For turbulent closure either twoeq or oneeq must be provided as options!"
-    exit -1
-  endif
-  if ($twoeq == 'TRUE' && $oneeq == 'TRUE') then
-    echo $0": Do not use both twoeq and oneeq as options for turbulent closure!"
-    exit -1
-  endif
-endif
-if ($#tracers != 0) then
-  foreach module ($tracers)
-    if      ($module == iage) then
-      echo $SRCROOT/components/blom/idlage >> Filepath
-      set cpp_ocn = "$cpp_ocn -DIDLAGE"
-    else if ($module == ecosys) then
-      echo $SRCROOT/components/blom/hamocc >> Filepath
-      set cpp_ocn = "$cpp_ocn -DHAMOCC -DRESTART_BGC -DWLIN"
-      if ($HAMOCC_CFC == TRUE) then
-        set cpp_ocn = "$cpp_ocn -DCFC"
-      endif       
-      if ($HAMOCC_NATTRC == TRUE) then
-        set cpp_ocn = "$cpp_ocn -DnatDIC"
-      endif       
-      if ($HAMOCC_SEDBYPASS == TRUE) then
-        set cpp_ocn = "$cpp_ocn -Dsedbypass"
-      endif       
-      if ($HAMOCC_CISO == TRUE) then
-        if($HAMOCC_SEDBYPASS == FALSE) then
-          echo $0": HAMOCC C-isotopes currently not supported in the sediment module. Use HAMOCC_SEDBYPASS=TRUE."
-          exit -1
-        endif
-        set cpp_ocn = "$cpp_ocn -Dcisonew"
-      endif       
-      if ($co2type == prognostic) then
-        set cpp_ocn = "$cpp_ocn -DPROGCO2"
-      else if ($co2type == diagnostic) then
-        set cpp_ocn = "$cpp_ocn -DDIAGCO2"
-      else if ($co2type != constant) then
-        echo $0": CO2 type $co2type is not recognized!"
-        exit -1
-      endif
-    else
-      echo $0": tracer module $module is not recognized!"
-      exit -1
-    endif
-  end
-endif
+logger = logging.getLogger(__name__)
 
-#------------------------------------------------------------------------------
-# Build the library
-#------------------------------------------------------------------------------
+###############################################################################
+def _main_func():
+###############################################################################
 
-gmake complib -j $GMAKE_J MODEL=blom COMPLIB=$LIBROOT/libocn.a MACFILE=$CASEROOT/Macros.$MACH USER_CPPDEFS="$cpp_ocn" -f $CASETOOLS/Makefile || exit 2
+    caseroot, libroot, bldroot = parse_input(sys.argv)
 
-if !(-f $LIBROOT/libocn.a) then
-  echo "ERROR: blom library not available"
-  exit -1
-endif
+    # run buildlib variant based on detection of cesm/cime version
 
+    comp_root_dir_ocn = Case(caseroot).get_value("COMP_ROOT_DIR_OCN")
+
+    if os.path.exists(os.path.join(caseroot,"env_workflow.xml")):
+        cmd = "{} {} {} {}".format(os.path.join(comp_root_dir_ocn, "cime_config", "buildlib_2.2"), caseroot, libroot, bldroot)
+        rc, out, err = run_cmd(cmd)
+        expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
+        print(out)
+    else:
+        cmd = "{} {} {} {}".format(os.path.join(comp_root_dir_ocn, "cime_config", "buildlib_2.1"), caseroot, libroot, bldroot)
+        rc, out, err = run_cmd(cmd)
+        expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
+        print(out)
+
+###############################################################################
+
+if __name__ == "__main__":
+    _main_func()

--- a/cime_config/buildlib_2.1
+++ b/cime_config/buildlib_2.1
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+"""
+build blom library
+"""
+import os, shutil, sys, glob, imp
+
+_CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT is None:
+    raise SystemExit("ERROR: must set CIMEROOT environment variable")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+
+from CIME.case import Case
+from CIME.utils import run_cmd, expect
+from CIME.buildlib import parse_input
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def _main_func():
+###############################################################################
+
+    caseroot, libroot, bldroot = parse_input(sys.argv)
+
+    with Case(caseroot, read_only=False) as case:
+
+        comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
+
+        # call buildcpp to set the cppdefs
+        cmd = os.path.join(os.path.join(comp_root_dir_ocn, "cime_config", "buildcpp"))
+        logger.info("     ...calling blom buildcpp to set build time options")
+        try:
+            mod = imp.load_source("buildcpp", cmd)
+            blom_cppdefs = mod.buildcpp(case)
+        except:
+            raise
+
+    with Case(caseroot) as case:
+
+        casetools = case.get_value("CASETOOLS")
+        complib = os.path.join(libroot, "libocn.a")
+        gmake_j = case.get_value("GMAKE_J")
+        gmake = case.get_value("GMAKE")
+        makefile = os.path.join(casetools, "Makefile")
+
+        # create Filepath file
+
+        filepath_file = os.path.join(bldroot, "Filepath")
+
+        if not os.path.isfile(filepath_file):
+
+            objroot = case.get_value("OBJROOT")
+            comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
+            turbclo = case.get_value("BLOM_TURBULENT_CLOSURE")
+            tracers = case.get_value("BLOM_TRACER_MODULES")
+            driver = case.get_value("COMP_INTERFACE")
+
+            paths = [os.path.join(caseroot, "SourceMods", "src.blom"),
+                     os.path.join(objroot, "ocn", "src"),
+                     os.path.join(comp_root_dir_ocn, "ben02"),
+                     os.path.join(comp_root_dir_ocn, "cesm"),
+                     os.path.join(comp_root_dir_ocn, "fuk95"),
+                     os.path.join(comp_root_dir_ocn, "channel"),
+                     os.path.join(comp_root_dir_ocn, "single_column"),
+                     os.path.join(comp_root_dir_ocn, "phy")]
+
+            if turbclo != 0 and tracers != 0:
+                paths.append(os.path.join(comp_root_dir_ocn, "trc"))
+
+            if tracers != 0:
+                for module in tracers.split():
+                    if module == "iage":
+                        paths.append(os.path.join(comp_root_dir_ocn, "idlage"))
+                    elif module == "ecosys":
+                        paths.append(os.path.join(comp_root_dir_ocn, "hamocc"))
+                    else:
+                        expect(False, "tracer module {} is not recognized".format(module))
+
+            if driver == "nuopc":
+                expect(False, "NUOPC driver not supported")
+            if driver == "mct":
+                paths.append(os.path.join(comp_root_dir_ocn, "drivers", "cpl_share"))
+                paths.append(os.path.join(comp_root_dir_ocn, "drivers", "cpl_mct"))
+
+            with open(filepath_file, "w") as filepath:
+                filepath.write("\n".join(paths))
+                filepath.write("\n")
+
+        # build the library
+
+        cmd = "{} complib -j {} MODEL=blom COMPLIB={} -f {} USER_CPPDEFS=\"{}\"" \
+            .format(gmake, gmake_j, complib, makefile, blom_cppdefs)
+
+        rc, out, err = run_cmd(cmd, from_dir=bldroot)
+        expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
+
+        logger.info("Command %s completed with output %s\nerr %s", cmd, out, err)
+
+###############################################################################
+
+if __name__ == "__main__":
+    _main_func()

--- a/cime_config/buildlib_2.2
+++ b/cime_config/buildlib_2.2
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+"""
+build blom library
+"""
+import os, shutil, sys, glob, imp
+
+_CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT is None:
+    raise SystemExit("ERROR: must set CIMEROOT environment variable")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+
+from CIME.case import Case
+from CIME.utils import run_cmd, expect
+from CIME.buildlib import parse_input
+from CIME.build import get_standard_makefile_args
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def _main_func():
+###############################################################################
+
+    caseroot, libroot, bldroot = parse_input(sys.argv)
+
+    with Case(caseroot, read_only=False) as case:
+
+        comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
+
+        # call buildcpp to set the cppdefs
+        cmd = os.path.join(os.path.join(comp_root_dir_ocn, "cime_config", "buildcpp"))
+        logger.info("     ...calling blom buildcpp to set build time options")
+        try:
+            mod = imp.load_source("buildcpp", cmd)
+            blom_cppdefs = mod.buildcpp(case)
+        except:
+            raise
+
+    with Case(caseroot) as case:
+
+        casetools = case.get_value("CASETOOLS")
+        complib = os.path.join(libroot, "libocn.a")
+        gmake_j = case.get_value("GMAKE_J")
+        gmake = case.get_value("GMAKE")
+        makefile = os.path.join(casetools, "Makefile")
+
+        # create Filepath file
+
+        filepath_file = os.path.join(bldroot, "Filepath")
+
+        if not os.path.isfile(filepath_file):
+
+            objroot = case.get_value("OBJROOT")
+            comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
+            turbclo = case.get_value("BLOM_TURBULENT_CLOSURE")
+            tracers = case.get_value("BLOM_TRACER_MODULES")
+            driver = case.get_value("COMP_INTERFACE")
+
+            paths = [os.path.join(caseroot, "SourceMods", "src.blom"),
+                     os.path.join(objroot, "ocn", "src"),
+                     os.path.join(comp_root_dir_ocn, "ben02"),
+                     os.path.join(comp_root_dir_ocn, "cesm"),
+                     os.path.join(comp_root_dir_ocn, "fuk95"),
+                     os.path.join(comp_root_dir_ocn, "channel"),
+                     os.path.join(comp_root_dir_ocn, "single_column"),
+                     os.path.join(comp_root_dir_ocn, "phy")]
+
+            if turbclo != 0 and tracers != 0:
+                paths.append(os.path.join(comp_root_dir_ocn, "trc"))
+
+            if tracers != 0:
+                for module in tracers.split():
+                    if module == "iage":
+                        paths.append(os.path.join(comp_root_dir_ocn, "idlage"))
+                    elif module == "ecosys":
+                        paths.append(os.path.join(comp_root_dir_ocn, "hamocc"))
+                    else:
+                        expect(False, "tracer module {} is not recognized".format(module))
+
+            if driver == "nuopc":
+                expect(False, "NUOPC driver not supported")
+            if driver == "mct":
+                paths.append(os.path.join(comp_root_dir_ocn, "drivers", "cpl_share"))
+                paths.append(os.path.join(comp_root_dir_ocn, "drivers", "cpl_mct"))
+
+            with open(filepath_file, "w") as filepath:
+                filepath.write("\n".join(paths))
+                filepath.write("\n")
+
+        # build the library
+
+        cmd = "{} complib -j {} MODEL=blom COMPLIB={} -f {} USER_CPPDEFS=\"{}\" {} " \
+            .format(gmake, gmake_j, complib, makefile, blom_cppdefs, get_standard_makefile_args(case))
+
+        rc, out, err = run_cmd(cmd, from_dir=bldroot)
+        expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
+
+        logger.info("Command %s completed with output %s\nerr %s", cmd, out, err)
+
+###############################################################################
+
+if __name__ == "__main__":
+    _main_func()

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -4,12 +4,8 @@
 # Get variables from Case XML-files
 #------------------------------------------------------------------------------
 
-set CONFIG_OCN_FILE = `./xmlquery CONFIG_OCN_FILE --value`
 set CASEROOT = `./xmlquery CASEROOT --value`
-set EXEROOT = `./xmlquery EXEROOT --value`
 set OCN_GRID = `./xmlquery OCN_GRID --value`
-set CONFIG_OCN_DIR1 = `dirname $CONFIG_OCN_FILE`
-set NTASKS_OCN = `./xmlquery NTASKS_OCN --value` 
 set DIN_LOC_ROOT = `./xmlquery  DIN_LOC_ROOT --value`
 set RUN_TYPE = `./xmlquery RUN_TYPE --value`
 set CONTINUE_RUN = `./xmlquery CONTINUE_RUN --value`
@@ -27,8 +23,6 @@ set RUN_STARTDATE = `./xmlquery RUN_STARTDATE --value`
 set PIO_TYPENAME_OCN = `./xmlquery PIO_TYPENAME_OCN --value`
 set PIO_NETCDF_FORMAT_OCN = `./xmlquery PIO_NETCDF_FORMAT_OCN --value`
 set NINST_OCN = `./xmlquery NINST_OCN --value`
-cd $EXEROOT/ocn/obj
-set CONFIG_OCN_DIR = $CONFIG_OCN_DIR1/../
 
 #------------------------------------------------------------------------------
 # Check if HAMOCC is requested
@@ -42,22 +36,6 @@ if ($#tracers != 0) then
       set ecosys = TRUE
     endif
   end
-endif
-
-#------------------------------------------------------------------------------
-# Make dimensions.F
-#------------------------------------------------------------------------------
-
-set dimdir = $EXEROOT/ocn/obj/dimensions
-mkdir -p $dimdir
-set kdm = `cat $CONFIG_OCN_DIR/bld/$OCN_GRID/kdm`
-$CONFIG_OCN_DIR/bld/blom_dimensions -n $NTASKS_OCN -k $kdm -d $CONFIG_OCN_DIR/bld/$OCN_GRID || exit -1
-set recompile = FALSE
-cmp -s dimensions.F $dimdir/dimensions.F || set recompile = TRUE
-if ($recompile == 'TRUE') then
-  mv dimensions.F $dimdir
-else
-  rm dimensions.F
 endif
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Based on suggestion from @monsieuralok, BLOM's CIME interface has been modified to work with both CESM2.1 and CESM2.2 based NorESM versions. Due to different CIME structure and functionality, "buildlib" will call different "buildlib" variants based on detection of CESM/CIME version. These variants are fully working "buildlib's", that can replace "buildlib" when supporting different CESM/CIME versions is not relevant anymore. The script "buildnml" has been simplified by moving the generation of the ocn task dependent dimension Fortran module to "buildcpp", which is called by "buildlib".

Testing done:
- Gives bit-identical results for N1850 compset and f09_tn14 grids using NorESM tag release-noresm2.0.5.
- Correct build and execution for N1850 compset and f09_tn14 grids using NorESM branch noresm2.2.