### PR TITLE
Remove reference to unused cpp flag RESTART_BGC.

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -121,7 +121,7 @@ def buildcpp(case):
             if module == "iage":
                 blom_cppdefs = blom_cppdefs + " -DIDLAGE"
             elif module == "ecosys":
-                blom_cppdefs = blom_cppdefs + " -DHAMOCC -DRESTART_BGC -DWLIN"
+                blom_cppdefs = blom_cppdefs + " -DHAMOCC -DWLIN"
                 if hamocc_cfc:
                     blom_cppdefs = blom_cppdefs + " -DCFC"
                 if hamocc_nattrc:

--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,7 @@ if get_option('iage')
 endif
 
 if get_option('ecosys')
-  add_project_arguments('-DHAMOCC','-DRESTART_BGC', '-DWLIN', language: 'fortran')
+  add_project_arguments('-DHAMOCC', '-DWLIN', language: 'fortran')
   if get_option('hamocc_agg')
     add_project_arguments('-DAGG', language: 'fortran')
   endif


### PR DESCRIPTION
The CPP flag RESTART_BGC is referenced but not used anywhere in BLOM/iHAMOCC. I see that this flag is used in CICE, so perhaps it is a remnant from an earlier micom/blom version with integrated CICE? I suggest to remove the remaining references to this CPP flag.