### PR TITLE
Added functionality to run BLOM with hybrid vertical coordinate in NorESM

### DIFF
--- a/Externals_BLOM.cfg
+++ b/Externals_BLOM.cfg
@@ -1,0 +1,9 @@
+[CVMix]
+tag = master
+protocol = git
+repo_url = https://github.com/CVMix/CVMix-src
+local_path = pkgs/CVMix-src
+required = True
+
+[externals_description]
+schema_version = 1.0.0

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -42,6 +42,7 @@ $SRCROOT/components/blom/channel
 $SRCROOT/components/blom/single_column
 $SRCROOT/components/blom/drivers/cpl_share
 $SRCROOT/components/blom/drivers/cpl_mct
+$SRCROOT/components/blom/pkgs/CVMix-src/src/shared
 $SRCROOT/components/blom/phy
 EOF1
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -167,6 +167,21 @@ else
   set IOTYPE =  0 
 endif
 
+set VCOORD_TYPE            = "'isopyc_bulkml'"
+set RECONSTRUCTION_METHOD  = "'ppm'"
+set DENSITY_LIMITING       = "'monotonic'"
+set TRACER_LIMITING        = "'monotonic'"
+set VELOCITY_LIMITING      = "'monotonic'"
+set DENSITY_PC_UPPER_BNDR  = .false.
+set DENSITY_PC_LOWER_BNDR  = .false.
+set TRACER_PC_UPPER_BNDR   = .true.
+set TRACER_PC_LOWER_BNDR   = .false.
+set VELOCITY_PC_UPPER_BNDR = .true.
+set VELOCITY_PC_LOWER_BNDR = .false.
+set DPMIN_SURFACE          = 2.5
+set DPMIN_INFLATION_FACTOR = 1.05
+set DPMIN_INTERIOR         = .1
+
 # set BGCNML defaults
 set ATM_CO2  = $CCSM_CO2_PPMV
 if ($BLOM_RIVER_NUTRIENTS == TRUE) then
@@ -234,8 +249,6 @@ set H2D_IDKEDT   =  '0,   4,   0'
 set H2D_LIP      =  '0,   4,   0'
 set H2D_MAXMLD   =  '4,   4,   0'
 set H2D_MLD      =  '0,   4,   0'
-set H2D_MLDU     =  '0,   0,   0'
-set H2D_MLDV     =  '0,   0,   0'
 set H2D_MLTS     =  '4,   4,   0'
 set H2D_MLTSMN   =  '0,   4,   0'
 set H2D_MLTSMX   =  '0,   4,   0'
@@ -247,8 +260,6 @@ set H2D_MTKERS   =  '0,   4,   0'
 set H2D_MTKEPE   =  '0,   4,   0'
 set H2D_MTKEKE   =  '0,   4,   0'
 set H2D_MTY      =  '0,   4,   0'
-set H2D_MXLU     =  '0,   4,   0'
-set H2D_MXLV     =  '0,   4,   0'
 set H2D_NSF      =  '0,   4,   0'
 set H2D_PBOT     =  '0,   4,   0'
 set H2D_PSRF     =  '0,   4,   0'
@@ -284,6 +295,9 @@ set H2D_VICE     =  '0,   0,   0'
 set H2D_ZTX      =  '0,   4,   0'
 set LYR_BFSQ     =  '0,   4,   0'
 set LYR_DIFDIA   =  '0,   4,   0'
+set LYR_DIFVMO   =  '0,   4,   0'
+set LYR_DIFVHO   =  '0,   4,   0'
+set LYR_DIFVSO   =  '0,   4,   0'
 set LYR_DIFINT   =  '0,   4,   0'
 set LYR_DIFISO   =  '0,   4,   0'
 set LYR_DP       =  '0,   4,   0'
@@ -317,6 +331,9 @@ set LYR_GLS_PSI  =  '0,   4,   0'
 set LYR_IDLAGE   =  '0,   4,   0'
 set LVL_BFSQ     =  '0,   4,   0'
 set LVL_DIFDIA   =  '0,   4,   0'
+set LVL_DIFVMO   =  '0,   4,   0'
+set LVL_DIFVHO   =  '0,   4,   0'
+set LVL_DIFVSO   =  '0,   4,   0'
 set LVL_DIFINT   =  '0,   4,   0'
 set LVL_DIFISO   =  '0,   4,   0'
 set LVL_DZ       =  '0,   4,   0'
@@ -947,6 +964,23 @@ cat >! $RUNDIR/ocn_in$inststr << EOF
   RSTCMP   = $RSTCMP
   IOTYPE   = $IOTYPE
 /
