### PR TITLE
Add framwork for applying ocean alkalinization scenarios

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -207,11 +207,11 @@ if ($BLOM_N_DEPOSITION == TRUE) then
     set NDEPFNAME = ndep_201501-210012-${BLOM_NDEP_SCENARIO}_tnx1v4_20191112.nc
   else if( $BLOM_NDEP_SCENARIO == UNSET ) then
     set DO_NDEP   = .false.
-    set NDEPFNAME = ""
+    set NDEPFNAME = "''"
   endif
 else
   set DO_NDEP   = .false.
-  set NDEPFNAME = ""
+  set NDEPFNAME = "''"
 endif
 if ($HAMOCC_SEDSPINUP == TRUE) then
   set DO_SEDSPINUP = .true.
@@ -230,8 +230,13 @@ if ($HAMOCC_VSLS == TRUE && $OCN_GRID != tnx1v4) then
   echo "$0 ERROR: HAMOCC_VSLS == TRUE not possible with this grid resolution (no swa-climatology available) "
   exit -1
 endif
+# For the following options, there are currently no switches in Case-XML files.
+# These options can be activated by expert users via user namelist.
+set DO_OALK = .false.
+set OALKSCEN = "''"
+set OALKFILE = "''"
 set WITH_DMSPH = .false.
-set PI_PH_FILE = ""
+set PI_PH_FILE = "''"
 
 # set DIAPHY defaults 
 set GLB_FNAMETAG = "'hd','hm','hy'"  
@@ -1448,6 +1453,9 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   RIVINFILE    = $RIVINFILE 
   DO_NDEP      = $DO_NDEP
   NDEPFILE     = $NDEPFILE
+  DO_OALK      = $DO_OALK
+  OALKSCEN     = $OALKSCEN
+  OALKFILE     = $OALKFILE
   DO_SEDSPINUP = $DO_SEDSPINUP
   SEDSPIN_YR_S = $SEDSPIN_YR_S
   SEDSPIN_YR_E = $SEDSPIN_YR_E
@@ -1853,6 +1861,11 @@ EOF
   if ($BLOM_N_DEPOSITION == TRUE) then
 cat >> $CASEBUILD/blom.input_data_list << EOF
 n_deposition_file = `echo $NDEPFILE | tr -d '"' | tr -d "'"`
+EOF
+  endif
+  if ($OALKFILE != "''") then
+cat >> $CASEBUILD/blom.input_data_list << EOF
+oafx_file = `echo $OAFILE | tr -d '"' | tr -d "'"`
 EOF
   endif
   if ($HAMOCC_VSLS == TRUE) then

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1865,7 +1865,7 @@ EOF
   endif
   if ($OALKFILE != "''") then
 cat >> $CASEBUILD/blom.input_data_list << EOF
-oafx_file = `echo $OAFILE | tr -d '"' | tr -d "'"`
+oafx_file = `echo $OALKFILE | tr -d '"' | tr -d "'"`
 EOF
   endif
   if ($HAMOCC_VSLS == TRUE) then

--- a/hamocc/hamocc4bcm.F90
+++ b/hamocc/hamocc4bcm.F90
@@ -19,7 +19,7 @@
 
       SUBROUTINE HAMOCC4BCM(kpie,kpje,kpke,kbnd,kplyear,kplmon,kplday,kldtday,&
                             pdlxp,pdlyp,pddpo,prho,pglat,omask,               &
-                            dust,rivin,ndep,pi_ph,                            &
+                            dust,rivin,ndep,oafx,pi_ph,                            &
                             pfswr,psicomo,ppao,pfu10,ptho,psao,               &
                             patmco2,pflxco2,pflxdms,patmbromo,pflxbromo)
 !******************************************************************************
@@ -66,6 +66,7 @@
 !  *REAL*    *dust*       - dust deposition flux [kg/m2/month].
 !  *REAL*    *rivin*      - riverine input [kmol m-2 yr-2].
 !  *REAL*    *ndep*       - nitrogen deposition [kmol m-2 yr-2].
+!  *REAL*    *oaflx*      - alkalinity flux from alkalinization [kmol m-2 yr-2]
 !  *REAL*    *pfswr*      - solar radiation [W/m**2].
 !  *REAL*    *psicomo*    - sea ice concentration
 !  *REAL*    *ppao*       - sea level pressure [Pascal].
