### PR TITLE
Fix timestep inventory

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -81,6 +81,7 @@ def buildcpp(case):
     tracers = case.get_value("BLOM_TRACER_MODULES")
     co2type = case.get_value("OCN_CO2_TYPE")
     hamocc_cfc = case.get_value("HAMOCC_CFC")
+    hamocc_debug = case.get_value("HAMOCC_DEBUG")
     hamocc_nattrc = case.get_value("HAMOCC_NATTRC")
     hamocc_sedbypass = case.get_value("HAMOCC_SEDBYPASS")
     hamocc_ciso = case.get_value("HAMOCC_CISO")
@@ -124,6 +125,8 @@ def buildcpp(case):
                 blom_cppdefs = blom_cppdefs + " -DHAMOCC -DWLIN"
                 if hamocc_cfc:
                     blom_cppdefs = blom_cppdefs + " -DCFC"
+                if hamocc_debug:
+                    blom_cppdefs = blom_cppdefs + " -DPBGC_OCNP_TIMESTEP -DPBGC_CK_TIMESTEP"
                 if hamocc_nattrc:
                     blom_cppdefs = blom_cppdefs + " -DnatDIC"
                 if hamocc_sedbypass:

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -188,6 +188,15 @@
       Requires module ecosys</desc>
   </entry>
 
+  <entry id="HAMOCC_DEBUG">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_component_blom</group>
+    <file>env_build.xml</file>
+    <desc>Set preprocessor option to activate the debugging mode for iHAMOCC. Requires module ecosys</desc>
+  </entry>
+
   <entry id="HAMOCC_VSLS">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/hamocc/inventory_bgc.F90
+++ b/hamocc/inventory_bgc.F90
@@ -355,6 +355,7 @@ SUBROUTINE INVENTORY_BGC(kpie,kpje,kpke,dlxp,dlyp,ddpo,omask,iogrp)
        & +zocetratot(izoo))*rcar+zocetratot(isco212)+zocetratot(icalc)         &
        & +zpowtratot(ipowaic)+zsedlayto(isssc12)+zsedlayto(issso12)*rcar       &
        & +zburial(isssc12)+zburial(issso12)*rcar                               &
+       & +zprorca*rcar+zprcaca                                                 &
 #if defined(BOXATM)
        & +zatmco2*ppm2con
 #else
@@ -368,6 +369,7 @@ SUBROUTINE INVENTORY_BGC(kpie,kpje,kpke,dlxp,dlyp,ddpo,omask,iogrp)
        &  +zsedlayto(issso12)*rnit+zburial(issso12)*rnit                       &
        &  +zocetratot(ian2o)*2                                                 &
        &  - sndepflux                                                          &
+       &  +zprorca*rnit                                                        &
 #if defined(BOXATM)
        &  +zatmn2*ppm2con*2
 #else
@@ -379,11 +381,13 @@ SUBROUTINE INVENTORY_BGC(kpie,kpje,kpke,dlxp,dlyp,ddpo,omask,iogrp)
        &   zocetratot(idet)+zocetratot(idoc)+zocetratot(iphy)                  &
        &  +zocetratot(izoo)+zocetratot(iphosph)                                &
        &  +zpowtratot(ipowaph)+zsedlayto(issso12)                              &
-       &  +zburial(issso12)
+       &  +zburial(issso12)                                                    &
+       &  +zprorca
 
   totalsil=                                                                    &
        &   zocetratot(isilica)+zocetratot(iopal)                               &
-       &  +zpowtratot(ipowasi)+zsedlayto(issssil)+zburial(issssil)
+       &  +zpowtratot(ipowasi)+zsedlayto(issssil)+zburial(issssil)             &
+       &  +zsilpro
 
   totaloxy=                                                                    &
        &  (zocetratot(idet)+zocetratot(idoc)+zocetratot(iphy)                  &
@@ -395,6 +399,7 @@ SUBROUTINE INVENTORY_BGC(kpie,kpje,kpke,dlxp,dlyp,ddpo,omask,iogrp)
        &  +zpowtratot(ipowno3)*1.5+zpowtratot(ipowaic)                         &
        &  +zpowtratot(ipowaox)+zpowtratot(ipowaph)*2                           &
        &  - sndepflux*1.5                                                      &
+       &  +zprorca*(-24.)+zprcaca                                              &
 #if defined(BOXATM)
        &  +zatmo2*ppm2con+zatmco2*ppm2con
 #else


### PR DESCRIPTION
This small fix provides the preprocessor flag `HAMOCC_DEBUG` via `xmlchange` that enables to debug iHAMOCC processes on a time step basis, i.e. the mass conservation of the inventory after individual processes. In addition, the time step based inventory calculation now accounts for particulate fluxes to the sediments.  