### PR TITLE
pCO2, Piston velocity and solubility output

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -424,7 +424,11 @@ set SRF_EXPORT    = '0, 2, 2'
 set SRF_EXPOSI    = '0, 2, 2' 
 set SRF_EXPOCA    = '0, 2, 2' 
 set SRF_KWCO2     = '0, 2, 2' 
+set SRF_KWCO2KHD  = '0, 2, 2' 
+set SRF_CO2KHD    = '0, 2, 2' 
+set SRF_CO2KH     = '0, 2, 2' 
 set SRF_PCO2      = '0, 2, 2' 
+set SRF_PCO2M     = '0, 2, 2' 
 set SRF_CO2FXD    = '4, 2, 2' 
 set SRF_CO2FXU    = '4, 2, 2' 
 set SRF_OXFLUX    = '0, 2, 2' 
@@ -1578,7 +1582,11 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   EXPOCA         - Ca export production (epcalc100) [mol Ca m-2 s-1]
 !   EXPOSI         - Si export production (epsi100) [mol Si m-2 s-1]
 !   PCO2           - Surface PCO2 (spco2) [uatm]
-!   KWCO2          - kwco2 x solubility
+!   PCO2M          - Surface PCO2 under moist air assumption [uatm]
+!   KWCO2          - kwco2 
+!   KWCO2KHD       - kwco2 x solubility (dry air)
+!   CO2KHD         - khd CO2 solubility under dry air assumption 
+!   CO2KH          - kh CO2 solubility under moist air assumption 
 !   CO2FXD         - Downward CO2 flux (co2fxd) [kg C m-2 s-1]
 !   CO2FXU         - Upward CO2 flux (co2fxu) [kg C m-2 s-1]
 !   NIFLUX         - Nitrogen flux (fgn2) [mol N2 m-2 s-1]
@@ -1658,7 +1666,11 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   SRF_EXPOSI    = $SRF_EXPOSI
   SRF_EXPOCA    = $SRF_EXPOCA
   SRF_KWCO2     = $SRF_KWCO2
+  SRF_KWCO2KHD  = $SRF_KWCO2KHD
+  SRF_CO2KHD    = $SRF_CO2KHD
+  SRF_CO2KH     = $SRF_CO2KH
   SRF_PCO2      = $SRF_PCO2
+  SRF_PCO2M     = $SRF_PCO2M
   SRF_CO2FXD    = $SRF_CO2FXD
   SRF_CO2FXU    = $SRF_CO2FXU
   SRF_OXFLUX    = $SRF_OXFLUX

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1583,10 +1583,10 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   EXPOSI         - Si export production (epsi100) [mol Si m-2 s-1]
 !   PCO2           - Surface PCO2 (spco2) [uatm]
 !   PCO2M          - Surface PCO2 under moist air assumption [uatm]
-!   KWCO2          - kwco2 
-!   KWCO2KHM       - kwco2 x solubility (moist air)
-!   CO2KH          - khd CO2 solubility under dry air assumption 
-!   CO2KHM         - kh CO2 solubility under moist air assumption 
+!   KWCO2          - Piston velocity (kwco2)  [m s-1]
+!   KWCO2KHM       - Piston velocity times solubility (kwco2*kh; moist air) [m s-1 mol kg-1 uatm-1]
+!   CO2KH          - CO2 solubility under dry air assumption (khd) [mol kg-1 atm-1] 
+!   CO2KHM         - CO2 solubility under moist air assumption (kh) [mol kg-1 atm-1] 
 !   CO2FXD         - Downward CO2 flux (co2fxd) [kg C m-2 s-1]
 !   CO2FXU         - Upward CO2 flux (co2fxu) [kg C m-2 s-1]
 !   NIFLUX         - Nitrogen flux (fgn2) [mol N2 m-2 s-1]

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -424,9 +424,9 @@ set SRF_EXPORT    = '0, 2, 2'
 set SRF_EXPOSI    = '0, 2, 2' 
 set SRF_EXPOCA    = '0, 2, 2' 
 set SRF_KWCO2     = '0, 2, 2' 
-set SRF_KWCO2KH   = '0, 2, 2' 
-set SRF_CO2KHD    = '0, 2, 2' 
+set SRF_KWCO2KHM  = '0, 2, 2' 
 set SRF_CO2KH     = '0, 2, 2' 
+set SRF_CO2KHM    = '0, 2, 2' 
 set SRF_PCO2      = '0, 2, 2' 
 set SRF_PCO2M     = '0, 2, 2' 
 set SRF_CO2FXD    = '4, 2, 2' 
@@ -1584,9 +1584,9 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   PCO2           - Surface PCO2 (spco2) [uatm]
 !   PCO2M          - Surface PCO2 under moist air assumption [uatm]
 !   KWCO2          - kwco2 
-!   KWCO2KH        - kwco2 x solubility (moist air)
-!   CO2KHD         - khd CO2 solubility under dry air assumption 
-!   CO2KH          - kh CO2 solubility under moist air assumption 
+!   KWCO2KHM       - kwco2 x solubility (moist air)
+!   CO2KH          - khd CO2 solubility under dry air assumption 
+!   CO2KHM         - kh CO2 solubility under moist air assumption 
 !   CO2FXD         - Downward CO2 flux (co2fxd) [kg C m-2 s-1]
 !   CO2FXU         - Upward CO2 flux (co2fxu) [kg C m-2 s-1]
 !   NIFLUX         - Nitrogen flux (fgn2) [mol N2 m-2 s-1]
@@ -1666,9 +1666,9 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   SRF_EXPOSI    = $SRF_EXPOSI
   SRF_EXPOCA    = $SRF_EXPOCA
   SRF_KWCO2     = $SRF_KWCO2
-  SRF_KWCO2KH   = $SRF_KWCO2KH
-  SRF_CO2KHD    = $SRF_CO2KHD
+  SRF_KWCO2KHM  = $SRF_KWCO2KHM
   SRF_CO2KH     = $SRF_CO2KH
+  SRF_CO2KHM    = $SRF_CO2KHM
   SRF_PCO2      = $SRF_PCO2
   SRF_PCO2M     = $SRF_PCO2M
   SRF_CO2FXD    = $SRF_CO2FXD

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -424,7 +424,7 @@ set SRF_EXPORT    = '0, 2, 2'
 set SRF_EXPOSI    = '0, 2, 2' 
 set SRF_EXPOCA    = '0, 2, 2' 
 set SRF_KWCO2     = '0, 2, 2' 
-set SRF_KWCO2KHD  = '0, 2, 2' 
+set SRF_KWCO2KH   = '0, 2, 2' 
 set SRF_CO2KHD    = '0, 2, 2' 
 set SRF_CO2KH     = '0, 2, 2' 
 set SRF_PCO2      = '0, 2, 2' 