@@ -91,6 +92,7 @@
       use mo_apply_fedep, only: apply_fedep
       use mo_apply_rivin, only: apply_rivin
       use mo_apply_ndep,  only: apply_ndep
+      use mo_apply_oafx,  only: apply_oafx
 #if defined(BOXATM)
       use mo_boxatm,      only: update_boxatm
 #endif
@@ -113,6 +115,7 @@
       REAL,    intent(in)  :: dust   (kpie,kpje)
       REAL,    intent(in)  :: rivin  (kpie,kpje,nriv)
       REAL,    intent(in)  :: ndep   (kpie,kpje)
+      REAL,    intent(in)  :: oafx   (kpie,kpje)
       REAL,    intent(in)  :: pi_ph  (kpie,kpje)
       REAL,    intent(in)  :: pfswr  (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)
       REAL,    intent(in)  :: psicomo(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)
@@ -294,6 +297,17 @@
       IF (mnproc.eq.1) THEN
       WRITE(io_stdo_bgc,*)' '
       WRITE(io_stdo_bgc,*)'after river input: call INVENTORY'
+      ENDIF
+      CALL INVENTORY_BGC(kpie,kpje,kpke,pdlxp,pdlyp,pddpo,omask,0)
+#endif	 
+
+      ! Apply alkalinity flux due to ocean alkalinization
+      call apply_oafx(kpie,kpje,kpke,pddpo,omask,oafx)
+
+#ifdef PBGC_CK_TIMESTEP 
+      IF (mnproc.eq.1) THEN
+      WRITE(io_stdo_bgc,*)' '
+      WRITE(io_stdo_bgc,*)'after ocean alkalinization: call INVENTORY'
       ENDIF
       CALL INVENTORY_BGC(kpie,kpje,kpke,pdlxp,pdlyp,pddpo,omask,0)
 #endif	 

--- a/hamocc/hamocc4bcm.F90
+++ b/hamocc/hamocc4bcm.F90
@@ -64,9 +64,9 @@
 !  *REAL*    *pglat*      - latitude of grid cells [deg north].
 !  *REAL*    *omask*      - land/ocean mask.
 !  *REAL*    *dust*       - dust deposition flux [kg/m2/month].
-!  *REAL*    *rivin*      - riverine input [kmol m-2 yr-2].
-!  *REAL*    *ndep*       - nitrogen deposition [kmol m-2 yr-2].
-!  *REAL*    *oaflx*      - alkalinity flux from alkalinization [kmol m-2 yr-2]
+!  *REAL*    *rivin*      - riverine input [kmol m-2 yr-1].
+!  *REAL*    *ndep*       - nitrogen deposition [kmol m-2 yr-1].
+!  *REAL*    *oaflx*      - alkalinity flux from alkalinization [kmol m-2 yr-1]
 !  *REAL*    *pfswr*      - solar radiation [W/m**2].
 !  *REAL*    *psicomo*    - sea ice concentration
 !  *REAL*    *ppao*       - sea level pressure [Pascal].

--- a/hamocc/hamocc_init.F90
+++ b/hamocc/hamocc_init.F90
@@ -43,7 +43,7 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   use mod_grid,       only: plon,plat
   use mod_tracers,    only: ntrbgc,ntr,itrbgc,trc
   use mo_control_bgc, only: bgc_namelist,get_bgc_namelist,                      &
-       &                    do_ndep,do_rivinpt,do_sedspinup,                    &
+       &                    do_ndep,do_rivinpt,do_oalk,do_sedspinup,            &
        &                    sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,             &
        &                    dtb,dtbgc,io_stdo_bgc,ldtbgc,                       &
        &                    ldtrunbgc,ndtdaybgc,with_dmsph
@@ -56,6 +56,7 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   use mo_read_rivin,  only: ini_read_rivin,rivinfile
   use mo_read_fedep,  only: ini_read_fedep,fedepfile
   use mo_read_ndep,   only: ini_read_ndep,ndepfile
+  use mo_read_oafx,   only: ini_read_oafx,oalkfile,oalkscen
   use mo_read_pi_ph,  only: ini_pi_ph,pi_ph_file
   use mo_clim_swa,    only: ini_swa_clim,swaclimfile
   use mo_Gdata_read,  only: inidic,inialk,inipo4,inioxy,inino3,                 &
@@ -76,9 +77,8 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   integer :: i,j,k,l,nt
   integer :: iounit
 
