### PR TITLE
bugfix: removed additional dimension in dust input field in hammoc4bcm

### DIFF
--- a/hamocc/hamocc4bcm.F90
+++ b/hamocc/hamocc4bcm.F90
@@ -106,7 +106,7 @@
       REAL,    intent(in)  :: prho   (kpie,kpje,kpke)
       REAL,    intent(in)  :: pglat  (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)
       REAL,    intent(in)  :: omask  (kpie,kpje)
-      REAL,    intent(in)  :: dust   (kpie,kpje,nriv)
+      REAL,    intent(in)  :: dust   (kpie,kpje)
       REAL,    intent(in)  :: rivin  (kpie,kpje,nriv)
       REAL,    intent(in)  :: ndep   (kpie,kpje)
       REAL,    intent(in)  :: pfswr  (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)


### PR DESCRIPTION
This bugfix produces bit identical results on noresm 2.0.5 on Betzy with intel
compiler.