### PR TITLE
add ability to read input file for ocean alkalinization

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -263,7 +263,7 @@ if ($HAMOCC_VSLS == TRUE && $OCN_GRID != tnx1v4) then
 endif
 # For the following options, there are currently no switches in Case-XML files.
 # These options can be activated by expert users via user namelist.
-set BGCOAFX_DO_OALK = .false.
+set DO_OALK = .false.
 set BGCOAFX_OALKSCEN = "''"
 set BGCOAFX_OALKFILE = "''"
 set BGCOAFX_ADDALK    = 0.135
@@ -1541,6 +1541,7 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
   RIVINFILE    = $RIVINFILE 
   DO_NDEP      = $DO_NDEP
   NDEPFILE     = $NDEPFILE
+  DO_OALK      = $DO_OALK
   DO_SEDSPINUP = $DO_SEDSPINUP
   SEDSPIN_YR_S = $SEDSPIN_YR_S
   SEDSPIN_YR_E = $SEDSPIN_YR_E
@@ -1571,7 +1572,6 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 ! RAMP_START    : Start year for ramp up in 'ramp' scenario
 ! RAMP_END      : End year for 'ramp' scenario
 &BGCOAFX
-  DO_OALK       = $BGCOAFX_DO_OALK
   OALKSCEN      = $BGCOAFX_OALKSCEN
   OALKFILE      = $BGCOAFX_OALKFILE
   ADDALK        = $BGCOAFX_ADDALK

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1564,6 +1564,8 @@ cat >>! $RUNDIR/ocn_in$inststr << EOF
 !
 ! CONTENTS:
 !
+! OALKSCEN      : Name of alkalinization scenario.
+! OALKFILE      : Full path of the input file for the alkalinization scenario 'file'.
 ! ADDALK    : Pmol alkalinity/yr added in the scenarios.
 ! CDRMIP_LATMAX : Max latitude where alkalinity is added according to the
 !                   CDRMIP protocol

--- a/hamocc/hamocc_init.F90
+++ b/hamocc/hamocc_init.F90
@@ -56,7 +56,7 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   use mo_read_rivin,  only: ini_read_rivin,rivinfile
   use mo_read_fedep,  only: ini_read_fedep,fedepfile
   use mo_read_ndep,   only: ini_read_ndep,ndepfile
-  use mo_read_oafx,   only: ini_read_oafx,oalkfile,oalkscen
+  use mo_read_oafx,   only: ini_read_oafx
   use mo_read_pi_ph,  only: ini_pi_ph,pi_ph_file
   use mo_read_sedpor, only: read_sedpor,sedporfile
   use mo_clim_swa,    only: ini_swa_clim,swaclimfile

--- a/hamocc/hamocc_init.F90
+++ b/hamocc/hamocc_init.F90
@@ -80,7 +80,7 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   real    :: sed_por(idm,jdm,ks) = 0.
 
   namelist /bgcnml/ atm_co2,fedepfile,do_rivinpt,rivinfile,do_ndep,ndepfile,    &
-       &   do_oalk,oalkscen,oalkfile,do_sedspinup,sedspin_yr_s,                 &
+       &   do_oalk,do_sedspinup,sedspin_yr_s,                 &
        &   sedspin_yr_e,sedspin_ncyc,                                           &
        &   inidic,inialk,inipo4,inioxy,inino3,inisil,                           &
        &   inid13c,inid14c,swaclimfile,                                         &

--- a/hamocc/mo_read_oafx.F90
+++ b/hamocc/mo_read_oafx.F90
@@ -23,6 +23,12 @@ module mo_read_oafx
 !
 ! Modified
 ! --------
+!  T. Bourgeois,     *NORCE climate, Bergen*   2023-01-31
+!  - add ramping-up scenario
+!  - add ability to define parameters from BLOM namelist
+!
+!  T. Bourgeois,     *NORCE climate, Bergen*   2023-02-09
+!  - add ability to use an OA input file
 !
 ! Purpose
 ! -------
@@ -31,22 +37,23 @@ module mo_read_oafx
 !
 ! Description:
 ! ------------