-  namelist /bgcnml/ atm_co2,do_rivinpt,do_ndep,                                 &
-       &   ndepfile,fedepfile,rivinfile,                                        &
-       &   do_sedspinup,sedspin_yr_s,                                           &
+  namelist /bgcnml/ atm_co2,fedepfile,do_rivinpt,rivinfile,do_ndep,ndepfile,    &
+       &   do_oalk,oalkscen,oalkfile,do_sedspinup,sedspin_yr_s,                 &
        &   sedspin_yr_e,sedspin_ncyc,                                           &
        &   inidic,inialk,inipo4,inioxy,inino3,inisil,                           &
        &   inid13c,inid14c,swaclimfile,                                         &
@@ -187,6 +187,8 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   CALL ini_read_ndep(idm,jdm)
 
   CALL ini_read_rivin(idm,jdm,omask)
+
+  CALL ini_read_oafx(idm,jdm,bgc_dx,bgc_dy,plat,omask)
 
 #ifdef BROMO
   CALL ini_swa_clim(idm,jdm,omask)

--- a/hamocc/hamocc_step.F90
+++ b/hamocc/hamocc_step.F90
@@ -36,6 +36,7 @@ subroutine hamocc_step(m,n,mm,nn,k1m,k1n)
   use mo_read_rivin,  only: rivflx
   use mo_read_fedep,  only: get_fedep
   use mo_read_ndep,   only: get_ndep
+  use mo_read_oafx,   only: get_oafx
   use mo_read_pi_ph,  only: get_pi_ph,pi_ph
   use mo_control_bgc, only: with_dmsph
 
@@ -46,6 +47,7 @@ subroutine hamocc_step(m,n,mm,nn,k1m,k1n)
   integer :: l,ldtday
   real    :: ndep(idm,jdm)
   real    :: dust(idm,jdm)
+  real    :: oafx(idm,jdm)      
 
   call trc_limitc(nn)
 
@@ -64,12 +66,13 @@ subroutine hamocc_step(m,n,mm,nn,k1m,k1n)
 
   call get_fedep(idm,jdm,date%month,dust)
   call get_ndep(idm,jdm,date%year,date%month,omask,ndep)
+  call get_oafx(idm,jdm,date%year,date%month,omask,oafx)
   if(with_dmsph) call get_pi_ph(idm,jdm,date%month)
 
   call hamocc4bcm(idm,jdm,kdm,nbdy,                                             &
        &   date%year,date%month,date%day,ldtday,                                &
        &   bgc_dx,bgc_dy,bgc_dp,bgc_rho,plat,omask,                             &
-       &   dust,rivflx,ndep,pi_ph,                                              &
+       &   dust,rivflx,ndep,oafx,pi_ph,                                         &
        &   swa,ficem,slp,abswnd,                                                &
        &   temp(1-nbdy,1-nbdy,1+nn),saln(1-nbdy,1-nbdy,1+nn),                   &
        &   atmco2,flxco2,flxdms,atmbrf,flxbrf)

--- a/hamocc/mo_apply_oafx.F90
+++ b/hamocc/mo_apply_oafx.F90
@@ -71,7 +71,7 @@ subroutine apply_oafx(kpie,kpje,kpke,pddpo,omask,oafx)
 !******************************************************************************
   use mo_control_bgc, only: dtb,do_oalk
   use mo_carbch,      only: ocetra
-  use mo_param1_bgc,  only: ialkali,inatalkali
+  use mo_param1_bgc,  only: ialkali
 
   implicit none
 
@@ -90,9 +90,6 @@ subroutine apply_oafx(kpie,kpje,kpke,pddpo,omask,oafx)
   do i=1,kpie
     if (omask(i,j).gt.0.5) then
       ocetra(i,j,1,ialkali)=ocetra(i,j,1,ialkali)+oafx(i,j)*dtb/365./pddpo(i,j,1)
-#ifdef natDIC
-      ocetra(i,j,1,inatalkali)=ocetra(i,j,1,inatalkali)+oafx(i,j)*dtb/365./pddpo(i,j,1)
-#endif
     endif
   enddo
   enddo

