### PR TITLE
Import get_bgc_namelist only in subroutine where it is needed.

### DIFF
--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -58,7 +58,6 @@
       use mod_nctools,    only: ncpack,nccomp,nccopa,ncwrtr
       use netcdf,         only: nf90_fill_double
       use mo_param1_bgc,  only: ks
-      use mo_control_bgc, only: get_bgc_namelist 
 
       IMPLICIT NONE
 
@@ -514,7 +513,7 @@
 
       SUBROUTINE ALLOC_MEM_BGCMEAN(kpie,kpje,kpke)
 
-      use mo_control_bgc, only: io_stdo_bgc,bgc_namelist
+      use mo_control_bgc, only: io_stdo_bgc,bgc_namelist,get_bgc_namelist
 
       IMPLICIT NONE 
      


### PR DESCRIPTION
I think it makes sense to move the module import statement to the subroutine where `get_bgc_namelist` is used. Not sure why it was placed in the main body of `mo_bgcmean` in the first place.