### PR TITLE
work around compile-time error in iHAMOCC when debug mode is activated

### DIFF
--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -259,10 +259,10 @@
         map_por2octra(ipown2)  = igasnit 
         map_por2octra(ipowno3) = iano3 
         map_por2octra(ipowasi) = isilica 
-       
-        ! if statements for non-base tracers 
-        if(ipowc13 > 0) map_por2octra(ipowc13) = isco213 
-        if(ipowc14 > 0) map_por2octra(ipowc14) = isco214
+#ifdef cisonew
+        map_por2octra(ipowc13) = isco213 
+        map_por2octra(ipowc14) = isco214
+#endif
       
       end subroutine init_por2octra_mapping
 


### PR DESCRIPTION
In debug mode the intel compiler generates an error in mo_param1 (see #254 by @mvertens). Apparently, since indices are defined as parameters, the compile-time array bounds check generate errors for actually unused indices even though the code cannot be reached. Since the intel compiler is our workhorse I suggest to fix this by using pre-processor directives instead of if-statements.