--- a/hamocc/mo_apply_oafx.F90
+++ b/hamocc/mo_apply_oafx.F90
@@ -1,0 +1,105 @@
+! Copyright (C) 2021  J. Schwinger
+!
+! This file is part of BLOM/iHAMOCC.
+!
+! BLOM is free software: you can redistribute it and/or modify it under the
+! terms of the GNU Lesser General Public License as published by the Free 
+! Software Foundation, either version 3 of the License, or (at your option) 
+! any later version. 
+!
+! BLOM is distributed in the hope that it will be useful, but WITHOUT ANY 
+! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+! FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+! more details. 
+!
+! You should have received a copy of the GNU Lesser General Public License 
+! along with BLOM. If not, see https://www.gnu.org/licenses/.
+
+
+module mo_apply_oafx
+!******************************************************************************
+!
+!   J.Schwinger             *NORCE Climate, Bergen*             2021-11-15
+!
+! Modified
+! --------
+!
+! Purpose
+! -------
+!  -Routines for applying ocean alkalinization
+!
+!
+! Description:
+! ------------
+!
+!  -subroutine alkalinization
+!     Apply alkalinization to the top-most model layer.
+!
+!
+!******************************************************************************
+  implicit none
+
+  private
+  public :: apply_oafx
+
+!******************************************************************************
+contains
+
+
+
+subroutine apply_oafx(kpie,kpje,kpke,pddpo,omask,oafx)
+!******************************************************************************
+!
+!     J. Schwinger            *NORCE Climate, Bergen*     2021-11-15
+!
+! Purpose
+! -------
+!  -apply alkalinization to the top-most model layer.
+!
+! Changes: 
+! --------
+!
+!
+! Parameter list:
+! ---------------
+!  *INTEGER*   *kpie*    - 1st dimension of model grid.
+!  *INTEGER*   *kpje*    - 2nd dimension of model grid.
+!  *REAL*      *pddpo*   - size of grid cell (depth) [m].
+!  *REAL*      *omask*   - land/ocean mask (1=ocean)
+!  *REAL*      *oafx*    - alkalinization field to apply [kmol m-2 yr-1]
+!
+!******************************************************************************
+  use mo_control_bgc, only: dtb,do_oalk
+  use mo_carbch,      only: ocetra
+  use mo_param1_bgc,  only: ialkali,inatalkali
+
+  implicit none
+
+  integer, intent(in) :: kpie,kpje,kpke
+  real,    intent(in) :: pddpo(kpie,kpje,kpke)
+  real,    intent(in) :: omask(kpie,kpje)
+  real,    intent(in) :: oafx(kpie,kpje)
+
+  ! local variables 
+  integer :: i,j
+
+  if (.not. do_oalk) return 
+
+  ! alkalinization in topmost layer 
+  do j=1,kpje
+  do i=1,kpie
+    if (omask(i,j).gt.0.5) then
+      ocetra(i,j,1,ialkali)=ocetra(i,j,1,ialkali)+oafx(i,j)*dtb/365./pddpo(i,j,1)
+#ifdef natDIC
+      ocetra(i,j,1,inatalkali)=ocetra(i,j,1,inatalkali)+oafx(i,j)*dtb/365./pddpo(i,j,1)
+#endif
+    endif
+  enddo
+  enddo
+
+!******************************************************************************
+end subroutine apply_oafx
+
+
+!******************************************************************************
+end module mo_apply_oafx

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -62,6 +62,7 @@
       LOGICAL, save :: do_ndep     =.true.   ! apply n-deposition
       LOGICAL, save :: do_rivinpt  =.true.   ! apply riverine input
       LOGICAL, save :: do_sedspinup=.false.  ! apply sediment spin-up
+      LOGICAL, save :: do_oalk     =.false.  ! apply ocean alkalinization
       logical, save :: with_dmsph  =.false.  ! apply DMS with pH dependence
 
     contains

