### PR TITLE
Hamocc fix restart file units

### DIFF
--- a/hamocc/aufw_bgc.F90
+++ b/hamocc/aufw_bgc.F90
@@ -730,7 +730,7 @@
      &    rmissing,92,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,8,'bur_clay',3,ncdimst,ncvarid,        &
-     &    9,'kg/m**2',20,'Burial layer of clay',                      &
+     &    9,'kg/m**2',20,'Burial layer of clay',                        &
      &    rmissing,93,io_stdo_bgc)
 
 #endif /* sedbypass */

--- a/hamocc/aufw_bgc.F90
+++ b/hamocc/aufw_bgc.F90
@@ -603,7 +603,7 @@
      &    rmissing,62,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'satoxy',3,ncdimst,ncvarid,          &
-     &    9,'xxxxxxxxx',9 ,'xxxxxxxxx',  &
+     &    9,'mol/kg',9 ,'Saturated oxygen',                             &
      &    rmissing,63,io_stdo_bgc)
 
 #ifdef natDIC
@@ -638,7 +638,7 @@
      &    rmissing,72,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'ssster',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',25,'Sediment accumulated clay',                 &
+     &    9,'kg/m**3',25,'Sediment accumulated clay',                   &
      &    rmissing,73,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'powaic',3,ncdimst,ncvarid,          &
@@ -730,7 +730,7 @@
      &    rmissing,92,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,8,'bur_clay',3,ncdimst,ncvarid,        &
-     &    9,'kmol/m**2',20,'Burial layer of clay',                      &
+     &    9,'kg/m**2',20,'Burial layer of clay',                      &
      &    rmissing,93,io_stdo_bgc)
 
 #endif /* sedbypass */

--- a/hamocc/aufw_bgc.F90
+++ b/hamocc/aufw_bgc.F90
@@ -626,15 +626,15 @@
       ENDIF
 
       CALL NETCDF_DEF_VARDB(ncid,6,'ssso12',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',35,'Sediment accumulated organic carbon',       &
+     &    9,'kmol/m**3',35,'Sediment accumulated organic carbon',       &
      &    rmissing,70,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'sssc12',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',38,'Sediment accumulated calcium carbonate',    &
+     &    9,'kmol/m**3',38,'Sediment accumulated calcium carbonate',    &
      &    rmissing,71,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'ssssil',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',25,'Sediment accumulated opal',                 &
+     &    9,'kmol/m**3',25,'Sediment accumulated opal',                 &
      &    rmissing,72,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'ssster',3,ncdimst,ncvarid,          &
@@ -671,19 +671,19 @@
 
 #ifdef cisonew
       CALL NETCDF_DEF_VARDB(ncid,6,'ssso13',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',37,'Sediment accumulated organic carbon13',     &
+     &    9,'kmol/m**3',37,'Sediment accumulated organic carbon13',     &
      &    rmasks,81,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'ssso14',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',37,'Sediment accumulated organic carbon14',     &
+     &    9,'kmol/m**3',37,'Sediment accumulated organic carbon14',     &
      &    rmasks,82,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'sssc13',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',40,'Sediment accumulated calcium carbonate13',  &
+     &    9,'kmol/m**3',40,'Sediment accumulated calcium carbonate13',  &
      &    rmasks,83,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'sssc14',3,ncdimst,ncvarid,          &
-     &    9,'kmol/m**2',40,'Sediment accumulated calcium carbonate14',  &
+     &    9,'kmol/m**3',40,'Sediment accumulated calcium carbonate14',  &
      &    rmasks,84,io_stdo_bgc)
 
       CALL NETCDF_DEF_VARDB(ncid,6,'powc13',3,ncdimst,ncvarid,          &


### PR DESCRIPTION
Hi @TomasTorsvik  and @JorgSchwinger , I prepared a fix for the units in the restart file as suggested in #238. I noticed that the particulate materials were all in `X/m2`, while I believe it should read `X/m3` and changed this as well. Of course, for the burial layer, it should stay with `X/m2`. Closes #238