### PR TITLE
Move main sediment parameters to mo_param_bgc

### DIFF
--- a/hamocc/dipowa.F90
+++ b/hamocc/dipowa.F90
@@ -56,8 +56,7 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 !**********************************************************************
 
   use mo_carbch,     only: ocetra, sedfluxo
-  use mo_sedmnt,     only: powtra,porwat,porwah,seddw,seddzi,zcoefsu,zcoeflo
-  use mo_param_bgc,  only: sedict
+  use mo_sedmnt,     only: powtra,porwat,porwah,seddw,zcoefsu,zcoeflo
   use mo_param1_bgc, only: ks,npowtra,map_por2octra
   use mo_vgrid,      only: kbo,bolay
   ! cisonew

--- a/hamocc/dipowa.F90
+++ b/hamocc/dipowa.F90
@@ -55,8 +55,9 @@ subroutine dipowa(kpie,kpje,kpke,omask,lspin)
 !
 !**********************************************************************
 
-  use mo_carbch,     only: ocetra, sedfluxo 
-  use mo_sedmnt,     only: powtra,porwat,porwah,sedict,seddw,seddzi,zcoefsu,zcoeflo 
+  use mo_carbch,     only: ocetra, sedfluxo
+  use mo_sedmnt,     only: powtra,porwat,porwah,seddw,seddzi,zcoefsu,zcoeflo
+  use mo_param_bgc,  only: sedict
   use mo_param1_bgc, only: ks,npowtra,map_por2octra
   use mo_vgrid,      only: kbo,bolay
   ! cisonew

--- a/hamocc/hamocc_init.F90
+++ b/hamocc/hamocc_init.F90
@@ -172,16 +172,20 @@ subroutine hamocc_init(read_rest,rstfnm_hamocc)
   !
   call set_vgrid(idm,jdm,kdm,bgc_dp)
   !
-  ! --- Initialize sediment layering
-  ! First read the porosity, then apply it in ini_sedmnt
-  CALL read_sedpor(idm,jdm,ks,omask,sed_por)
-  CALL ini_sedmnt(idm,jdm,kdm,omask,sed_por)
-  !
-  ! --- Initialize parameters, sediment and ocean tracer.
+  ! --- Initialize parameters
   !
   CALL ini_parambgc(idm,jdm)
-  call ini_fields_atm(idm,jdm) ! initialize atmospheric fields with (updated) parameter values
+
+  ! --- Initialize atmospheric fields with (updated) parameter values
+  call ini_fields_atm(idm,jdm)
+
+  ! --- Initialize sediment and ocean tracers
   CALL ini_fields_ocean(read_rest,idm,jdm,kdm,nbdy,bgc_dp,bgc_rho,omask,plon,plat)
+
+  ! --- Initialize sediment layering
+  !     First, read the porosity and potentially apply it in ini_sedimnt
+  CALL read_sedpor(idm,jdm,ks,omask,sed_por)
+  CALL ini_sedmnt(idm,jdm,kdm,omask,sed_por)
   !
   ! --- Initialise reading of input data (dust, n-deposition, river, etc.)
   !

--- a/hamocc/powach.F90
+++ b/hamocc/powach.F90
@@ -61,12 +61,11 @@ subroutine powach(kpie,kpje,kpke,kbnd,prho,omask,psao,lspin)
 !******************************************************************************
   use mo_control_bgc, only: dtbgc,use_cisonew
   use mo_param1_bgc,  only: ioxygen,ipowaal,ipowaic,ipowaox,ipowaph,ipowasi,ipown2,ipowno3,isilica,isssc12,issso12,issssil,        &
-                            issster,ks,ipowc13,ipowc14,isssc13,isssc14,issso13,issso14,safediv 
+                            issster,ks,ipowc13,ipowc14,isssc13,isssc14,issso13,issso14,safediv
   use mo_carbch,      only: co3,keqb,ocetra,sedfluxo
   use mo_chemcon,     only: calcon
-  use mo_sedmnt,      only: porwat,porsol,powtra,produs,prcaca,prorca,rno3,seddw,sedhpl,sedlay,silpro,disso_sil,silsat,disso_poc,  &
-                            sed_denit,disso_caco3,pror13,pror14,prca13,prca14
-  use mo_param_bgc,   only: rnit,ro2ut
+  use mo_param_bgc,   only: rnit,ro2ut,disso_sil,silsat,disso_poc,sed_denit,disso_caco3
+  use mo_sedmnt,      only: porwat,porsol,powtra,produs,prcaca,prorca,seddw,sedhpl,sedlay,silpro,pror13,pror14,prca13,prca14
   use mo_vgrid,       only: kbo,bolay
 
   implicit none
@@ -372,7 +371,7 @@ subroutine powach(kpie,kpje,kpke,kbnd,prho,omask,psao,lspin)
               end if
               sedlay(i,j,k,issso12) = sedlay(i,j,k,issso12) - posol
               powtra(i,j,k,ipowaph) = powtra(i,j,k,ipowaph) + posol*umfa
-              powtra(i,j,k,ipowno3) = powtra(i,j,k,ipowno3) + posol*umfa*rno3
+              powtra(i,j,k,ipowno3) = powtra(i,j,k,ipowno3) + posol*umfa*rnit
               if (use_cisonew) then
                  sedlay(i,j,k,issso13) = sedlay(i,j,k,issso13) - poso13
                  sedlay(i,j,k,issso14) = sedlay(i,j,k,issso14) - poso14

--- a/hamocc/powadi.F90
+++ b/hamocc/powadi.F90
@@ -56,7 +56,8 @@ subroutine powadi(j,kpie,kpje,solrat,sedb1,sediso,bolven,omask)
 !
 !**********************************************************************
 
-  use mo_sedmnt,     only: porwah,porwat,seddw,sedict,seddzi
+  use mo_sedmnt,     only: porwah,porwat,seddw,seddzi
+  use mo_param_bgc,  only: sedict
   use mo_param1_bgc, only: ks
   use mo_vgrid,      only: bolay
 


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik , I moved most sediment parameters to `mo_param_bgc` (with the exceptions of `calfa`, `oplfa`, `orgfa`, `clafa` that are calculated from parameters set in `mo_param_bgc` - if you wish, I can also transfer them). In 1D, it looks bit-identical - but I will also set up runs on betzy to test it there. 
Closes #296 