--- a/hamocc/mo_read_oafx.F90
+++ b/hamocc/mo_read_oafx.F90
@@ -1,0 +1,277 @@
+! Copyright (C) 2021-2022  J. Schwinger
+!
+! This file is part of BLOM/iHAMOCC.
+!
+! BLOM is free software: you can redistribute it and/or modify it under the
+! terms of the GNU Lesser General Public License as published by the Free 
+! Software Foundation, either version 3 of the License, or (at your option) 
+! any later version. 
+!
+! BLOM is distributed in the hope that it will be useful, but WITHOUT ANY 
+! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+! FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+! more details. 
+!
+! You should have received a copy of the GNU Lesser General Public License 
+! along with BLOM. If not, see https://www.gnu.org/licenses/.
+
+
+module mo_read_oafx
+!******************************************************************************
+!
+!   J.Schwinger             *NORCE Climate, Bergen*             2022-08-24
+!
+! Modified
+! --------
+!
+! Purpose
+! -------
+!  -Routines for reading ocean alkalinization fluxes from netcdf files
+!
+!
+! Description:
+! ------------
+!  The routine get_oafx reads a fluxs of alkalinity from file (or, for simple
+!  cases, constructs an alkalinity flux field from scratch). The alkalinity
+!  flux is then passed to hamocc4bcm where it is applied to the top-most model 
+!  layer by a call to apply_oafx (mo_apply_oafx).
+!
+!  Ocean alkalinization is activated through a logical switch 'do_oalk' read from
+!  HAMOCC's bgcnml namelist. If ocean alkalinization is acitvated, a valid 
+!  name of an alkalinisation scenario (defined in this module, see below) and 
+!  the file name (including the full path) of the corresponding OA-scenario 
+!  input file needs to be provided via HAMOCC's bgcnml namelist (variables 
+!  oascenario and oafxfile). If the input file is not found, an error will be 
+!  issued. The input data must be already pre-interpolated to the ocean grid.
+!
+!  Currently available ocean alkalinisation scenarios:
+!    -'const_0p14':   constant alkalinity flux of 0.14 Pmol yr-1 applied to the 
+!                     surface ocean between 60S and 70N (no input file needed)
+!    -'const_0p56':   constant alkalinity flux of 0.56 Pmol yr-1 applied to the 
+!                     surface ocean between 60S and 70N (no input file needed)
+!
+!
+!  -subroutine ini_read_oafx
+!     Initialise the module
+!
+!  -subroutine get_oafx
+!     Gets the alkalinity flux to apply at a given time.
+!
+!
+!******************************************************************************
+  implicit none
+
+  private
+  public :: ini_read_oafx,get_oafx,oalkscen,oalkfile
+
+  real,allocatable, save :: oalkflx(:,:)
+   
+  character(len=128), save :: oalkscen=''
+  character(len=512), save :: oalkfile=''
+  real, parameter          :: Pmol2kmol  = 1.0e12
+  
+  ! Parameter used in the definition of alkalinization scenarios:
+  real, parameter :: addalk_0p14 = 0.14 ! Pmol of alkalinit per year added in the
+  real, parameter :: addalk_0p56 = 0.56 ! 'const_0p14' and 'const_0p56' scenarios
+
+  logical,   save :: lini = .false.
+
+!******************************************************************************
+contains
+
+
+
+subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
+!******************************************************************************
+!
+!     J.Schwinger               *NORCE Climate, Bergen*         2021-11-15
+!
+! Purpose
+! -------
+!  -Initialise the alkalinization module.
+!
+! Changes: 
+! --------
+!
+! Parameter list:
+! ---------------
+!  *INTEGER* *kpie*       - 1st dimension of model grid.
+!  *INTEGER* *kpje*       - 2nd dimension of model grid.
+!  *REAL*    *pdlxp*      - size of grid cell (longitudinal) [m].
+!  *REAL*    *pdlyp*      - size of grid cell (latitudinal) [m].
+!  *REAL*    *pglat*      - latitude grid cell centres [degree N].
+!  *REAL*    *omask*      - land/ocean mask.
+!
+!******************************************************************************
+  use mod_xc,         only: xcsum,xchalt,mnproc,nbdy,ips
+  use mo_control_bgc, only: io_stdo_bgc,do_oalk
+
+  implicit none 
+
+  integer, intent(in) :: kpie,kpje
+  real,    intent(in) :: pdlxp(kpie,kpje), pdlyp(kpie,kpje)
+  real,    intent(in) :: pglat(1-nbdy:kpie+nbdy,1-nbdy:kpje+nbdy)  
+  real,    intent(in) :: omask(kpie,kpje)
+
+  integer :: i,j,errstat
+  real    :: avflx,ztotarea,addalk_tot
+  real    :: ztmp1(1-nbdy:kpie+nbdy,1-nbdy:kpje+nbdy)
+
+  ! Return if alkalinization is turned off
+  if (.not. do_oalk) then
+    if (mnproc.eq.1) then
+      write(io_stdo_bgc,*) ''
+      write(io_stdo_bgc,*) 'ini_read_oafx: ocean alkalinization is not activated.'
+    endif
+    return
+  end if
+
+  ! Initialise the module
+  if(.not. lini) then 
+
+    if(mnproc.eq.1) then
+      write(io_stdo_bgc,*)' '
+      write(io_stdo_bgc,*)'***************************************************'
+      write(io_stdo_bgc,*)'iHAMOCC: Initialization of module mo_read_oafx:'
+      write(io_stdo_bgc,*)' '
+    endif
+
+    !--------------------------------
+    ! Scenarios of constant fluxes
+    !--------------------------------
+    if( trim(oalkscen)=='const_0p14' .or. trim(oalkscen)=='const_0p56' ) then
+
+      if(mnproc.eq.1) then
+        write(io_stdo_bgc,*)'Using alkalinization scenario ', trim(oalkscen)
+        write(io_stdo_bgc,*)' '
+      endif
+
+      ! Allocate field to hold constant alkalinization fluxes
+      if(mnproc.eq.1) then
+        write(io_stdo_bgc,*)'Memory allocation for variable oalkflx ...'
+        write(io_stdo_bgc,*)'First dimension    : ',kpie
+        write(io_stdo_bgc,*)'Second dimension   : ',kpje
+      endif
+   
+      allocate(oalkflx(kpie,kpje),stat=errstat)
+      if(errstat.ne.0) stop 'not enough memory oalkflx'
+      oalkflx(:,:) = 0.0
+
+      ! Calculate total ocean area 
+      ztmp1(:,:)=0.0
+      do j=1,kpje
+      do i=1,kpie
+        if( omask(i,j).gt.0.5 .and. pglat(i,j)<70.0 .and. pglat(i,j)>-60.0 ) then
+          ztmp1(i,j)=ztmp1(i,j)+pdlxp(i,j)*pdlyp(i,j)
+        endif
+      enddo
+      enddo
+
+      call xcsum(ztotarea,ztmp1,ips)
+      
+      if( trim(oalkscen)=='const_0p14') then
+        addalk_tot = addalk_0p14
+      else
+        addalk_tot = addalk_0p56
+      endif
+    
+      ! Calculate alkalinity flux (kmol m^2 yr-1) to be applied
+      avflx = addalk_tot/ztotarea*Pmol2kmol
+      if(mnproc.eq.1) then
+        write(io_stdo_bgc,*)' '
+        write(io_stdo_bgc,*)' applying alkalinity flux of ', avflx, ' kmol m-2 yr-1'
+        write(io_stdo_bgc,*)'             over an area of ', ztotarea , ' m-2'
+      endif
+
+      do j=1,kpje
+      do i=1,kpie
+        if( omask(i,j).gt.0.5 .and. pglat(i,j)<70.0 .and. pglat(i,j)>-60.0 ) then
+          oalkflx(i,j) = avflx
+        endif
+      enddo
+      enddo
+
+      lini=.true.
+
+    !--------------------------------
+    ! No valid scenario specified
+    !--------------------------------
+    else
+    
+      write(io_stdo_bgc,*) ''
+      write(io_stdo_bgc,*) 'ini_read_oafx: invalid alkalinization scenario... '
+      call xchalt('(ini_read_oafx)')
+      stop '(ini_read_oafx)' 
+      
+    endif
+
+  endif ! not lini
+
+
+!******************************************************************************
+end subroutine ini_read_oafx
+
+
+subroutine get_oafx(kpie,kpje,kplyear,kplmon,omask,oafx)
+!******************************************************************************
+!
+!     J. Schwinger            *NORCE Climate, Bergen*     2021-11-15
+!
+! Purpose
+! -------
+!  -return ocean alkalinization flux.
+!
+! Changes: 
+! --------
+!
+!
+! Parameter list:
+! ---------------
+!  *INTEGER*   *kpie*    - 1st dimension of model grid.
+!  *INTEGER*   *kpje*    - 2nd dimension of model grid.
+!  *INTEGER*   *kplyear* - current year.
+!  *INTEGER*   *kplmon*  - current month.
+!  *REAL*      *omask*   - land/ocean mask (1=ocean)
+!  *REAL*      *oaflx*   - alkalinization flux [kmol m-2 yr-1]
+!
+!******************************************************************************
+  use mod_xc,         only: xchalt
+  use mo_control_bgc, only: io_stdo_bgc,do_oalk
+
+  implicit none
+
+  integer, intent(in)  :: kpie,kpje,kplyear,kplmon
+  real,    intent(in)  :: omask(kpie,kpje)
+  real,    intent(out) :: oafx(kpie,kpje)
+
+  ! local variables 
+  integer :: i,j
+
+  if (.not. do_oalk) then
+    oafx(:,:) = 0.0
+    return 
+  endif
+  
+  !--------------------------------
+  ! Scenarios of constant fluxes
+  !--------------------------------
+  if( trim(oalkscen)=='const_0p14' .or. trim(oalkscen)=='const_0p56' ) then
+      
+    oafx(:,:) = oalkflx(:,:)
+
+  else
+    
+    write(io_stdo_bgc,*) ''
+    write(io_stdo_bgc,*) 'get_oafx: invalid alkalinization scenario... '
+    call xchalt('(get_oafx)')
+    stop '(get_oafx)' 
+      
+  endif
+
+!******************************************************************************
+end subroutine get_oafx
+
+
+
+!******************************************************************************
+end module mo_read_oafx