@@ -1584,7 +1584,7 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !   PCO2           - Surface PCO2 (spco2) [uatm]
 !   PCO2M          - Surface PCO2 under moist air assumption [uatm]
 !   KWCO2          - kwco2 
-!   KWCO2KHD       - kwco2 x solubility (dry air)
+!   KWCO2KH        - kwco2 x solubility (moist air)
 !   CO2KHD         - khd CO2 solubility under dry air assumption 
 !   CO2KH          - kh CO2 solubility under moist air assumption 
 !   CO2FXD         - Downward CO2 flux (co2fxd) [kg C m-2 s-1]
@@ -1666,7 +1666,7 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   SRF_EXPOSI    = $SRF_EXPOSI
   SRF_EXPOCA    = $SRF_EXPOCA
   SRF_KWCO2     = $SRF_KWCO2
-  SRF_KWCO2KHD  = $SRF_KWCO2KHD
+  SRF_KWCO2KH   = $SRF_KWCO2KH
   SRF_CO2KHD    = $SRF_CO2KHD
   SRF_CO2KH     = $SRF_CO2KH
   SRF_PCO2      = $SRF_PCO2

--- a/hamocc/accfields.F90
+++ b/hamocc/accfields.F90
@@ -64,7 +64,7 @@
                               & jlvlph,jlvlphosph,jlvlphosy,jlvlphyto,jlvlphyto13,jlvlpoc,jlvlpoc13,jlvlprefalk,jlvlprefdic,       &
                               & jlvlprefo2,jlvlprefpo4,jlvlsf6,jlvlsilica,jlvlwnos,jlvlwphy,jn2flux,jn2o,jn2oflux,jn2ofx,          &
                               & jprorca,jprcaca,jsilpro,jpodiic,jpodial,jpodiph,jpodiox,jpodin2,jpodino3,jpodisi,jndep,            &
-                              & jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,jpco2m,jkwco2khd,jco2khd,  &
+                              & jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,jpco2m,jkwco2kh,jco2khd,   &
                               & jco2kh,jph,jphosph,jphosy,jphyto,                                                                  & 
                               & jpoc,jprefalk,jprefdic,jprefo2,jprefpo4,jsilica,jsrfalkali,jsrfano3,jsrfdic,jsrfiron,jsrfoxygen,   &
                               & jsrfphosph,jsrfphyto,jsrfsilica,jwnos,jwphy,nbgc,nacc_bgc,bgcwrt,glb_inventory,bgct2d,acclvl,      &
@@ -230,7 +230,7 @@
 ! Accumulate 2d diagnostics
       call accsrf(jpco2,pco2d,omask,0)
       call accsrf(jpco2m,pco2m,omask,0)
-      call accsrf(jkwco2khd,kwco2sol,omask,0)
+      call accsrf(jkwco2kh,kwco2sol,omask,0)
       call accsrf(jkwco2,kwco2d,omask,0)
       call accsrf(jco2khd,co2sold,omask,0)
       call accsrf(jco2kh,co2solm,omask,0)

--- a/hamocc/accfields.F90
+++ b/hamocc/accfields.F90
@@ -64,7 +64,7 @@
                               & jlvlph,jlvlphosph,jlvlphosy,jlvlphyto,jlvlphyto13,jlvlpoc,jlvlpoc13,jlvlprefalk,jlvlprefdic,       &
                               & jlvlprefo2,jlvlprefpo4,jlvlsf6,jlvlsilica,jlvlwnos,jlvlwphy,jn2flux,jn2o,jn2oflux,jn2ofx,          &
                               & jprorca,jprcaca,jsilpro,jpodiic,jpodial,jpodiph,jpodiox,jpodin2,jpodino3,jpodisi,jndep,            &
-                              & jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,jpco2m,jkwco2kh,jco2khd,   &
+                              & jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,jpco2m,jkwco2khm,jco2khm,  &
                               & jco2kh,jph,jphosph,jphosy,jphyto,                                                                  & 
                               & jpoc,jprefalk,jprefdic,jprefo2,jprefpo4,jsilica,jsrfalkali,jsrfano3,jsrfdic,jsrfiron,jsrfoxygen,   &
                               & jsrfphosph,jsrfphyto,jsrfsilica,jwnos,jwphy,nbgc,nacc_bgc,bgcwrt,glb_inventory,bgct2d,acclvl,      &
@@ -230,10 +230,10 @@
 ! Accumulate 2d diagnostics
       call accsrf(jpco2,pco2d,omask,0)
       call accsrf(jpco2m,pco2m,omask,0)
-      call accsrf(jkwco2kh,kwco2sol,omask,0)
+      call accsrf(jkwco2khm,kwco2sol,omask,0)
       call accsrf(jkwco2,kwco2d,omask,0)
-      call accsrf(jco2khd,co2sold,omask,0)
-      call accsrf(jco2kh,co2solm,omask,0)
+      call accsrf(jco2kh,co2sold,omask,0)
+      call accsrf(jco2khm,co2solm,omask,0)
       call accsrf(jsrfphosph,ocetra(1,1,1,iphosph),omask,0)
       call accsrf(jsrfoxygen,ocetra(1,1,1,ioxygen),omask,0)
       call accsrf(jsrfiron,ocetra(1,1,1,iiron),omask,0)

--- a/hamocc/accfields.F90
+++ b/hamocc/accfields.F90
@@ -46,7 +46,8 @@
 !**********************************************************************
       use mod_xc,         only: mnproc
       use mod_dia,        only: ddm
-      use mo_carbch,      only: atm,atmflx,co2fxd,co2fxu,co3,hi,kwco2sol,ndepflx,rivinflx,ocetra,omegaa,omegac,pco2d,satoxy,sedfluxo
+      use mo_carbch,      only: atm,atmflx,co2fxd,co2fxu,co3,hi,kwco2sol,ndepflx,rivinflx,ocetra,omegaa,omegac,pco2d,satoxy,       &
+                              & sedfluxo,pco2m,kwco2d,co2sold,co2solm
       use mo_biomod,      only: bsiflx_bot,bsiflx0100,bsiflx0500,bsiflx1000,bsiflx2000,bsiflx4000,calflx_bot,calflx0100,calflx0500,&
                               & calflx1000,calflx2000,calflx4000,carflx_bot,carflx0100,carflx0500,carflx1000,carflx2000,carflx4000,&
                               & expoca,expoor,exposi,intdms_bac,intdms_uv,intdmsprod,intdnit,intnfix,intphosy,phosy3d
@@ -63,7 +64,8 @@
                               & jlvlph,jlvlphosph,jlvlphosy,jlvlphyto,jlvlphyto13,jlvlpoc,jlvlpoc13,jlvlprefalk,jlvlprefdic,       &
                               & jlvlprefo2,jlvlprefpo4,jlvlsf6,jlvlsilica,jlvlwnos,jlvlwphy,jn2flux,jn2o,jn2oflux,jn2ofx,          &
                               & jprorca,jprcaca,jsilpro,jpodiic,jpodial,jpodiph,jpodiox,jpodin2,jpodino3,jpodisi,jndep,            &