-!  The routine get_oafx reads a fluxs of alkalinity from file (or, for simple
+!  The routine get_oafx reads a flux of alkalinity from file (or, for simple
 !  cases, constructs an alkalinity flux field from scratch). The alkalinity
 !  flux is then passed to hamocc4bcm where it is applied to the top-most model 
 !  layer by a call to apply_oafx (mo_apply_oafx).
 !
-!  Ocean alkalinization is activated through a logical switch 'do_oalk' read from
-!  HAMOCC's bgcnml namelist. If ocean alkalinization is acitvated, a valid 
-!  name of an alkalinisation scenario (defined in this module, see below) and 
+!  Ocean alkalinization is activated through a logical switch 'do_oalk' read
+!  from HAMOCC's bgcnml namelist. If ocean alkalinization is activated, a valid
+!  name of an alkalinisation scenario (defined in this module, see below) OR 
 !  the file name (including the full path) of the corresponding OA-scenario 
 !  input file needs to be provided via HAMOCC's bgcnml namelist (variables 
-!  oascenario and oafxfile). If the input file is not found, an error will be 
-!  issued. The input data must be already pre-interpolated to the ocean grid.
+!  oalkscen and oalkfile). If the input file is not found or the scenario is
+!  invalid or if both are defined, an error will be issued. The input data must
+!  be already pre-interpolated to the ocean grid.
 !
 !  Currently available ocean alkalinisation scenarios:
-!  (no input file needed, flux and latitude range can be defined in the
-!   namelist, default values are defined):
+!  (no input file needed, parameters can be defined in the namelist, default
+!  values are defined):
 !    -'const':        constant alkalinity flux applied to the surface ocean 
 !                     between two latitudes.
 !    -'ramp':         ramping-up alkalinity flux from 0 Pmol yr-1 to a maximum
@@ -66,11 +73,12 @@ module mo_read_oafx
 
   private
   public :: ini_read_oafx,get_oafx,oalkscen,oalkfile
-
-  real,allocatable, save :: oalkflx(:,:)
-   
+ 
   character(len=128), save :: oalkscen   =''
   character(len=512), save :: oalkfile   =''
+  real,allocatable,   save :: oalkflx(:,:)
+  integer,            save :: startyear,endyear
+
   real, parameter          :: Pmol2kmol  = 1.0e12
   
   ! Parameter used in the definition of alkalinization scenarios. The following 
@@ -127,6 +135,8 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
 !******************************************************************************
   use mod_xc,         only: xcsum,xchalt,mnproc,nbdy,ips
   use mo_control_bgc, only: io_stdo_bgc,do_oalk,bgc_namelist,get_bgc_namelist
+  use mod_dia,        only: iotype
+  use mod_nctools,    only: ncfopn,ncgeti,ncfcls
 
   implicit none
 
@@ -136,6 +146,7 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
   real,    intent(in) :: omask(kpie,kpje)
 
   integer :: i,j,errstat
+  logical :: file_exists=.false.
   integer :: iounit
   real    :: avflx,ztotarea
   real    :: ztmp1(1-nbdy:kpie+nbdy,1-nbdy:kpje+nbdy)
@@ -169,11 +180,27 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
       write(io_stdo_bgc,*)' '
     endif
 
-    if( trim(oalkscen)=='const' .or. trim(oalkscen)=='ramp' ) then
+    if( trim(oalkscen)=='const' .and. trim(oalkfile)=='' .or.                 &
+        trim(oalkscen)=='ramp'  .and. trim(oalkfile)=='' .or.                 &
+        trim(oalkfile)/='' .and. trim(oalkscen)=='' ) then
 
       if(mnproc.eq.1) then
         write(io_stdo_bgc,*)'Using alkalinization scenario ', trim(oalkscen)
+        if( trim(oalkfile)/='' ) then
+          write(io_stdo_bgc,*) 'from ', trim(oalkfile)
+        endif
         write(io_stdo_bgc,*)' '
+      endif
+
+      if( trim(oalkfile)/='' ) then
+        ! Check if OA file exists. If not, abort.
+        inquire(file=oalkfile,exist=file_exists)
+        if (.not. file_exists .and. mnproc.eq.1) then
+          write(io_stdo_bgc,*) ''
+          write(io_stdo_bgc,*) 'ini_read_oafx: Cannot find ocean alkalinization file... '
+          call xchalt('(ini_read_oafx)')
+          stop '(ini_read_oafx)'
+        endif
       endif
 
       ! Allocate field to hold alkalinization fluxes
@@ -187,38 +214,50 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
       if(errstat.ne.0) stop 'not enough memory oalkflx'
       oalkflx(:,:) = 0.0
 
