### PR TITLE
Update config_pes for OMIP-2 simulations on Betzy

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -187,6 +187,46 @@
       </pes>
     </mach>
   </grid>
+
+  <!-- 512 pes is minimum setting for normal job size on betzy !-->
+  <grid name="a%TL319.+oi%tnx1v4">
+    <mach name="betzy">
+      <pes pesize="L" compset="_DATM.*_BLOM">
+	      <comment>Large pe-layout with 512 pes in total</comment>
+	      <ntasks>
+	        <ntasks_atm>1</ntasks_atm>
+	        <ntasks_rof>1</ntasks_rof>
+	        <ntasks_ice>154</ntasks_ice>
+	        <ntasks_ocn>354</ntasks_ocn>
+	        <ntasks_cpl>158</ntasks_cpl>
+	        <ntasks_lnd>1</ntasks_lnd>
+	        <ntasks_glc>1</ntasks_glc>
+	        <ntasks_wav>1</ntasks_wav>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>155</rootpe_atm>
+	        <rootpe_lnd>156</rootpe_lnd>
+	        <rootpe_rof>157</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>158</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
   <grid name="a%0.9x1.25.+oi%tnx1v4|a%1.9x2.5.+oi%tnx1v4">
     <mach name="any">
       <pes pesize="M" compset="_DATM%CPLHIST.*_BLOM">
@@ -597,44 +637,6 @@
 	  <rootpe_glc>3</rootpe_glc> 
 	  <rootpe_wav>3</rootpe_wav> 
 	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%TL319.+oi%tnx1v4">
-    <mach name="any">
-      <pes pesize="L" compset="any">
-	<comment>Large pe-layout with 512 pes in total</comment>
-	<ntasks>
-	  <ntasks_atm>1</ntasks_atm>
-	  <ntasks_rof>1</ntasks_rof>
-	  <ntasks_ice>154</ntasks_ice>
-	  <ntasks_ocn>354</ntasks_ocn>
-	  <ntasks_cpl>158</ntasks_cpl>
-	  <ntasks_lnd>1</ntasks_lnd>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>1</ntasks_wav>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>155</rootpe_atm>
-	  <rootpe_lnd>156</rootpe_lnd>
-	  <rootpe_rof>157</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>158</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -602,4 +602,42 @@
     </mach>
   </grid>
 
+  <grid name="a%TL319.+oi%tnx1v4">
+    <mach name="any">
+      <pes pesize="L" compset="any">
+	<comment>Large pe-layout with 512 pes in total</comment>
+	<ntasks>
+	  <ntasks_atm>1</ntasks_atm>
+	  <ntasks_rof>1</ntasks_rof>
+	  <ntasks_ice>154</ntasks_ice>
+	  <ntasks_ocn>354</ntasks_ocn>
+	  <ntasks_cpl>158</ntasks_cpl>
+	  <ntasks_lnd>1</ntasks_lnd>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>1</ntasks_wav>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>155</rootpe_atm>
+	  <rootpe_lnd>156</rootpe_lnd>
+	  <rootpe_rof>157</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>158</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+
 </config_pes>


### PR DESCRIPTION
I wanted to run OMIP-2 simulations on Betzy, and found that I could not find a suitable `config_pes` definition for NOIIAJRA for runnig on Betzy. I have made a new definition for running on 512 cores (4 nodes), but I'm not sure it's an optimal setting. Should it be defined for "betzy" only, or for some particular compset (e.g. "DATM") only?