-                              & jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,jph,jphosph,jphosy,jphyto, &
+                              & jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,jpco2m,jkwco2khd,jco2khd,  &
+                              & jco2kh,jph,jphosph,jphosy,jphyto,                                                                  & 
                               & jpoc,jprefalk,jprefdic,jprefo2,jprefpo4,jsilica,jsrfalkali,jsrfano3,jsrfdic,jsrfiron,jsrfoxygen,   &
                               & jsrfphosph,jsrfphyto,jsrfsilica,jwnos,jwphy,nbgc,nacc_bgc,bgcwrt,glb_inventory,bgct2d,acclvl,      &
                               & acclyr,accsrf,bgczlv
@@ -227,7 +229,11 @@
 
 ! Accumulate 2d diagnostics
       call accsrf(jpco2,pco2d,omask,0)
-      call accsrf(jkwco2,kwco2sol,omask,0)
+      call accsrf(jpco2m,pco2m,omask,0)
+      call accsrf(jkwco2khd,kwco2sol,omask,0)
+      call accsrf(jkwco2,kwco2d,omask,0)
+      call accsrf(jco2khd,co2sold,omask,0)
+      call accsrf(jco2kh,co2solm,omask,0)
       call accsrf(jsrfphosph,ocetra(1,1,1,iphosph),omask,0)
       call accsrf(jsrfoxygen,ocetra(1,1,1,ioxygen),omask,0)
       call accsrf(jsrfiron,ocetra(1,1,1,iiron),omask,0)

--- a/hamocc/carchm.F90
+++ b/hamocc/carchm.F90
@@ -530,7 +530,7 @@
 #endif
 
 ! Save product of piston velocity and solubility for output
-       kwco2sol(i,j) = kwco2*Kh*1e-6 !(WHY 1e-6???)
+       kwco2sol(i,j) = kwco2*Kh*1e-6 !m/s mol/kg/muatm 
        kwco2d(i,j)   = kwco2 ! m/s (incl. ice fraction!)
        co2sold(i,j)  = Khd  ! mol/kg/atm
        co2solm(i,j)  = Kh   ! mol/kg/atm

--- a/hamocc/carchm.F90
+++ b/hamocc/carchm.F90
@@ -94,7 +94,8 @@
 !     none.
 !
 !**********************************************************************
-      use mo_carbch,      only: atm,atmflx,co2fxd,co2fxu,co2star,co3,hi,keqb,kwco2sol,ocetra,omegaa,omegac,pco2d,satn2o,satoxy
+      use mo_carbch,      only: atm,atmflx,co2fxd,co2fxu,co2star,co3,hi,keqb,kwco2sol,ocetra,omegaa,omegac,pco2d,satn2o,satoxy,    &
+                                pco2m,kwco2d,co2sold,co2solm
       use mo_chemcon,     only: al1,al2,al3,al4,an0,an1,an2,an3,an4,an5,an6,atn2o,bl1,bl2,bl3,calcon,ox0,ox1,ox2,ox3,ox4,ox5,ox6,  &
                               & oxyco,tzero
       use mo_control_bgc, only: dtbgc
@@ -180,7 +181,11 @@
        co214fxd (:,:)=0.
        co214fxu (:,:)=0.
 #endif
-       pco2d    (:,:)=0. 
+       pco2d    (:,:)=0.
+       pco2m    (:,:)=0.
+       kwco2d    (:,:)=0.
+       co2sold  (:,:)=0.
+       co2solm  (:,:)=0.
        kwco2sol (:,:)=0.
        co2star(:,:,:)=0.
        co3    (:,:,:)=0.
@@ -518,13 +523,17 @@
 
 ! Save pco2 w.r.t. dry air for output
        pco2d(i,j) = cu * 1.e6 / Khd
+       !pCO2 wrt moist air
+       pco2m(i,j) = cu * 1.e6 / Kh
 #ifdef natDIC
        natpco2d(i,j) = natcu * 1.e6 / Khd
 #endif
 
 ! Save product of piston velocity and solubility for output
-       kwco2sol(i,j) = kwco2*Kh*1e-6
-
+       kwco2sol(i,j) = kwco2*Kh*1e-6 !(WHY 1e-6???)
+       kwco2d(i,j)    = kwco2 ! m/s (incl. ice fraction!)
+       co2sold(i,j)  = Khd  ! mol/kg/atm
+       co2solm(i,j)  = Kh   ! mol/kg/atm
 
       endif ! k==1
 #ifdef BROMO

--- a/hamocc/carchm.F90
+++ b/hamocc/carchm.F90
@@ -183,7 +183,7 @@
 #endif
        pco2d    (:,:)=0.
        pco2m    (:,:)=0.
-       kwco2d    (:,:)=0.
+       kwco2d   (:,:)=0.
        co2sold  (:,:)=0.
        co2solm  (:,:)=0.
        kwco2sol (:,:)=0.

--- a/hamocc/carchm.F90
+++ b/hamocc/carchm.F90
@@ -531,7 +531,7 @@
 
 ! Save product of piston velocity and solubility for output
        kwco2sol(i,j) = kwco2*Kh*1e-6 !(WHY 1e-6???)
-       kwco2d(i,j)    = kwco2 ! m/s (incl. ice fraction!)
+       kwco2d(i,j)   = kwco2 ! m/s (incl. ice fraction!)
        co2sold(i,j)  = Khd  ! mol/kg/atm
        co2solm(i,j)  = Kh   ! mol/kg/atm
 

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -76,6 +76,8 @@
 ! --- Namelist for diagnostic output 
       INTEGER, DIMENSION(nbgcmax), SAVE ::                              &
      & SRF_KWCO2     =0    ,SRF_PCO2      =0    ,SRF_DMSFLUX   =0    ,  &
+     & SRF_KWCO2KHD  =0    ,SRF_CO2KH     =0    ,SRF_CO2KHD    =0    ,  &
+     & SRF_PCO2M     =0    ,                                            &
      & SRF_CO2FXD    =0    ,SRF_CO2FXU    =0    ,SRF_CO213FXD  =0    ,  &
      & SRF_CO213FXU  =0    ,SRF_CO214FXD  =0    ,SRF_CO214FXU  =0    ,  &
      & SRF_OXFLUX    =0    ,SRF_NIFLUX    =0    ,SRF_DMS       =0    ,  &
@@ -150,6 +152,8 @@
       CHARACTER(LEN=10), DIMENSION(nbgcmax), SAVE :: GLB_FNAMETAG
       namelist /DIABGC/                                                 &
      & SRF_KWCO2         ,SRF_PCO2          ,SRF_DMSFLUX       ,        &
