### PR TITLE
Fix potential OMP issues and bug fix in wrapping the burial fields

### DIFF
--- a/hamocc/dipowa.F90
+++ b/hamocc/dipowa.F90
@@ -84,8 +84,7 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 !ik needed for boundary layer ventilation in fast sediment routine
   real :: bolven(kpie)                 ! bottom layer ventilation rate
 
-!$OMP PARALLEL DO                            &
-!$OMP&PRIVATE(i,k,iv,l,bolven,tredsy,sedb1,aprior,iv_oc)
+!$OMP PARALLEL DO PRIVATE(i,k,iv,l,bolven,tredsy,sedb1,aprior,iv_oc)
   j_loop: do j=1,kpje
 
 ! calculate bottom ventilation rate for scaling of sediment-water exchange
@@ -206,5 +205,5 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
   endif ! .not. lspin
   
   enddo j_loop
-
+!$OMP END PARALLEL DO
 end subroutine dipowa

--- a/hamocc/mo_intfcblom.F90
+++ b/hamocc/mo_intfcblom.F90
@@ -377,12 +377,22 @@ subroutine blom2hamocc(m,n,mm,nn)
      do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
         sedlay(i,j,k,:) = sedlay2(i,j,kn,:)
         powtra(i,j,k,:) = powtra2(i,j,kn,:)
-        burial(i,j,:)   = burial2(i,j,n,:)
      enddo
      enddo
      enddo
   enddo
 !$OMP END PARALLEL DO
+
+!$OMP PARALLEL DO PRIVATE(l,i)
+  do j=1,jj
+  do l=1,isp(j)
+  do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
+        burial(i,j,:)   = burial2(i,j,n,:)
+  enddo
+  enddo
+  enddo
+!$OMP END PARALLEL DO
+
 #endif
 
 ! --- ------------------------------------------------------------------
@@ -486,14 +496,24 @@ subroutine hamocc2blom(m,n,mm,nn)
         powtra2(i,j,km,:) = wts1*powtra2(i,j,km,:)   &
              + wts2*powtra2(i,j,kn,:)                &
              + wts2*powtra(i,j,k,:)
-        burial2(i,j,m,:)  = wts1*burial2(i,j,m,:)    &
-             + wts2*burial2(i,j,n,:)                 &
-             + wts2*burial(i,j,:)
      enddo
      enddo
      enddo
   enddo
 !$OMP END PARALLEL DO
+
+!$OMP PARALLEL DO PRIVATE(l,i)
+  do j=1,jj
+  do l=1,isp(j)
+  do i=max(1,ifp(j,l)),min(ii,ilp(j,l))              ! time smoothing (analog to tmsmt2.F)
+        burial2(i,j,m,:)  = wts1*burial2(i,j,m,:)    &
+             + wts2*burial2(i,j,n,:)                 &
+             + wts2*burial(i,j,:)
+  enddo
+  enddo
+  enddo
+!$OMP END PARALLEL DO
+
 
 !$OMP PARALLEL DO PRIVATE(k,kn,l,i)
   do k=1,ks
@@ -503,12 +523,22 @@ subroutine hamocc2blom(m,n,mm,nn)
      do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
         sedlay2(i,j,kn,:) = sedlay(i,j,k,:)  ! new time level replaces old time level here
         powtra2(i,j,kn,:) = powtra(i,j,k,:)
-        burial2(i,j,n,:)  = burial(i,j,:)
      enddo
      enddo
      enddo
   enddo
 !$OMP END PARALLEL DO
+
+!$OMP PARALLEL DO PRIVATE(l,i)
+  do j=1,jj
+  do l=1,isp(j)
+  do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
+        burial2(i,j,n,:)  = burial(i,j,:)
+  enddo
+  enddo
+  enddo
+!$OMP END PARALLEL DO
+
 #endif
 
 ! --- ------------------------------------------------------------------

--- a/hamocc/mo_vgrid.F90
+++ b/hamocc/mo_vgrid.F90
@@ -110,8 +110,8 @@ subroutine set_vgrid(kpie,kpje,kpke,pddpo)
   ! --- depth of layer kpke+1 centre
   ptiestu(:,:,kpke+1)=9000.
 
