### PR TITLE
Correct unit of diagnostic field and make conservation and checksum diagnostics selectable by namelist options

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -123,6 +123,8 @@ set SPRFAC   = .false.
 set ATM_PATH = "'unset'"
 set ITEST    = 60
 set JTEST    = 60
+set CNSVDI   = .false.
+set CSDIAG   = .false.
 set RSTFRQ   =  1
 if ($PIO_NETCDF_FORMAT_OCN == 64bit_offset) then
   set RSTFMT   =  1
@@ -897,6 +899,8 @@ cat >! $RUNDIR/ocn_in$inststr << EOF
 !            'ben02syn' (a)
 ! ITEST    : Global i-index of point diagnostics (i)
 ! JTEST    : Global j-index of point diagnostics (i)
+! CNSVDI   : Conservation diagnostics flag (l)
+! CSDIAG   : Checksum diagnostics flag (l)
 ! RSTFRQ   : Restart frequency in days (30=1month,365=1year) (i)
 ! RSTFMT   : Format of restart file (valid arguments are 0 for classic,
 !            1 for 64-bit offset and 2 for netcdf4/hdf5 format) (i)
@@ -961,6 +965,8 @@ cat >! $RUNDIR/ocn_in$inststr << EOF
   ATM_PATH = $ATM_PATH
   ITEST    = $ITEST
   JTEST    = $JTEST
+  CNSVDI   = $CNSVDI
+  CSDIAG   = $CSDIAG
   RSTFRQ   = $RSTFRQ
   RSTFMT   = $RSTFMT
   RSTCMP   = $RSTCMP

--- a/phy/mod_budget.F90
+++ b/phy/mod_budget.F90
@@ -39,12 +39,14 @@ module mod_budget
 
    private
 
+   ! Options with default values, modifiable by namelist.
+   logical :: &
+      cnsvdi = .false. ! Flag that indicates whether conservation diagnostics
+                       ! are written.
+
    ! Constants.
    integer, parameter :: &
       ncalls = 7       ! Number of calls after which budgets are computed.
-   logical :: &
-      cnsvdi = .true.  ! Flag that indicates whether conservation diagnostics
-                       ! are written.
 
    real(r8), dimension(ncalls, 2) :: &
       sdp, &           ! Global mass weighted sum of salinity.

--- a/phy/mod_checksum.F90
+++ b/phy/mod_checksum.F90
@@ -26,7 +26,7 @@ module mod_checksum
 
    private
 
-   ! Constants.
+   ! Options with default values, modifiable by namelist.
    logical :: &
       csdiag = .false. ! Flag that indicates whether checksums are written.
 

--- a/phy/mod_dia.F
+++ b/phy/mod_dia.F
@@ -2919,7 +2919,7 @@ c
         call inilyr(ACC_UTILLYR(1),'p',0.)
         call acclyr(ACC_UTILLYR,dp(1-nbdy,1-nbdy,k1m),tmp3d,0,'p')
         call wrtlyr(ACC_UTILLYR(1),
-     .    max(LYR_IDLAGE(iogrp),LYR_TRC(iogrp)),1.,0.,cmpflg,ip,'p',
+     .    max(LYR_IDLAGE(iogrp),LYR_TRC(iogrp)),.1,0.,cmpflg,ip,'p',
      .    'dp_trc','Layer pressure thickness',' ','Pa')
       endif
 #  ifdef IDLAGE

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -57,6 +57,7 @@ c
       use mod_cesm, only: runid_cesm, ocn_cpl_dt_cesm, nstep_in_cpl,
      .                    smtfrc
       use mod_pointtest, only: itest, jtest
+      use mod_budget, only: cnsvdi
       use mod_checksum, only: csdiag
 c
       implicit none
@@ -71,13 +72,14 @@ c
      .  mdv2hi,mdv2lo,mdv4hi,mdv4lo,mdc2hi,mdc2lo,
      .  vsc2hi,vsc2lo,vsc4hi,vsc4lo,cbar,cb,cwbdts,cwbdls,
      .  mommth,bmcmth,rmpmth,mlrttp,
-     .  
      .  rm0,rm5,ce,tdfile,niwgf,niwbf,niwlf,
      .  swamth,jwtype,chlopt,ccfile,
      .  trxday,srxday,trxdpt,srxdpt,trxlim,srxlim,
      .  aptflx,apsflx,ditflx,disflx,srxbal,scfile,smtfrc,sprfac,
      .  atm_path,
      .  itest,jtest,
+     .  cnsvdi,
+     .  csdiag,
      .  rstfrq,rstfmt,rstcmp,iotype
 c
 c --- read limits namelist
@@ -163,6 +165,8 @@ c --- - print limits namelist to stdout
         write (lp,*) 'ATM_PATH ',trim(ATM_PATH)
         write (lp,*) 'ITEST',ITEST
         write (lp,*) 'JTEST',JTEST
+        write (lp,*) 'CNSVDI',CNSVDI
+        write (lp,*) 'CSDIAG',CSDIAG
         write (lp,*) 'RSTFRQ',RSTFRQ
         write (lp,*) 'RSTFMT',RSTFMT
         write (lp,*) 'RSTCMP',RSTCMP