+     & SRF_KWCO2KHD      ,SRF_CO2KH         ,SRF_CO2KHD        ,        &
+     & SRF_PCO2M         ,                                              &
      & SRF_CO2FXD        ,SRF_CO2FXU        ,SRF_CO213FXD      ,        &
      & SRF_CO213FXU      ,SRF_CO214FXD      ,SRF_CO214FXU      ,        &
      & SRF_OXFLUX        ,SRF_NIFLUX        ,SRF_DMS           ,        &
@@ -255,7 +259,11 @@
       INTEGER, SAVE :: i_bsc_m2d 
       INTEGER, DIMENSION(nbgcmax), SAVE ::                              &
      &          jkwco2     = 0 ,                                        &
+     &          jkwco2khd  = 0 ,                                        &
+     &          jco2khd    = 0 ,                                        &
+     &          jco2kh     = 0 ,                                        &
      &          jpco2      = 0 ,                                        &
+     &          jpco2m     = 0 ,                                        &
      &          jdmsflux   = 0 ,                                        &
      &          jco2fxd    = 0 ,                                        &
      &          jco2fxu    = 0 ,                                        &
@@ -560,8 +568,16 @@
       DO n=1,nbgc  
         IF (SRF_KWCO2(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jkwco2(n)=i_bsc_m2d*min(1,SRF_KWCO2(n))
+        IF (SRF_KWCO2KHD(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jkwco2khd(n)=i_bsc_m2d*min(1,SRF_KWCO2KHD(n))
+        IF (SRF_CO2KHD(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jco2khd(n)=i_bsc_m2d*min(1,SRF_CO2KHD(n))
+        IF (SRF_CO2KH(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jco2kh(n)=i_bsc_m2d*min(1,SRF_CO2KH(n))
         IF (SRF_PCO2(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jpco2(n)=i_bsc_m2d*min(1,SRF_PCO2(n))
+        IF (SRF_PCO2M(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jpco2m(n)=i_bsc_m2d*min(1,SRF_PCO2M(n))
         IF (SRF_DMSFLUX(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jdmsflux(n)=i_bsc_m2d*min(1,SRF_DMSFLUX(n))
         IF (SRF_CO2FXD(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -76,7 +76,7 @@
 ! --- Namelist for diagnostic output 
       INTEGER, DIMENSION(nbgcmax), SAVE ::                              &
      & SRF_KWCO2     =0    ,SRF_PCO2      =0    ,SRF_DMSFLUX   =0    ,  &
-     & SRF_KWCO2KH   =0    ,SRF_CO2KH     =0    ,SRF_CO2KHD    =0    ,  &
+     & SRF_KWCO2KHM  =0    ,SRF_CO2KHM    =0    ,SRF_CO2KH     =0    ,  &
      & SRF_PCO2M     =0    ,                                            &
      & SRF_CO2FXD    =0    ,SRF_CO2FXU    =0    ,SRF_CO213FXD  =0    ,  &
      & SRF_CO213FXU  =0    ,SRF_CO214FXD  =0    ,SRF_CO214FXU  =0    ,  &
@@ -152,7 +152,7 @@
       CHARACTER(LEN=10), DIMENSION(nbgcmax), SAVE :: GLB_FNAMETAG
       namelist /DIABGC/                                                 &
      & SRF_KWCO2         ,SRF_PCO2          ,SRF_DMSFLUX       ,        &
-     & SRF_KWCO2KH       ,SRF_CO2KH         ,SRF_CO2KHD        ,        &
+     & SRF_KWCO2KHM      ,SRF_CO2KHM        ,SRF_CO2KH         ,        &
      & SRF_PCO2M         ,                                              &
      & SRF_CO2FXD        ,SRF_CO2FXU        ,SRF_CO213FXD      ,        &
      & SRF_CO213FXU      ,SRF_CO214FXD      ,SRF_CO214FXU      ,        &
@@ -259,9 +259,9 @@
       INTEGER, SAVE :: i_bsc_m2d 
       INTEGER, DIMENSION(nbgcmax), SAVE ::                              &
      &          jkwco2     = 0 ,                                        &
-     &          jkwco2kh   = 0 ,                                        &
-     &          jco2khd    = 0 ,                                        &
+     &          jkwco2khm  = 0 ,                                        &
      &          jco2kh     = 0 ,                                        &
+     &          jco2khm    = 0 ,                                        &
      &          jpco2      = 0 ,                                        &
      &          jpco2m     = 0 ,                                        &
      &          jdmsflux   = 0 ,                                        &
@@ -568,12 +568,12 @@
       DO n=1,nbgc  
         IF (SRF_KWCO2(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jkwco2(n)=i_bsc_m2d*min(1,SRF_KWCO2(n))
-        IF (SRF_KWCO2KH(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
-        jkwco2kh(n)=i_bsc_m2d*min(1,SRF_KWCO2KH(n))
-        IF (SRF_CO2KHD(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
-        jco2khd(n)=i_bsc_m2d*min(1,SRF_CO2KHD(n))
+        IF (SRF_KWCO2KHM(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jkwco2khm(n)=i_bsc_m2d*min(1,SRF_KWCO2KHM(n))
         IF (SRF_CO2KH(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jco2kh(n)=i_bsc_m2d*min(1,SRF_CO2KH(n))
+        IF (SRF_CO2KHM(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jco2khm(n)=i_bsc_m2d*min(1,SRF_CO2KHM(n))
         IF (SRF_PCO2(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jpco2(n)=i_bsc_m2d*min(1,SRF_PCO2(n))
         IF (SRF_PCO2M(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -76,7 +76,7 @@
 ! --- Namelist for diagnostic output 
       INTEGER, DIMENSION(nbgcmax), SAVE ::                              &
      & SRF_KWCO2     =0    ,SRF_PCO2      =0    ,SRF_DMSFLUX   =0    ,  &
-     & SRF_KWCO2KHD  =0    ,SRF_CO2KH     =0    ,SRF_CO2KHD    =0    ,  &
+     & SRF_KWCO2KH   =0    ,SRF_CO2KH     =0    ,SRF_CO2KHD    =0    ,  &
      & SRF_PCO2M     =0    ,                                            &
      & SRF_CO2FXD    =0    ,SRF_CO2FXU    =0    ,SRF_CO213FXD  =0    ,  &
      & SRF_CO213FXU  =0    ,SRF_CO214FXD  =0    ,SRF_CO214FXU  =0    ,  &
@@ -152,7 +152,7 @@
       CHARACTER(LEN=10), DIMENSION(nbgcmax), SAVE :: GLB_FNAMETAG
       namelist /DIABGC/                                                 &
      & SRF_KWCO2         ,SRF_PCO2          ,SRF_DMSFLUX       ,        &
-     & SRF_KWCO2KHD      ,SRF_CO2KH         ,SRF_CO2KHD        ,        &
+     & SRF_KWCO2KH       ,SRF_CO2KH         ,SRF_CO2KHD        ,        &
      & SRF_PCO2M         ,                                              &
      & SRF_CO2FXD        ,SRF_CO2FXU        ,SRF_CO213FXD      ,        &
      & SRF_CO213FXU      ,SRF_CO214FXD      ,SRF_CO214FXU      ,        &
@@ -259,7 +259,7 @@
       INTEGER, SAVE :: i_bsc_m2d 
       INTEGER, DIMENSION(nbgcmax), SAVE ::                              &
      &          jkwco2     = 0 ,                                        &
-     &          jkwco2khd  = 0 ,                                        &
+     &          jkwco2kh   = 0 ,                                        &
      &          jco2khd    = 0 ,                                        &
      &          jco2kh     = 0 ,                                        &
      &          jpco2      = 0 ,                                        &
@@ -568,8 +568,8 @@
       DO n=1,nbgc  
         IF (SRF_KWCO2(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jkwco2(n)=i_bsc_m2d*min(1,SRF_KWCO2(n))
-        IF (SRF_KWCO2KHD(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
-        jkwco2khd(n)=i_bsc_m2d*min(1,SRF_KWCO2KHD(n))
+        IF (SRF_KWCO2KH(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
+        jkwco2kh(n)=i_bsc_m2d*min(1,SRF_KWCO2KH(n))
         IF (SRF_CO2KHD(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 
         jco2khd(n)=i_bsc_m2d*min(1,SRF_CO2KHD(n))
         IF (SRF_CO2KH(n).GT.0) i_bsc_m2d=i_bsc_m2d+1 

--- a/hamocc/mo_carbch.F90
+++ b/hamocc/mo_carbch.F90
@@ -74,7 +74,11 @@
       REAL, DIMENSION (:,:,:),   ALLOCATABLE :: sedfluxo
 
       REAL, DIMENSION (:,:),     ALLOCATABLE :: pco2d
+      REAL, DIMENSION (:,:),     ALLOCATABLE :: pco2m
       REAL, DIMENSION (:,:),     ALLOCATABLE :: kwco2sol
+      REAL, DIMENSION (:,:),     ALLOCATABLE :: kwco2d
+      REAL, DIMENSION (:,:),     ALLOCATABLE :: co2sold
+      REAL, DIMENSION (:,:),     ALLOCATABLE :: co2solm
       REAL, DIMENSION (:,:),     ALLOCATABLE :: co2fxd
       REAL, DIMENSION (:,:),     ALLOCATABLE :: co2fxu
 #ifdef cisonew
@@ -334,12 +338,51 @@
       if(errstat.ne.0) stop 'not enough memory pco2d'
       pco2d(:,:) = 0.0
 
+      IF (mnproc.eq.1) THEN
+      WRITE(io_stdo_bgc,*)'Memory allocation for variable pco2m ...'
+      WRITE(io_stdo_bgc,*)'First dimension    : ',kpie
+      WRITE(io_stdo_bgc,*)'Second dimension   : ',kpje
+      ENDIF
+
+      ALLOCATE (pco2m(kpie,kpje),stat=errstat)
+      if(errstat.ne.0) stop 'not enough memory pco2m'
+      pco2m(:,:) = 0.0
+
+      IF (mnproc.eq.1) THEN
+      WRITE(io_stdo_bgc,*)'Memory allocation for variable kwco2d ...'
+      WRITE(io_stdo_bgc,*)'First dimension    : ',kpie
+      WRITE(io_stdo_bgc,*)'Second dimension   : ',kpje
+      ENDIF
+
+      ALLOCATE (kwco2d(kpie,kpje),stat=errstat)
+      if(errstat.ne.0) stop 'not enough memory kwco2d'
+      kwco2d(:,:) = 0.0
 
       IF (mnproc.eq.1) THEN
       WRITE(io_stdo_bgc,*)'Memory allocation for variable kwco2sol ...'
       WRITE(io_stdo_bgc,*)'First dimension    : ',kpie
       WRITE(io_stdo_bgc,*)'Second dimension   : ',kpje
       ENDIF
+      
+      IF (mnproc.eq.1) THEN
+      WRITE(io_stdo_bgc,*)'Memory allocation for variable co2sold ...'
+      WRITE(io_stdo_bgc,*)'First dimension    : ',kpie
+      WRITE(io_stdo_bgc,*)'Second dimension   : ',kpje
+      ENDIF
+
+      ALLOCATE (co2sold(kpie,kpje),stat=errstat)
+      if(errstat.ne.0) stop 'not enough memory co2sold'
+      co2sold(:,:) = 0.0
+      
+      IF (mnproc.eq.1) THEN
+      WRITE(io_stdo_bgc,*)'Memory allocation for variable co2solm ...'
+      WRITE(io_stdo_bgc,*)'First dimension    : ',kpie
+      WRITE(io_stdo_bgc,*)'Second dimension   : ',kpje
+      ENDIF
+
+      ALLOCATE (co2solm(kpie,kpje),stat=errstat)
+      if(errstat.ne.0) stop 'not enough memory co2solm'
+      co2solm(:,:) = 0.0
 
       ALLOCATE (kwco2sol(kpie,kpje),stat=errstat)
       if(errstat.ne.0) stop 'not enough memory co2fxd,co2fxu'

--- a/hamocc/ncout_hamocc.F90
+++ b/hamocc/ncout_hamocc.F90
@@ -75,7 +75,7 @@ subroutine ncwrt_bgc(iogrp)
        &                    jlvlwnos,jlvlwphy,jn2flux,jn2o,jn2oflux,            &
        &                    jn2ofx,jndep,jniflux,jnos,jo2flux,jo2sat,           &
        &                    jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,        &
-       &                    jpco2m,jkwco2kh,jco2khd,jco2kh,                     &
+       &                    jpco2m,jkwco2khm,jco2kh,jco2khm,                    &
        &                    jph,jphosph,jphosy,jphyto,jpoc,jprefalk,            &
        &                    jprefdic,jprefo2,jprefpo4,jsilica,                  &
        &                    jsrfalkali,jsrfano3,jsrfdic,jsrfiron,               &
@@ -96,7 +96,7 @@ subroutine ncwrt_bgc(iogrp)
        &                    lvl_n2o,lvl_prefo2,lvl_o2sat,lvl_prefpo4,           &
        &                    lvl_prefalk,lvl_prefdic,lvl_dicsat,                 &
        &                    lvl_o2sat,srf_n2ofx,srf_atmco2,srf_kwco2,           &
-       &                    srf_kwco2kh,srf_co2khd,srf_co2kh,srf_pco2m,         &
+       &                    srf_kwco2khm,srf_co2kh,srf_co2khm,srf_pco2m,        &
        &                    srf_pco2,srf_dmsflux,srf_co2fxd,                    &
        &                    srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,           &
        &                    srf_dmsprod,srf_dms_bac,srf_dms_uv,                 &
@@ -395,12 +395,13 @@ subroutine ncwrt_bgc(iogrp)
   ! --- Store 2d fields
   call wrtsrf(jkwco2(iogrp),SRF_KWCO2(iogrp),rnacc,0.,cmpflg,                   &
        &   'kwco2','CO2 piston velocity',' ','m s-1')
-  call wrtsrf(jkwco2kh(iogrp),SRF_KWCO2KH(iogrp),rnacc,0.,cmpflg,               &
-       &   'kwco2kh','CO2 piston velocity times solubility (moist air)',' ','m s-1 mol kg-1 atm-1')
-  call wrtsrf(jco2khd(iogrp),SRF_CO2KHD(iogrp),rnacc,0.,cmpflg,                 &
-       &   'co2khd','CO2 solubility (dry air) ',' ','mol kg-1 atm-1')
+  call wrtsrf(jkwco2khm(iogrp),SRF_KWCO2KHM(iogrp),rnacc,0.,cmpflg,             &
+       &   'kwco2khm','CO2 piston velocity times solubility (moist air)',' ',   &
+       &   'm s-1 mol kg-1 muatm-1')
   call wrtsrf(jco2kh(iogrp),SRF_CO2KH(iogrp),rnacc,0.,cmpflg,                   &
-       &   'co2kh','CO2 solubility (moist air) ',' ','mol kg-1 atm-1')
+       &   'co2kh','CO2 solubility (dry air) ',' ','mol kg-1 atm-1')
+  call wrtsrf(jco2khm(iogrp),SRF_CO2KHM(iogrp),rnacc,0.,cmpflg,                 &
+       &   'co2khm','CO2 solubility (moist air) ',' ','mol kg-1 atm-1')
   call wrtsrf(jpco2(iogrp),SRF_PCO2(iogrp),rnacc,0.,cmpflg,                     &
        &   'pco2','Surface PCO2',' ','uatm')
   call wrtsrf(jpco2m(iogrp),SRF_PCO2M(iogrp),rnacc,0.,cmpflg,                   &
@@ -887,9 +888,9 @@ subroutine ncwrt_bgc(iogrp)
 
   ! --- Initialise fields
   call inisrf(jkwco2(iogrp),0.)
-  call inisrf(jkwco2kh(iogrp),0.)
-  call inisrf(jco2khd(iogrp),0.)
+  call inisrf(jkwco2khm(iogrp),0.)
   call inisrf(jco2kh(iogrp),0.)
+  call inisrf(jco2khm(iogrp),0.)
   call inisrf(jpco2(iogrp),0.)
   call inisrf(jpco2m(iogrp),0.)
   call inisrf(jdmsflux(iogrp),0.)
@@ -1133,7 +1134,7 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
        &   nctime,ncfcls,ncedef,ncdefvar3d,ndouble
 
   use mo_bgcmean, only: srf_kwco2,srf_pco2,srf_dmsflux,srf_co2fxd,              &
-       &   srf_kwco2kh,srf_co2khd,srf_co2kh,srf_pco2m,                          &
+       &   srf_kwco2khm,srf_co2kh,srf_co2khm,srf_pco2m,                         &
        &   srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,srf_dmsprod,                &
        &   srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
        &   srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
@@ -1211,12 +1212,13 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
   call ncdefvar('depth_bnds','bounds depth',ndouble,8)
   call ncdefvar3d(SRF_KWCO2(iogrp),cmpflg,'p',                                  &
        &   'kwco2','CO2 piston velocity',' ','m s-1',0)
-  call ncdefvar3d(SRF_KWCO2KH(iogrp),cmpflg,'p',                                &
-       &   'kwco2kh','CO2 piston velocity times solubility (moist air)',' ','m s-1 mol kg-1 atm-1',0)
-  call ncdefvar3d(SRF_CO2KHD(iogrp),cmpflg,'p',                                 &
-       &   'co2khd','CO2 solubility (dry air)',' ','mol kg-1 atm-1',0)
+  call ncdefvar3d(SRF_KWCO2KHM(iogrp),cmpflg,'p',                               &
+       &   'kwco2khm','CO2 piston velocity times solubility (moist air)',' ',   &
+       &   'm s-1 mol kg-1 muatm-1',0)
   call ncdefvar3d(SRF_CO2KH(iogrp),cmpflg,'p',                                  &
-       &   'co2kh','CO2 solubility (moist air)',' ','mol kg-1 atm-1',0)
+       &   'co2kh','CO2 solubility (dry air)',' ','mol kg-1 atm-1',0)
+  call ncdefvar3d(SRF_CO2KHM(iogrp),cmpflg,'p',                                 &
+       &   'co2khm','CO2 solubility (moist air)',' ','mol kg-1 atm-1',0)
   call ncdefvar3d(SRF_PCO2(iogrp),cmpflg,'p',                                   &
        &   'pco2','Surface PCO2',' ','uatm',0)
   call ncdefvar3d(SRF_PCO2M(iogrp),cmpflg,'p',                                  &

--- a/hamocc/ncout_hamocc.F90
+++ b/hamocc/ncout_hamocc.F90
@@ -75,6 +75,7 @@ subroutine ncwrt_bgc(iogrp)
        &                    jlvlwnos,jlvlwphy,jn2flux,jn2o,jn2oflux,            &
        &                    jn2ofx,jndep,jniflux,jnos,jo2flux,jo2sat,           &
        &                    jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,        &
+       &                    jpco2m,jkwco2khd,jco2khd,jco2kh,                    &
        &                    jph,jphosph,jphosy,jphyto,jpoc,jprefalk,            &
        &                    jprefdic,jprefo2,jprefpo4,jsilica,                  &
        &                    jsrfalkali,jsrfano3,jsrfdic,jsrfiron,               &
@@ -95,6 +96,7 @@ subroutine ncwrt_bgc(iogrp)
        &                    lvl_n2o,lvl_prefo2,lvl_o2sat,lvl_prefpo4,           &
        &                    lvl_prefalk,lvl_prefdic,lvl_dicsat,                 &
        &                    lvl_o2sat,srf_n2ofx,srf_atmco2,srf_kwco2,           &
+       &                    srf_kwco2khd,srf_co2khd,srf_co2kh,srf_pco2m,        &
        &                    srf_pco2,srf_dmsflux,srf_co2fxd,                    &
        &                    srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,           &
        &                    srf_dmsprod,srf_dms_bac,srf_dms_uv,                 &
@@ -392,9 +394,17 @@ subroutine ncwrt_bgc(iogrp)
 
   ! --- Store 2d fields
   call wrtsrf(jkwco2(iogrp),SRF_KWCO2(iogrp),rnacc,0.,cmpflg,                   &
-       &   'kwco2',' ',' ',' ')
+       &   'kwco2','CO2 piston velocity',' ','m s-1')
+  call wrtsrf(jkwco2khd(iogrp),SRF_KWCO2KHD(iogrp),rnacc,0.,cmpflg,             &
+       &   'kwco2khd','CO2 piston velocity times solubility (dry air)',' ','m s-1 mol kg-1 atm-1')
+  call wrtsrf(jco2khd(iogrp),SRF_CO2KHD(iogrp),rnacc,0.,cmpflg,                 &
+       &   'co2khd','CO2 solubility (dry air) ',' ','mol kg-1 atm-1')
+  call wrtsrf(jco2kh(iogrp),SRF_CO2KH(iogrp),rnacc,0.,cmpflg,                   &
+       &   'co2kh','CO2 solubility (moist air) ',' ','mol kg-1 atm-1')
   call wrtsrf(jpco2(iogrp),SRF_PCO2(iogrp),rnacc,0.,cmpflg,                     &
        &   'pco2','Surface PCO2',' ','uatm')
+  call wrtsrf(jpco2m(iogrp),SRF_PCO2M(iogrp),rnacc,0.,cmpflg,                   &
+       &   'pco2m','Surface PCO2 (moist air)',' ','uatm')
   call wrtsrf(jdmsflux(iogrp),SRF_DMSFLUX(iogrp),rnacc*1e3/dtbgc,0.,            &
        &   cmpflg,'dmsflux','DMS flux',' ','mol DMS m-2 s-1')
   call wrtsrf(jco2fxd(iogrp),SRF_CO2FXD(iogrp),rnacc*12./dtbgc,0.,              &
@@ -877,7 +887,11 @@ subroutine ncwrt_bgc(iogrp)
 
   ! --- Initialise fields
   call inisrf(jkwco2(iogrp),0.)
+  call inisrf(jkwco2khd(iogrp),0.)
+  call inisrf(jco2khd(iogrp),0.)
+  call inisrf(jco2kh(iogrp),0.)
   call inisrf(jpco2(iogrp),0.)
+  call inisrf(jpco2m(iogrp),0.)
   call inisrf(jdmsflux(iogrp),0.)
   call inisrf(jco2fxd(iogrp),0.)
   call inisrf(jco2fxu(iogrp),0.)
@@ -1119,6 +1133,7 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
        &   nctime,ncfcls,ncedef,ncdefvar3d,ndouble
 
   use mo_bgcmean, only: srf_kwco2,srf_pco2,srf_dmsflux,srf_co2fxd,              &
+       &   srf_kwco2khd,srf_co2khd,srf_co2kh,srf_pco2m,                         &
        &   srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,srf_dmsprod,                &
        &   srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
        &   srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
@@ -1195,9 +1210,17 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
   call ncattr('bounds','depth_bnds')
   call ncdefvar('depth_bnds','bounds depth',ndouble,8)
   call ncdefvar3d(SRF_KWCO2(iogrp),cmpflg,'p',                                  &
-       &   'kwco2',' ',' ',' ',0)
+       &   'kwco2','CO2 piston velocity',' ','m s-1',0)
+  call ncdefvar3d(SRF_KWCO2KHD(iogrp),cmpflg,'p',                                  &
+       &   'kwco2khd','CO2 piston velocity times solubility (dry air)',' ','m s-1 mol kg-1 atm-1',0)
+  call ncdefvar3d(SRF_CO2KHD(iogrp),cmpflg,'p',                                  &
+       &   'co2khd','CO2 solubility (dry air)',' ','mol kg-1 atm-1',0)
+  call ncdefvar3d(SRF_CO2KH(iogrp),cmpflg,'p',                                  &
+       &   'co2kh','CO2 solubility (moist air)',' ','mol kg-1 atm-1',0)
   call ncdefvar3d(SRF_PCO2(iogrp),cmpflg,'p',                                   &
        &   'pco2','Surface PCO2',' ','uatm',0)
+  call ncdefvar3d(SRF_PCO2M(iogrp),cmpflg,'p',                                   &
+       &   'pco2m','Surface PCO2 (moist air)',' ','uatm',0)
   call ncdefvar3d(SRF_DMSFLUX(iogrp),                                           &
        &   cmpflg,'p','dmsflux','DMS flux',' ','mol DMS m-2 s-1',0)
   call ncdefvar3d(SRF_CO2FXD(iogrp),                                            &

--- a/hamocc/ncout_hamocc.F90
+++ b/hamocc/ncout_hamocc.F90
@@ -1133,7 +1133,7 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
        &   nctime,ncfcls,ncedef,ncdefvar3d,ndouble
 
   use mo_bgcmean, only: srf_kwco2,srf_pco2,srf_dmsflux,srf_co2fxd,              &
-       &   srf_kwco2kh,srf_co2khd,srf_co2kh,srf_pco2m,                         &
+       &   srf_kwco2kh,srf_co2khd,srf_co2kh,srf_pco2m,                          &
        &   srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,srf_dmsprod,                &
        &   srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
        &   srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
@@ -1211,15 +1211,15 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
   call ncdefvar('depth_bnds','bounds depth',ndouble,8)
   call ncdefvar3d(SRF_KWCO2(iogrp),cmpflg,'p',                                  &
        &   'kwco2','CO2 piston velocity',' ','m s-1',0)
-  call ncdefvar3d(SRF_KWCO2KH(iogrp),cmpflg,'p',                                  &
+  call ncdefvar3d(SRF_KWCO2KH(iogrp),cmpflg,'p',                                &
        &   'kwco2kh','CO2 piston velocity times solubility (moist air)',' ','m s-1 mol kg-1 atm-1',0)
-  call ncdefvar3d(SRF_CO2KHD(iogrp),cmpflg,'p',                                  &
+  call ncdefvar3d(SRF_CO2KHD(iogrp),cmpflg,'p',                                 &
        &   'co2khd','CO2 solubility (dry air)',' ','mol kg-1 atm-1',0)
   call ncdefvar3d(SRF_CO2KH(iogrp),cmpflg,'p',                                  &
        &   'co2kh','CO2 solubility (moist air)',' ','mol kg-1 atm-1',0)
   call ncdefvar3d(SRF_PCO2(iogrp),cmpflg,'p',                                   &
        &   'pco2','Surface PCO2',' ','uatm',0)
-  call ncdefvar3d(SRF_PCO2M(iogrp),cmpflg,'p',                                   &
+  call ncdefvar3d(SRF_PCO2M(iogrp),cmpflg,'p',                                  &
        &   'pco2m','Surface PCO2 (moist air)',' ','uatm',0)
   call ncdefvar3d(SRF_DMSFLUX(iogrp),                                           &
        &   cmpflg,'p','dmsflux','DMS flux',' ','mol DMS m-2 s-1',0)

--- a/hamocc/ncout_hamocc.F90
+++ b/hamocc/ncout_hamocc.F90
@@ -75,7 +75,7 @@ subroutine ncwrt_bgc(iogrp)
        &                    jlvlwnos,jlvlwphy,jn2flux,jn2o,jn2oflux,            &
        &                    jn2ofx,jndep,jniflux,jnos,jo2flux,jo2sat,           &
        &                    jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,        &
-       &                    jpco2m,jkwco2khd,jco2khd,jco2kh,                    &
+       &                    jpco2m,jkwco2kh,jco2khd,jco2kh,                     &
        &                    jph,jphosph,jphosy,jphyto,jpoc,jprefalk,            &
        &                    jprefdic,jprefo2,jprefpo4,jsilica,                  &
        &                    jsrfalkali,jsrfano3,jsrfdic,jsrfiron,               &
@@ -96,7 +96,7 @@ subroutine ncwrt_bgc(iogrp)
        &                    lvl_n2o,lvl_prefo2,lvl_o2sat,lvl_prefpo4,           &
        &                    lvl_prefalk,lvl_prefdic,lvl_dicsat,                 &
        &                    lvl_o2sat,srf_n2ofx,srf_atmco2,srf_kwco2,           &
-       &                    srf_kwco2khd,srf_co2khd,srf_co2kh,srf_pco2m,        &
+       &                    srf_kwco2kh,srf_co2khd,srf_co2kh,srf_pco2m,         &
        &                    srf_pco2,srf_dmsflux,srf_co2fxd,                    &
        &                    srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,           &
        &                    srf_dmsprod,srf_dms_bac,srf_dms_uv,                 &
@@ -395,8 +395,8 @@ subroutine ncwrt_bgc(iogrp)
   ! --- Store 2d fields
   call wrtsrf(jkwco2(iogrp),SRF_KWCO2(iogrp),rnacc,0.,cmpflg,                   &
        &   'kwco2','CO2 piston velocity',' ','m s-1')
-  call wrtsrf(jkwco2khd(iogrp),SRF_KWCO2KHD(iogrp),rnacc,0.,cmpflg,             &
-       &   'kwco2khd','CO2 piston velocity times solubility (dry air)',' ','m s-1 mol kg-1 atm-1')
+  call wrtsrf(jkwco2kh(iogrp),SRF_KWCO2KH(iogrp),rnacc,0.,cmpflg,               &
+       &   'kwco2kh','CO2 piston velocity times solubility (moist air)',' ','m s-1 mol kg-1 atm-1')
   call wrtsrf(jco2khd(iogrp),SRF_CO2KHD(iogrp),rnacc,0.,cmpflg,                 &
        &   'co2khd','CO2 solubility (dry air) ',' ','mol kg-1 atm-1')
   call wrtsrf(jco2kh(iogrp),SRF_CO2KH(iogrp),rnacc,0.,cmpflg,                   &
@@ -887,7 +887,7 @@ subroutine ncwrt_bgc(iogrp)
 
   ! --- Initialise fields
   call inisrf(jkwco2(iogrp),0.)
-  call inisrf(jkwco2khd(iogrp),0.)
+  call inisrf(jkwco2kh(iogrp),0.)
   call inisrf(jco2khd(iogrp),0.)
   call inisrf(jco2kh(iogrp),0.)
   call inisrf(jpco2(iogrp),0.)
@@ -1133,7 +1133,7 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
        &   nctime,ncfcls,ncedef,ncdefvar3d,ndouble
 
   use mo_bgcmean, only: srf_kwco2,srf_pco2,srf_dmsflux,srf_co2fxd,              &
-       &   srf_kwco2khd,srf_co2khd,srf_co2kh,srf_pco2m,                         &
+       &   srf_kwco2kh,srf_co2khd,srf_co2kh,srf_pco2m,                         &
        &   srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,srf_dmsprod,                &
        &   srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
        &   srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
@@ -1211,8 +1211,8 @@ subroutine hamoccvardef(iogrp,timeunits,calendar,cmpflg)
   call ncdefvar('depth_bnds','bounds depth',ndouble,8)
   call ncdefvar3d(SRF_KWCO2(iogrp),cmpflg,'p',                                  &
        &   'kwco2','CO2 piston velocity',' ','m s-1',0)
-  call ncdefvar3d(SRF_KWCO2KHD(iogrp),cmpflg,'p',                                  &
-       &   'kwco2khd','CO2 piston velocity times solubility (dry air)',' ','m s-1 mol kg-1 atm-1',0)
+  call ncdefvar3d(SRF_KWCO2KH(iogrp),cmpflg,'p',                                  &
+       &   'kwco2kh','CO2 piston velocity times solubility (moist air)',' ','m s-1 mol kg-1 atm-1',0)
   call ncdefvar3d(SRF_CO2KHD(iogrp),cmpflg,'p',                                  &
        &   'co2khd','CO2 solubility (dry air)',' ','mol kg-1 atm-1',0)
   call ncdefvar3d(SRF_CO2KH(iogrp),cmpflg,'p',                                  &

--- a/hamocc/ncout_hamocc.F90
+++ b/hamocc/ncout_hamocc.F90
@@ -397,7 +397,7 @@ subroutine ncwrt_bgc(iogrp)
        &   'kwco2','CO2 piston velocity',' ','m s-1')
   call wrtsrf(jkwco2khm(iogrp),SRF_KWCO2KHM(iogrp),rnacc,0.,cmpflg,             &
        &   'kwco2khm','CO2 piston velocity times solubility (moist air)',' ',   &
-       &   'm s-1 mol kg-1 muatm-1')
+       &   'm s-1 mol kg-1 uatm-1')
   call wrtsrf(jco2kh(iogrp),SRF_CO2KH(iogrp),rnacc,0.,cmpflg,                   &
        &   'co2kh','CO2 solubility (dry air) ',' ','mol kg-1 atm-1')
   call wrtsrf(jco2khm(iogrp),SRF_CO2KHM(iogrp),rnacc,0.,cmpflg,                 &


### PR DESCRIPTION
Hi Tomas, hi Jörg, 

I added output for pCO2 under moist air assumption (which can actually make quite some difference - up to ca. O(10ppm)), pure piston velocity, and solubility under dry and moist air assumption. There are two things to note, though:
1. the former `kwco2` now really only holds the Piston velocity (not times solubility anymore) - Piston times solubility (moist air, as before) is available via `kwco2kh` now. Does that change need some changes in any cmorization packages (which I am currently not fully aware of)?
2. I am uncertain, why `kwco2sol(i,j) = kwco2*Kh*1e-6`  (WHY 1e-6???, carchm l. 533) From my understanding, `kwco2` has units of m/s and `Kh` mol/kg/atm - so to which units were/is it converted to? Should it be per µatm?

Another thing might be, if we want to keep track of the air-pressure correction `rpp0` used for calculating CO2 fluxes (which affects the gas saturation).

Closes #31 
  