+
+&VCOORD
+  VCOORD_TYPE            = $VCOORD_TYPE
+  RECONSTRUCTION_METHOD  = $RECONSTRUCTION_METHOD
+  DENSITY_LIMITING       = $DENSITY_LIMITING
+  TRACER_LIMITING        = $TRACER_LIMITING
+  VELOCITY_LIMITING      = $VELOCITY_LIMITING
+  DENSITY_PC_UPPER_BNDR  = $DENSITY_PC_UPPER_BNDR
+  DENSITY_PC_LOWER_BNDR  = $DENSITY_PC_LOWER_BNDR
+  TRACER_PC_UPPER_BNDR   = $TRACER_PC_UPPER_BNDR
+  TRACER_PC_LOWER_BNDR   = $TRACER_PC_LOWER_BNDR
+  VELOCITY_PC_UPPER_BNDR = $VELOCITY_PC_UPPER_BNDR
+  VELOCITY_PC_LOWER_BNDR = $VELOCITY_PC_LOWER_BNDR
+  DPMIN_SURFACE          = $DPMIN_SURFACE
+  DPMIN_INFLATION_FACTOR = $DPMIN_INFLATION_FACTOR
+  DPMIN_INTERIOR         = $DPMIN_INTERIOR
+/
 EOF
 
 if ($?CWMTAG) then
@@ -1075,8 +1109,6 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   LIP      - liquid precipitation [kg m-2 s-1]
 !   MAXMLD   - maximum mixed layer depth [m]
 !   MLD      - mixed layer depth [m]
-!   MLDU     - mixed layer depth at u-point [m]
-!   MLDV     - mixed layer depth at v-point [m]
 !   MLTS     - mixed layer thickness using "sigma-t" criterion [m]
 !   MLTSMN   - minimum mixed layer thickness using "sigma-t" criterion [m]
 !   MLTSMX   - maximum mixed layer thickness using "sigma-t" criterion [m]
@@ -1088,8 +1120,6 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   MTKEPE   - mixed layer TKE tendency related to pot. energy change [kg s-3]
 !   MTKEKE   - mixed layer TKE tendency related to kin. energy change [kg s-3]
 !   MTY      - wind stress y-component [N m-2]
-!   MXLU     - mixed layer velocity x-component [m s-1]
-!   MXLV     - mixed layer velocity y-component [m s-1]
 !   NSF      - non-solar heat flux [W m-2]
 !   PBOT     - bottom pressure [Pa]
 !   PSRF     - surface pressure [Pa]
@@ -1124,7 +1154,10 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   VICE     - ice velocity y-component [m s-1]
 !   ZTX      - wind stress x-component [N m-2]
 !   BFSQ     - buoyancy frequency squared [s-1]
-!   DIFDIA   - diapycnal diffusivity [log10(m2 s-1)]
+!   DIFDIA   - vertical diffusivity [log10(m2 s-1)|m2 s-1]
+!   DIFVMO   - vertical momentum diffusivity [log10(m2 s-1)|m2 s-1]
+!   DIFVHO   - vertical heat diffusivity [log10(m2 s-1)|m2 s-1]
+!   DIFVSO   - vertical salt diffusivity [log10(m2 s-1)|m2 s-1]
 !   DIFINT   - layer interface diffusivity [log10(m2 s-1)]
 !   DIFISO   - isopycnal diffusivity [log10(m2 s-1)]
 !   DP       - layer pressure thickness [Pa]
@@ -1197,8 +1230,6 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   H2D_LIP      = $H2D_LIP
   H2D_MAXMLD   = $H2D_MAXMLD
   H2D_MLD      = $H2D_MLD
-  H2D_MLDU     = $H2D_MLDU
-  H2D_MLDV     = $H2D_MLDV
   H2D_MLTS     = $H2D_MLTS
   H2D_MLTSMN   = $H2D_MLTSMN
   H2D_MLTSMX   = $H2D_MLTSMX
@@ -1210,8 +1241,6 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   H2D_MTKEPE   = $H2D_MTKEPE
   H2D_MTKEKE   = $H2D_MTKEKE
   H2D_MTY      = $H2D_MTY
-  H2D_MXLU     = $H2D_MXLU
-  H2D_MXLV     = $H2D_MXLV
   H2D_NSF      = $H2D_NSF
   H2D_PBOT     = $H2D_PBOT
   H2D_PSRF     = $H2D_PSRF
@@ -1247,6 +1276,9 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   H2D_ZTX      = $H2D_ZTX
   LYR_BFSQ     = $LYR_BFSQ
   LYR_DIFDIA   = $LYR_DIFDIA
+  LYR_DIFVMO   = $LYR_DIFVMO
+  LYR_DIFVHO   = $LYR_DIFVHO
+  LYR_DIFVSO   = $LYR_DIFVSO
   LYR_DIFINT   = $LYR_DIFINT
   LYR_DIFISO   = $LYR_DIFISO
   LYR_DP       = $LYR_DP
@@ -1280,6 +1312,9 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   LYR_IDLAGE   = $LYR_IDLAGE
   LVL_BFSQ     = $LVL_BFSQ
   LVL_DIFDIA   = $LVL_DIFDIA
+  LVL_DIFVMO   = $LVL_DIFVMO
+  LVL_DIFVHO   = $LVL_DIFVHO
+  LVL_DIFVSO   = $LVL_DIFVSO
   LVL_DIFINT   = $LVL_DIFINT
   LVL_DIFISO   = $LVL_DIFISO
   LVL_DZ       = $LVL_DZ


### PR DESCRIPTION
Name list variables for VCOORD group and functionality to checkout and build CVMix are added. CVMix is checked out using CESM's "checkout_externals" script.

To run with hybrid coordinate, "kdm" must be modified and suitable VCOORD name list variables must be set in "user_nl_blom". At a minimum VCOORD_TYPE = 'cntiso_hybrid' is required.