### PR TITLE
Removed OMP in pressure calculation to avoid race condition

### DIFF
--- a/hamocc/mo_intfcblom.F90
+++ b/hamocc/mo_intfcblom.F90
@@ -269,8 +269,6 @@ subroutine blom2hamocc(m,n,mm,nn)
 
 ! --- calculate pressure at interfaces (necesarry since p has
 ! --- not been calculated at restart)
-
-!$OMP PARALLEL DO PRIVATE(k,kn,l,i)
   do k=1,kk
      kn=k+nn
      do j=1,jj
@@ -281,7 +279,6 @@ subroutine blom2hamocc(m,n,mm,nn)
      enddo
   enddo
   enddo
-!$OMP END PARALLEL DO
 
 ! --- ------------------------------------------------------------------
 ! --- 2D fields


### PR DESCRIPTION
Hi @JorgSchwinger, Tomas and I, we yesterday identified a potential race condition that (among others) causing issues when running BLOM/iHAMOCC in single column mode. Further places in iHAMOCC seem to be in `ocprod` (settling routine - potential race condition due to `k` versus `kdonor`?) and  in `carchm` (to be checked). In this PR, I only addressed the pressure calculation. Currently, single column mode with `master` is only advisable with flag `-D openmp=disabled` to get reproducible results. 