### PR TITLE
Ensure checkout of CVMix tag v0.98-beta

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "pkgs/CVMix-src"]
+[submodule "CVMix-src"]
 	path = pkgs/CVMix-src
-	url = https://github.com/CVMix/CVMix-src.git
+	url = git@github.com:CVMix/CVMix-src.git

--- a/Externals_BLOM.cfg
+++ b/Externals_BLOM.cfg
@@ -1,5 +1,5 @@
 [CVMix]
-tag = master
+tag = v0.98-beta
 protocol = git
 repo_url = https://github.com/CVMix/CVMix-src
 local_path = pkgs/CVMix-src


### PR DESCRIPTION
Ensure checkout of CVMix tag v0.98-beta for both git submodule and CESM checkout_externals functionality. Also the CVMix URL in .gitmodules has been changed from https to ssh. The code has been checked with BLOM_VCOORD = cntiso_hybrid and it reproduces compset N1850frc2 at resolution f09_tn14 on machine Betzy. 