@@ -231,6 +235,8 @@ c
       call xcbcst(atm_path)
       call xcbcst(itest)
       call xcbcst(jtest)
+      call xcbcst(cnsvdi)
+      call xcbcst(csdiag)
       call xcbcst(rstfrq)
       call xcbcst(rstfmt)
       call xcbcst(rstcmp)

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -79,6 +79,8 @@
 !            'ben02syn' (a)
 ! ITEST    : Global i-index of point diagnostics (i)
 ! JTEST    : Global j-index of point diagnostics (i)
+! CNSVDI   : Conservation diagnostics flag (l)
+! CSDIAG   : Checksum diagnostics flag (l)
 ! RSTFRQ   : Restart frequency in days (30=1month,365=1year) (i)
 ! RSTFMT   : Format of restart file (valid arguments are 0 for classic,
 !            1 for 64-bit offset and 2 for netcdf4/hdf5 format) (i)
@@ -319,8 +321,6 @@
 !   LIP      - liquid precipitation [kg m-2 s-1]
 !   MAXMLD   - maximum mixed layer depth [m]
 !   MLD      - mixed layer depth [m]
-!   MLDU     - mixed layer depth at u-point [m]
-!   MLDV     - mixed layer depth at v-point [m]
 !   MLTS     - mixed layer thickness using "sigma-t" criterion [m]
 !   MLTSMN   - minimum mixed layer thickness using "sigma-t" criterion [m]
 !   MLTSMX   - maximum mixed layer thickness using "sigma-t" criterion [m]
@@ -332,8 +332,6 @@
 !   MTKEPE   - mixed layer TKE tendency related to pot. energy change [kg s-3]
 !   MTKEKE   - mixed layer TKE tendency related to kin. energy change [kg s-3]
 !   MTY      - wind stress y-component [N m-2]
-!   MXLU     - mixed layer velocity x-component [m s-1]
-!   MXLV     - mixed layer velocity y-component [m s-1]
 !   NSF      - non-solar heat flux [W m-2]
 !   PBOT     - bottom pressure [Pa]
 !   PSRF     - surface pressure [Pa]
@@ -368,7 +366,10 @@
 !   VICE     - ice velocity y-component [m s-1]
 !   ZTX      - wind stress x-component [N m-2]
 !   BFSQ     - buoyancy frequency squared [s-1]
-!   DIFDIA   - diapycnal diffusivity [log10(m2 s-1)]
+!   DIFDIA   - vertical diffusivity [log10(m2 s-1)|m2 s-1]
+!   DIFVMO   - vertical momentum diffusivity [log10(m2 s-1)|m2 s-1]
+!   DIFVHO   - vertical heat diffusivity [log10(m2 s-1)|m2 s-1]
+!   DIFVSO   - vertical salt diffusivity [log10(m2 s-1)|m2 s-1]
 !   DIFINT   - layer interface diffusivity [log10(m2 s-1)]
 !   DIFISO   - isopycnal diffusivity [log10(m2 s-1)]
 !   DP       - layer pressure thickness [Pa]
@@ -441,8 +442,6 @@
   H2D_LIP      = 0,   0
   H2D_MAXMLD   = 4,   4
   H2D_MLD      = 0,   4
-  H2D_MLDU     = 0,   0
-  H2D_MLDV     = 0,   0
   H2D_MLTS     = 0,   4
   H2D_MLTSMN   = 0,   4
   H2D_MLTSMX   = 0,   4
@@ -454,8 +453,6 @@
   H2D_MTKEPE   = 0,   4
   H2D_MTKEKE   = 0,   4
   H2D_MTY      = 0,   0
-  H2D_MXLU     = 4,   4
-  H2D_MXLV     = 4,   4
   H2D_NSF      = 0,   0
   H2D_PBOT     = 0,   4
   H2D_PSRF     = 0,   0
@@ -491,6 +488,9 @@
   H2D_ZTX      = 0,   0
   LYR_BFSQ     = 0,   4
   LYR_DIFDIA   = 0,   4
+  LYR_DIFVMO   = 0,   4
+  LYR_DIFVHO   = 0,   4
+  LYR_DIFVSO   = 0,   0
   LYR_DIFINT   = 0,   0
   LYR_DIFISO   = 0,   0
   LYR_DP       = 0,   4
@@ -524,6 +524,9 @@
   LYR_IDLAGE   = 0,   4
   LVL_BFSQ     = 0,   4
   LVL_DIFDIA   = 0,   4
+  LVL_DIFVMO   = 0,   4
+  LVL_DIFVHO   = 0,   4
+  LVL_DIFVSO   = 0,   0
   LVL_DIFINT   = 0,   0
   LVL_DIFISO   = 0,   0
   LVL_DZ       = 0,   4


### PR DESCRIPTION
This resolves issues #203 and #204.

Using the NOIIAOC NorESM compset at resolution T62_tn14, the code has been tested on machine betzy.sigma2.no to bit-reproduce current NorESMhub/BLOM/master.