### PR TITLE
Dynamic mapping of pore water tracers to ocean tracers

### DIFF
--- a/hamocc/dipowa.F90
+++ b/hamocc/dipowa.F90
@@ -198,14 +198,15 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 
            ! diffusive fluxes (positive downward)
            sedfluxo(i,j,iv) = sedfluxo(i,j,iv)                                 &
-                &  -(ocetra(i,j,kbo(i,j),iv) - aprior)* bolay(i,j)
+                &  -(ocetra(i,j,kbo(i,j),iv_oc) - aprior)* bolay(i,j)
 #ifdef natDIC
-           if (iv==isco212) ocetra(i,j,kbo(i,j),inatsco212) =                  &
+           ! workaround as long as natDIC is not implemented throughout the sediment module 
+           if (iv_oc==isco212) ocetra(i,j,kbo(i,j),inatsco212) =               &
                 &  ocetra(i,j,kbo(i,j),inatsco212) +                           &
-                &  ocetra(i,j,kbo(i,j),iv) - aprior
-           if (iv==ialkali) ocetra(i,j,kbo(i,j),inatalkali) =                  &
+                &  ocetra(i,j,kbo(i,j),isco212) - aprior
+           if (iv_oc==ialkali) ocetra(i,j,kbo(i,j),inatalkali) =               &
                 &  ocetra(i,j,kbo(i,j),inatalkali) +                           &
-                &  ocetra(i,j,kbo(i,j),iv) - aprior
+                &  ocetra(i,j,kbo(i,j),ialkali) - aprior
 #endif
         endif
      enddo

--- a/hamocc/dipowa.F90
+++ b/hamocc/dipowa.F90
@@ -57,7 +57,7 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 
   use mo_carbch,     only: ocetra, sedfluxo 
   use mo_sedmnt,     only: powtra,porwat,porwah,sedict,seddw,seddzi 
-  use mo_param1_bgc, only: ks,npowtra
+  use mo_param1_bgc, only: ks,npowtra,map_por2octra
   use mo_vgrid,      only: kbo,bolay
 #ifdef cisonew
   use mo_param1_bgc, only: ipowc13,ipowc14,isco213,isco214
@@ -112,11 +112,7 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 
   k = 0
   do iv = 1,npowtra      ! loop over pore water tracers
-     iv_oc = iv
-#ifdef cisonew
-     if (iv == ipowc13) iv_oc = isco213
-     if (iv == ipowc14) iv_oc = isco214
-#endif
+     iv_oc = map_por2octra(iv)
      do i = 1,kpie
         sedb1(i,k,iv) = 0.
         if (omask(i,j) > 0.5) then
@@ -190,16 +186,8 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 
   if(.not. lspin) THEN
 ! sediment ocean interface
-!
-! CAUTION - the following assumes same indecees for ocetra and powtra
-!           test npowa_base 071106
-!           check mo_param1_bgc.f90 for consistency
   do iv = 1, npowtra
-     iv_oc = iv
-#ifdef cisonew
-     if (iv == ipowc13) iv_oc=isco213
-     if (iv == ipowc14) iv_oc=isco214
-#endif
+     iv_oc = map_por2octra(iv)
      do i = 1,kpie
         l = 0
         if (omask(i,j) > 0.5) then

--- a/hamocc/hamocc_init.F90
+++ b/hamocc/hamocc_init.F90
@@ -47,7 +47,7 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
        &                    sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,             &
        &                    dtb,dtbgc,io_stdo_bgc,ldtbgc,                       &
        &                    ldtrunbgc,ndtdaybgc,with_dmsph
-  use mo_param1_bgc,  only: ks,nsedtra,npowtra
+  use mo_param1_bgc,  only: ks,nsedtra,npowtra,init_por2octra_mapping
   use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
   use mo_biomod,      only: alloc_mem_biomod
   use mo_sedmnt,      only: alloc_mem_sedmnt,sedlay,powtra,burial
@@ -130,6 +130,9 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
      endif
 
   ENDIF
+  ! init the index-mapping between pore water and ocean tracers
+  CALL init_por2octra_mapping()
+
   !
   ! --- Memory allocation
   !

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -245,6 +245,27 @@
      &                      ipowc14 = -1  
 #endif
       INTEGER, PARAMETER :: npowtra = i_pow_base + i_pow_cisonew
+      
+     ! Mapping between pore water and ocean tracers needed for pore water diffusion
+      INTEGER, SAVE      :: map_por2octra(npowtra)
+   
+      contains
+
+      subroutine init_por2octra_mapping()
+        
+        map_por2octra(ipowaic) = isco212 
+        map_por2octra(ipowaal) = ialkali 
+        map_por2octra(ipowaph) = iphosph 
+        map_por2octra(ipowaox) = ioxygen 
+        map_por2octra(ipown2)  = igasnit 
+        map_por2octra(ipowno3) = iano3 
+        map_por2octra(ipowasi) = isilica 
+       
+        ! if statements for non-base tracers 
+        if(ipowc13 > 0) map_por2octra(ipowc13) = isco213 
+        if(ipowc14 > 0) map_por2octra(ipowc14) = isco214
+      
+      end subroutine init_por2octra_mapping
 
 !******************************************************************************
       END MODULE mo_param1_bgc

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -226,7 +226,6 @@
 
 
      ! sediment pore water components