--- a/hamocc/mo_read_oafx.F90
+++ b/hamocc/mo_read_oafx.F90
@@ -70,9 +70,20 @@ module mo_read_oafx
   character(len=512), save :: oalkfile=''
   real, parameter          :: Pmol2kmol  = 1.0e12
   
-  ! Parameter used in the definition of alkalinization scenarios:
-  real, parameter :: addalk_0p14 = 0.14 ! Pmol of alkalinit per year added in the
-  real, parameter :: addalk_0p56 = 0.56 ! 'const_0p14' and 'const_0p56' scenarios
+  ! Parameter used in the definition of alkalinization scenarios. The following 
+  ! scenarios are defined in this module:
+  !
+  !  const_0p14    Homogeneous addition of 0.14 Pmol ALK/yr-1 over the ice-free
+  !                surface ocean (assumed to be between 60S and 70N)
+  !  const_0p56    Homogeneous addition of 0.56 Pmol ALK/yr-1 over the ice-free
+  !                surface ocean (assumed to be between 60S and 70N)
+  !
+  real, parameter :: addalk_0p14   = 0.14  ! Pmol alkalinity/yr added in the
+  real, parameter :: addalk_0p56   = 0.56  ! 'const_0p14' and 'const_0p56' 
+                                           ! scenarios
+  real, parameter :: cdrmip_latmax =  70.0 ! Min and max latitude where
+  real, parameter :: cdrmip_latmin = -60.0 ! alkalinity is added according
+                                           ! to the CDRMIP protocol
 
   logical,   save :: lini = .false.
 
