### PR TITLE
Exclude HAMOCC from compilation for cmp-flag ecosys=false

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,7 +68,6 @@ subdir('fuk95')
 subdir('channel')
 subdir('single_column')
 subdir('pkgs/')
-subdir('hamocc')
 
 # Handle options and add necessary flags and subfolders with source files
 
@@ -115,6 +114,7 @@ endif
 
 if get_option('ecosys')
   add_project_arguments('-DHAMOCC', language: 'fortran')
+  subdir('hamocc')
 endif
 
 if get_option('levitus2x')

--- a/trc/initrc.F
+++ b/trc/initrc.F
@@ -23,7 +23,9 @@ c --- ------------------------------------------------------------------
 c --- initialization of tracers
 c --- ------------------------------------------------------------------
 c
+#ifdef HAMOCC
       use mo_hamocc_init, only: hamocc_init
+#endif
 
       implicit none
 c

--- a/trc/restart_trcrd.F90
+++ b/trc/restart_trcrd.F90
@@ -23,7 +23,10 @@ subroutine restart_trcrd(rstfnm_ocn)
 ! --- Read tracer state from restart files
 ! --- ------------------------------------------------------------------
 !
+#ifdef HAMOCC
   use mo_hamocc_init, only: hamocc_init
+#endif
+
   use mod_config, only: expcnf
   use mod_xc
 

--- a/trc/restart_trcwt.F90
+++ b/trc/restart_trcwt.F90
@@ -23,7 +23,9 @@ subroutine restart_trcwt(rstfnm_ocn)
 ! --- Write tracer state to restart files
 ! --- ------------------------------------------------------------------
 !
+#ifdef HAMOCC
   use mo_restart_hamoccwt, only : restart_hamoccwt
+#endif
   use mod_config, only: expcnf
   use mod_xc
 

--- a/trc/updtrc.F
+++ b/trc/updtrc.F
@@ -23,7 +23,10 @@ c --- ------------------------------------------------------------------
 c --- update tracers due to non-passive processes
 c --- ------------------------------------------------------------------
 c
+#ifdef HAMOCC
       use mo_hamocc_step, only: hamocc_step
+#endif
+
       use mod_xc
 c
       implicit none


### PR DESCRIPTION
Hi @TomasTorsvik , @JorgSchwinger and @mvertens , as discussed among some of us, I reverted back Marianas changes wrt to the compilation of HAMOCC in case it is a physics-only setup. So essentially, the HAMOCC code part is only compiled, when it should be compiled, which can save compile time.  

This will (likely) be the last commit for the CMIP6-compatible HAMOCC version (not sure about BLOM, though). **Question:** How shall we handle the tagging #295 (or can/shall this be a separate commit - also since I am currently unaware, if there will be some BLOM commits)? 