-!$OMP PARALLEL DO PRIVATE(j,i)
   do k=1,kpke
+!$OMP PARALLEL DO PRIVATE(j,i)
     do j=1,kpje
     do i=1,kpie
 
@@ -122,8 +122,8 @@ subroutine set_vgrid(kpie,kpje,kpke,pddpo)
 
     enddo
     enddo
-  enddo
 !$OMP END PARALLEL DO
+  enddo
 
 
   kbo(:,:)  =1

--- a/hamocc/ocprod.F90
+++ b/hamocc/ocprod.F90
@@ -131,7 +131,7 @@ subroutine ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph)
   real,    intent(in) :: ptho(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,kpke)
   real,    intent(in) :: pi_ph(kpie,kpje)
 
-  ! Local varaibles
+  ! Local variables
   integer :: i,j,k,l
   integer :: is,kdonor
   integer, parameter :: nsinkmax = 12
@@ -1049,11 +1049,11 @@ subroutine ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph)
 ! C(k,T+dt)=(ddpo(k)*C(k,T)+w*dt*C(k-1,T+dt))/(ddpo(k)+w*dt)
 ! sedimentation=w*dt*C(ks,T+dt)
 !
-!$OMP PARALLEL DO PRIVATE(kdonor,wpoc,wpocd,wcal,wcald,wopal,wopald,wdust,wdustd   &
+!$OMP PARALLEL DO PRIVATE(kdonor,wpoc,wpocd,wcal,wcald,wopal,wopald,wdust,wdustd,tco,tcn,q    &
 #if defined(AGG)
-!$OMP ,wnos,wnosd,dagg                                                &
+!$OMP ,wnos,wnosd,dagg                                                                        &
 #endif
-!$OMP ,i,k)
+!$OMP ,i,k) ORDERED
   do j = 1,kpje
   do i = 1,kpie
 
@@ -1064,7 +1064,7 @@ subroutine ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph)
 
         kdonor = 1
         do k = 1,kpke
-
+           !$OMP ORDERED
            ! Sum up total column inventory before sinking scheme
            if( pddpo(i,j,k) > dp_min ) then
               tco( 1) = tco( 1) + ocetra(i,j,k,idet  )*pddpo(i,j,k)
@@ -1217,7 +1217,7 @@ subroutine ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph)
               tcn(12) = tcn(12) + ocetra(i,j,k,icalc14)*pddpo(i,j,k)
 #endif
            endif
-
+           !$OMP END ORDERED
         enddo  ! loop k=1,kpke
 
 

--- a/hamocc/ocprod.F90
+++ b/hamocc/ocprod.F90
@@ -1439,7 +1439,7 @@ subroutine ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph)
 #ifdef cisonew
 !$OMP ,flor13,flor14,flca13,flca14                                      &
 #endif
-!$OMP ,i,k)
+!$OMP ,i,k) ORDERED
   do j=1,kpje
   do i = 1,kpie
      if(omask(i,j) > 0.5) then
@@ -1447,9 +1447,9 @@ subroutine ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph)
         ! calculate depth of water column
         dz = 0.0
         do k = 1,kpke
-
+           !$OMP ORDERED
            if( pddpo(i,j,k) > dp_min ) dz = dz+pddpo(i,j,k)
-
+           !$OMP END ORDERED
         enddo
 
         florca = prorca(i,j)/dz


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik , during my coding and checking the SIunits4HAMOCC, I found another potential race condition during OMP parallelization (in `mo_vgrid`) in addition to the known one in the sinking scheme that I now also fixed (see also #243 and #244) - for the sinking in `ocprod.F90`, I understood that `tco,tcn,q` should be private within the `i`, `j` loops (right?), hence I also added those as private in the OMP statement. Further, there was a bug in the wrapper related to burial fields - the `k`-loop was causing to time-smooth the `burial2` field multiple times. Please have a closer look, since this pull request is potentially/likely answer changing (hence the pull request for the `beyond-CMIP6` branch). As a side note: after these fixes, it was possible to run the single column setup **with** OMP and get bit identical results (which wasn't the case before - while for speed reasons, disabling OMP in single column mode is advisable).  

I still have to run a test run on betzy (somehow, I have currently -ongoing- access problems - I contacted sigma2).  