-      ! Calculate total ocean area 
-      ztmp1(:,:)=0.0
-      do j=1,kpje
-      do i=1,kpie
-        if( omask(i,j).gt.0.5 .and. pglat(i,j)<cdrmip_latmax                  &
-                              .and. pglat(i,j)>cdrmip_latmin ) then
-          ztmp1(i,j)=ztmp1(i,j)+pdlxp(i,j)*pdlyp(i,j)
-        endif
-      enddo
-      enddo
+      if( trim(oalkfile)/='' ) then
 
-      call xcsum(ztotarea,ztmp1,ips)
-      
-      ! Calculate alkalinity flux (kmol m^2 yr-1) to be applied
-      avflx = addalk/ztotarea*Pmol2kmol
-      if(mnproc.eq.1) then
-        write(io_stdo_bgc,*)' '
-        write(io_stdo_bgc,*)' applying alkalinity flux of ', avflx, ' kmol m-2 yr-1'
-        write(io_stdo_bgc,*)'             over an area of ', ztotarea , ' m2'
-        if( trim(oalkscen)=='ramp' ) then
-          write(io_stdo_bgc,*)'             ramping-up from ', ramp_start, ' to ', ramp_end
+        ! read start and end year of OA file
+        call ncfopn(trim(oalkfile),'r',' ',1,iotype)
+        call ncgeti('startyear',startyear)
+        call ncgeti('endyear',endyear)
+        call ncfcls
+    
+      else
+
+        ! Calculate total ocean area 
+        ztmp1(:,:)=0.0
+        do j=1,kpje
+        do i=1,kpie
+          if( omask(i,j).gt.0.5 .and. pglat(i,j)<cdrmip_latmax                  &
+                                .and. pglat(i,j)>cdrmip_latmin ) then
+            ztmp1(i,j)=ztmp1(i,j)+pdlxp(i,j)*pdlyp(i,j)
+          endif
+        enddo
+        enddo
+  
+        call xcsum(ztotarea,ztmp1,ips)
+        
+        ! Calculate alkalinity flux (kmol m^2 yr-1) to be applied
+        avflx = addalk/ztotarea*Pmol2kmol
+        if(mnproc.eq.1) then
+          write(io_stdo_bgc,*)' '
+          write(io_stdo_bgc,*)' applying alkalinity flux of ', avflx, ' kmol m-2 yr-1'
+          write(io_stdo_bgc,*)'             over an area of ', ztotarea , ' m2'
+          if( trim(oalkscen)=='ramp' ) then
+            write(io_stdo_bgc,*)'             ramping-up from ', ramp_start, ' to ', ramp_end
+          endif
         endif
+  
+        do j=1,kpje
+        do i=1,kpie
+          if( omask(i,j).gt.0.5 .and. pglat(i,j)<cdrmip_latmax                  &
+                                .and. pglat(i,j)>cdrmip_latmin ) then
+            oalkflx(i,j) = avflx
+          endif
+        enddo
+        enddo
+
       endif
-
-      do j=1,kpje
-      do i=1,kpie
-        if( omask(i,j).gt.0.5 .and. pglat(i,j)<cdrmip_latmax                  &
-                              .and. pglat(i,j)>cdrmip_latmin ) then
-          oalkflx(i,j) = avflx
-        endif
-      enddo
-      enddo
 
       lini=.true.
 
@@ -228,7 +267,8 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
     else
     
       write(io_stdo_bgc,*) ''
-      write(io_stdo_bgc,*) 'ini_read_oafx: invalid alkalinization scenario... '
+      write(io_stdo_bgc,*) 'ini_read_oafx: invalid alkalinization scenario'
+      write(io_stdo_bgc,*) 'or oalkscen and oalkfile are both defined...'
       call xchalt('(ini_read_oafx)')
       stop '(ini_read_oafx)' 
       
@@ -265,6 +305,7 @@ subroutine get_oafx(kpie,kpje,kplyear,kplmon,omask,oafx)
 !
 !******************************************************************************
   use mod_xc,         only: xchalt,mnproc
+  use netcdf,         only: nf90_open,nf90_close,nf90_nowrite
   use mo_control_bgc, only: io_stdo_bgc,do_oalk
   use mod_time,       only: nday_of_year
 
@@ -275,8 +316,9 @@ subroutine get_oafx(kpie,kpje,kplyear,kplmon,omask,oafx)
   real,    intent(out) :: oafx(kpie,kpje)
   integer              :: current_day
 
-  ! local variables 
-  integer :: i,j
+  ! local variables
+  integer              :: month_in_file,ncstat,ncid
+  integer, save        :: oldmonth=0 
 
   if (.not. do_oalk) then
     oafx(:,:) = 0.0