@@ -161,7 +172,8 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
       ztmp1(:,:)=0.0
       do j=1,kpje
       do i=1,kpie
-        if( omask(i,j).gt.0.5 .and. pglat(i,j)<70.0 .and. pglat(i,j)>-60.0 ) then
+        if( omask(i,j).gt.0.5 .and. pglat(i,j)<cdrmip_latmax                  &
+                              .and. pglat(i,j)>cdrmip_latmin ) then
           ztmp1(i,j)=ztmp1(i,j)+pdlxp(i,j)*pdlyp(i,j)
         endif
       enddo
@@ -185,7 +197,8 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
 
       do j=1,kpje
       do i=1,kpie
-        if( omask(i,j).gt.0.5 .and. pglat(i,j)<70.0 .and. pglat(i,j)>-60.0 ) then
+        if( omask(i,j).gt.0.5 .and. pglat(i,j)<cdrmip_latmax                  &
+                              .and. pglat(i,j)>cdrmip_latmin ) then
           oalkflx(i,j) = avflx
         endif
       enddo

--- a/hamocc/mo_read_oafx.F90
+++ b/hamocc/mo_read_oafx.F90
@@ -180,7 +180,7 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
       if(mnproc.eq.1) then
         write(io_stdo_bgc,*)' '
         write(io_stdo_bgc,*)' applying alkalinity flux of ', avflx, ' kmol m-2 yr-1'
-        write(io_stdo_bgc,*)'             over an area of ', ztotarea , ' m-2'
+        write(io_stdo_bgc,*)'             over an area of ', ztotarea , ' m2'
       endif
 
       do j=1,kpje


### PR DESCRIPTION
This PR adds two modules to iHAMOCC that read and apply an alkalinity flux to the surface layer. Future addition of more alkalinization scenarios can be done easily by modifications in mo_read_oafx.F90.

There is currently no configuration through the NorESM xml-files available. For now, this is only for expert users who can set ´do_oalk´ to true in user_nl_blom. If ´do_oalk´ is set to false (the default) the model produces bit-identical results compared to the CMIP6 version.