### PR TITLE
Bugfix kOBL

### DIFF
--- a/phy/mod_difest.F
+++ b/phy/mod_difest.F
@@ -1205,10 +1205,6 @@ c --- ------ make sure it is in metrics if stability depends on rho
      .              kk,                                ! (in) Number of levels in array shape
      .              CVMix_kpp_params_user=KPP_params ) ! KPP parameters
 
-             ! gets index of the level and interface above hbl
-             kOBL = CVMix_kpp_compute_kOBL_depth(iFaceHeight,
-     .                               cellHeight,OBLdepth(i,j))
-
 c ---- ccc -------
              ! convert m2/s to cm2/s
              Kv_kpp = Kv_kpp*1e4

--- a/phy/mod_difest.F
+++ b/phy/mod_difest.F
@@ -1161,8 +1161,8 @@ c --- ------ centers.
      .                               cellHeight,OBLdepth(i,j))
 
              ! gets index of the level and interface above hbl
-             kOBL = CVMix_kpp_compute_kOBL_depth(iFaceHeight,
-     .                               cellHeight,OBLdepth(i,j))
+             kOBL = int(hOBL(i,j))    ! index of interface above OBL depth
+
 c --- ------ Diapycnal mixing when local stability is weak
 c --- ------ convection routine based on N2 not rho
 c --- ------ make sure it is in metrics if stability depends on rho


### PR DESCRIPTION
@milicak @matsbn 
Hi,
the assignment of kOBL looks strange to me (see #179). The code change suggested here is according to code description in CVMix, assuming that kOBL should represent the index of the cell center above the OBL depth (this is what we want to use in iHAMOCC). If this was not your intention, we should perhaps define a new index variable according to `kt` below, that can be imported in iHAMOCC.

> DESCRIPTION:
> Computes the index of the level and interface above OBL\_depth. The index is
> stored as a real number, and the integer index can be solved for in the
> following way:\\
>   \verb|kt| = index of cell center above OBL\_depth = \verb|nint(kOBL_depth)-1|
>   \verb|kw| = index of interface above OBL\_depth = \verb|floor(kOBL_depth)|