@@ -286,14 +328,14 @@ subroutine get_oafx(kpie,kpje,kplyear,kplmon,omask,oafx)
   !--------------------------------
   ! Scenarios of constant fluxes
   !--------------------------------
-  if( trim(oalkscen)=='const' ) then
+  if( trim(oalkscen)=='const' .and. trim(oalkfile)=='') then
       
     oafx(:,:) = oalkflx(:,:)
 
   !--------------------------------
   ! Scenario of ramping-up fluxes
   !--------------------------------
-  elseif(trim(oalkscen)=='ramp' ) then
+  elseif(trim(oalkscen)=='ramp' .and. trim(oalkfile)=='') then
 
     if(kplyear.lt.ramp_start ) then
       oafx(:,:) = 0.0
@@ -303,6 +345,25 @@ subroutine get_oafx(kpie,kpje,kplyear,kplmon,omask,oafx)
       current_day = (kplyear-ramp_start)*365+nday_of_year
       oafx(:,:) = oalkflx(:,:) * current_day / ((ramp_end-ramp_start)*365.)
     endif
+
+  !--------------------------------
+  ! Scenario from OA file
+  !--------------------------------
+  elseif(trim(oalkfile)/=''  .and. trim(oalkscen)=='') then
+
+    ! read OA data from file
+    if (kplmon.ne.oldmonth) then
+      month_in_file=(max(startyear,min(endyear,kplyear))-startyear)*12+kplmon
+      if (mnproc.eq.1) then
+        write(io_stdo_bgc,*) 'Read OA month ',month_in_file, &
+                             'from file ',trim(oalkfile)
+      endif
+      ncstat=nf90_open(trim(oalkfile),nf90_nowrite,ncid)
+      call read_netcdf_var(ncid,'oafx',oalkflx,1,month_in_file,0)
+      ncstat=nf90_close(ncid)
+      oldmonth=kplmon
+    endif
+    oafx(:,:) = oalkflx
 
   else
     

--- a/hamocc/mo_read_oafx.F90
+++ b/hamocc/mo_read_oafx.F90
@@ -153,8 +153,8 @@ subroutine ini_read_oafx(kpie,kpje,pdlxp,pdlyp,pglat,omask)
   real    :: avflx,ztotarea
   real    :: ztmp1(1-nbdy:kpie+nbdy,1-nbdy:kpje+nbdy)
 
-  namelist /bgcoafx/ do_oalk,oalkscen,oalkfile,addalk,cdrmip_latmax,          &
-       &             cdrmip_latmin,ramp_start,ramp_end
+  namelist /bgcoafx/ oalkscen,oalkfile,addalk,cdrmip_latmax,cdrmip_latmin,    &
+       &             ramp_start,ramp_end
 
   ! Read parameters for alkalinization fluxes from namelist file
   if(.not. allocated(bgc_namelist)) call get_bgc_namelist
@@ -314,10 +314,9 @@ subroutine get_oafx(kpie,kpje,kplyear,kplmon,omask,oafx)
   integer, intent(in)  :: kpie,kpje,kplyear,kplmon
   real,    intent(in)  :: omask(kpie,kpje)
   real,    intent(out) :: oafx(kpie,kpje)
-  integer              :: current_day
 
   ! local variables
-  integer              :: month_in_file,ncstat,ncid
+  integer              :: month_in_file,ncstat,ncid,current_day
   integer, save        :: oldmonth=0 
 
   if (.not. do_oalk) then


### PR DESCRIPTION
Hi all,

Previously, a constant scenario and a linear ramping-up of ocean alkalinization have been implemented in `mo_read_oafx.F90`, both spatially homogeneous and customizable via the user_nl_blom namelist. Here, a third case is added for scenarios defined from a file `oalkfile` prescribing monthly 2D fields of surface alkalinity addition in kmol ALK m-2 yr-1.

Now, to use the constant or ramping-up scenario, the user needs to define only the variable `oalkscen` and leaves `oalkfile` undefined (default value is `''`). To use the scenario from `oalkfile`, the user needs to define only `oalkfile`  and leaves `oalkscen` undefined (default value `''` as well). Defining both `oalkscen` and `oalkfile` returns an explicit error.

Because this case defined from a file is the same procedure as the N deposition, this commit is mostly coming from a copy-paste of `mo_read_ndep.F90` blocks.

Example of user_nl_blom to use this case:
```
BGCOAFX_DO_OALK = .true.
BGCOAFX_OALKFILE = '/path/to/file.nc'
```