-     ! pore water tracers, index should be the same as for ocetra
       INTEGER, PARAMETER :: i_pow_base=7
       INTEGER, PARAMETER :: ipowaic=1,                                  &
      &                      ipowaal=2,                                  &
@@ -237,8 +236,8 @@
      &                      ipowasi=7
 #ifdef cisonew
       INTEGER, PARAMETER :: i_pow_cisonew = 2
-      INTEGER, PARAMETER :: ipowc13=i_pow_base + 1,                     &  ! C-isotope indices do NOT correspond to ocetra!
-     &                      ipowc14=i_pow_base + 2                         ! C-isotope indices do NOT correspond to ocetra!
+      INTEGER, PARAMETER :: ipowc13=i_pow_base + 1,                     &
+     &                      ipowc14=i_pow_base + 2                       
 #else
       INTEGER, PARAMETER :: i_pow_cisonew = 0
       INTEGER, PARAMETER :: ipowc13 = -1,                               &

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -201,53 +201,50 @@
      &                      irdoc  =6,                                  & ! dissolved organic carbon
      &                      irdet  =7                                     ! particulate carbon
 
-
-! sediment
-#ifdef cisonew
-      INTEGER, PARAMETER :: nsedtra=8
+      
+! ---  sediment
+     ! sediment solid components 
+      INTEGER, PARAMETER :: i_sed_base = 4
       INTEGER, PARAMETER :: issso12=1,                                  &
      &                      isssc12=2,                                  &
      &                      issssil=3,                                  &
-     &                      issster=4,                                  &
-     &                      issso13=5,                                  &
-     &                      issso14=6,                                  &
-     &                      isssc13=7,                                  &
-     &                      isssc14=8
-     
-! pore water tracers, index should be the same as for ocetra
-      INTEGER, PARAMETER :: npowtra=9
-      INTEGER, PARAMETER :: ipowaic=1,                                  &
-     &                      ipowaal=2,                                  &
-     &                      ipowaph=3,                                  &
-     &                      ipowaox=4,                                  &
-     &                      ipown2 =5,                                  &
-     &                      ipowno3=6,                                  &
-     &                      ipowasi=7,                                  &
-     &                      ipowc13=8,                                  &  ! C-isotope idices do NOT correspond to ocetra!
-     &                      ipowc14=9                                      ! C-isotope idices do NOT correspond to ocetra!
+     &                      issster=4
+#ifdef cisonew 
+      INTEGER, PARAMETER :: i_sed_cisonew = 4
+      INTEGER, PARAMETER :: issso13 = i_sed_base+1,                     &
+     &                      issso14 = i_sed_base+2,                     &
+     &                      isssc13 = i_sed_base+3,                     &
+     &                      isssc14 = i_sed_base+4
 #else
-      INTEGER, PARAMETER :: nsedtra=4
-      INTEGER, PARAMETER :: issso12=1,                                  &
-     &                      isssc12=2,                                  &
-     &                      issssil=3,                                  &
-     &                      issster=4,                                  &
-     &                      issso13=-1,                                 &
-     &                      issso14=-1,                                 &
-     &                      isssc13=-1,                                 &
-     &                      isssc14=-1
+      INTEGER, PARAMETER :: i_sed_cisonew = 0
+      INTEGER, PARAMETER :: issso13 = -1,                               &
+     &                      issso14 = -1,                               &
+     &                      isssc13 = -1,                               &
+     &                      isssc14 = -1 
+#endif
+      INTEGER, PARAMETER :: nsedtra = i_sed_base + i_sed_cisonew
 
-! pore water tracers, index should be the same as for ocetra
-      INTEGER, PARAMETER :: npowtra=7
+
+     ! sediment pore water components
+     ! pore water tracers, index should be the same as for ocetra
+      INTEGER, PARAMETER :: i_pow_base=7
       INTEGER, PARAMETER :: ipowaic=1,                                  &
      &                      ipowaal=2,                                  &
      &                      ipowaph=3,                                  &
      &                      ipowaox=4,                                  &
      &                      ipown2 =5,                                  &
      &                      ipowno3=6,                                  &
-     &                      ipowasi=7,                                  &
-     &                      ipowc13=-1,                                 &  
-     &                      ipowc14=-1                                      
+     &                      ipowasi=7
+#ifdef cisonew
+      INTEGER, PARAMETER :: i_pow_cisonew = 2
+      INTEGER, PARAMETER :: ipowc13=i_pow_base + 1,                     &  ! C-isotope indices do NOT correspond to ocetra!
+     &                      ipowc14=i_pow_base + 2                         ! C-isotope indices do NOT correspond to ocetra!
+#else
+      INTEGER, PARAMETER :: i_pow_cisonew = 0
+      INTEGER, PARAMETER :: ipowc13 = -1,                               &
+     &                      ipowc14 = -1  
 #endif
+      INTEGER, PARAMETER :: npowtra = i_pow_base + i_pow_cisonew
 
 !******************************************************************************
       END MODULE mo_param1_bgc


### PR DESCRIPTION
As announced in #191, I modified the way how we map the pore water tracers to the ocean tracers during diffusive exchange between sediment and ocean. I left the (potential) bug untouched, which will be fixed in a separate step. I tested the new implementation against former `master` and results were bit-identical. 