### PR TITLE
Quick fix on buildnml after incomplete shell variable renaming from PR 224

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1982,9 +1982,9 @@ cat >> $CASEBUILD/blom.input_data_list << EOF
 n_deposition_file = `echo $NDEPFILE | tr -d '"' | tr -d "'"`
 EOF
   endif
-  if ($OALKFILE != "''") then
+  if ($BGCOAFX_OALKFILE != "''") then
 cat >> $CASEBUILD/blom.input_data_list << EOF
-oafx_file = `echo $OALKFILE | tr -d '"' | tr -d "'"`
+oafx_file = `echo $BGCOAFX_OALKFILE | tr -d '"' | tr -d "'"`
 EOF
   endif
   if ($HAMOCC_VSLS == TRUE) then


### PR DESCRIPTION
A proposed commit has been suggested in [PR 224](https://github.com/NorESMhub/BLOM/pull/224) to include a new naming convention for shell variables in buildnml. I had approved the commit but there was 2 missing renaming that I missed. The code compiles correctly with this PR.