### PR TITLE
Properly declare and initialize bifrXX_ini and clean mo_biomod from growth_co2

### DIFF
--- a/hamocc/mo_aufr_bgc.F90
+++ b/hamocc/mo_aufr_bgc.F90
@@ -95,7 +95,7 @@ CONTAINS
     use mo_vgrid,           only: kbo
     use mo_sedmnt,          only: sedhpl
     use mo_intfcblom,       only: sedlay2,powtra2,burial2,atm2
-    use mo_param_bgc,       only: bifr13,bifr14,c14fac,re1312,re14to,prei13,prei14
+    use mo_param_bgc,       only: bifr13_ini,bifr14_ini,c14fac,re1312,re14to,prei13,prei14
     use mo_netcdf_bgcrw,    only: read_netcdf_var
 
     ! Arguments
@@ -518,14 +518,14 @@ CONTAINS
               ! Initialise the remaining 13C and 14C fields, using the restart isco212 field
               rco213=locetra(i,j,k,isco213)/(locetra(i,j,k,isco212)+safediv)
               rco214=locetra(i,j,k,isco214)/(locetra(i,j,k,isco212)+safediv)
-              locetra(i,j,k,idoc13)=locetra(i,j,k,idoc)*rco213*bifr13
-              locetra(i,j,k,idoc14)=locetra(i,j,k,idoc)*rco214*bifr14
-              locetra(i,j,k,iphy13)=locetra(i,j,k,iphy)*rco213*bifr13
-              locetra(i,j,k,iphy14)=locetra(i,j,k,iphy)*rco214*bifr14
-              locetra(i,j,k,izoo13)=locetra(i,j,k,izoo)*rco213*bifr13
-              locetra(i,j,k,izoo14)=locetra(i,j,k,izoo)*rco214*bifr14
-              locetra(i,j,k,idet13)=locetra(i,j,k,idet)*rco213*bifr13
-              locetra(i,j,k,idet14)=locetra(i,j,k,idet)*rco214*bifr14
+              locetra(i,j,k,idoc13)=locetra(i,j,k,idoc)*rco213*bifr13_ini
+              locetra(i,j,k,idoc14)=locetra(i,j,k,idoc)*rco214*bifr14_ini
+              locetra(i,j,k,iphy13)=locetra(i,j,k,iphy)*rco213*bifr13_ini
+              locetra(i,j,k,iphy14)=locetra(i,j,k,iphy)*rco214*bifr14_ini
+              locetra(i,j,k,izoo13)=locetra(i,j,k,izoo)*rco213*bifr13_ini
+              locetra(i,j,k,izoo14)=locetra(i,j,k,izoo)*rco214*bifr14_ini
+              locetra(i,j,k,idet13)=locetra(i,j,k,idet)*rco213*bifr13_ini
+              locetra(i,j,k,idet14)=locetra(i,j,k,idet)*rco214*bifr14_ini
               locetra(i,j,k,icalc13)=locetra(i,j,k,icalc)*rco213
               locetra(i,j,k,icalc14)=locetra(i,j,k,icalc)*rco214
             endif
@@ -542,8 +542,8 @@ CONTAINS
                 rco214=locetra(i,j,kbo(i,j),isco214)/(locetra(i,j,kbo(i,j),isco212)+safediv)
                 powtra2(i,j,k,ipowc13)=powtra2(i,j,k,ipowaic)*rco213
                 powtra2(i,j,k,ipowc14)=powtra2(i,j,k,ipowaic)*rco214
-                sedlay2(i,j,k,issso13)=sedlay2(i,j,k,issso12)*rco213*bifr13
-                sedlay2(i,j,k,issso14)=sedlay2(i,j,k,issso12)*rco214*bifr14
+                sedlay2(i,j,k,issso13)=sedlay2(i,j,k,issso12)*rco213*bifr13_ini
+                sedlay2(i,j,k,issso14)=sedlay2(i,j,k,issso12)*rco214*bifr14_ini
                 sedlay2(i,j,k,isssc13)=sedlay2(i,j,k,isssc12)*rco213
                 sedlay2(i,j,k,isssc14)=sedlay2(i,j,k,isssc12)*rco214
               endif
@@ -557,8 +557,8 @@ CONTAINS
               if(omask(i,j)  >  0.5) then
                 rco213=locetra(i,j,kbo(i,j),isco213)/(locetra(i,j,kbo(i,j),isco212)+safediv)
                 rco214=locetra(i,j,kbo(i,j),isco214)/(locetra(i,j,kbo(i,j),isco212)+safediv)
-                burial2(i,j,k,issso13)=burial2(i,j,k,issso12)*rco213*bifr13
-                burial2(i,j,k,issso14)=burial2(i,j,k,issso12)*rco214*bifr14
+                burial2(i,j,k,issso13)=burial2(i,j,k,issso12)*rco213*bifr13_ini
+                burial2(i,j,k,issso14)=burial2(i,j,k,issso12)*rco214*bifr14_ini
                 burial2(i,j,k,isssc13)=burial2(i,j,k,isssc12)*rco213
                 burial2(i,j,k,isssc14)=burial2(i,j,k,isssc12)*rco214
               endif

--- a/hamocc/mo_biomod.F90
+++ b/hamocc/mo_biomod.F90
@@ -84,8 +84,6 @@ module mo_biomod
   real, dimension (:,:),   allocatable, public  :: int_chbr3_prod
   real, dimension (:,:),   allocatable, public  :: int_chbr3_uv
 
-  real, public :: growth_co2
-
 CONTAINS
 
   subroutine alloc_mem_biomod(kpie,kpje,kpke)

--- a/hamocc/mo_biomod.F90
+++ b/hamocc/mo_biomod.F90
@@ -85,7 +85,6 @@ module mo_biomod
   real, dimension (:,:),   allocatable, public  :: int_chbr3_uv
 
   real, public :: growth_co2
-  real, public :: bifr13_perm
 
 CONTAINS
 

--- a/hamocc/mo_ini_fields.F90
+++ b/hamocc/mo_ini_fields.F90
@@ -87,7 +87,7 @@ contains
     !***********************************************************************************************
 
     use mo_carbch,      only: co2star,co3,hi,ocetra
-    use mo_param_bgc,   only: fesoly,cellmass,fractdim,bifr13,bifr14,c14fac,re1312,re14to
+    use mo_param_bgc,   only: fesoly,cellmass,fractdim,bifr13_ini,bifr14_ini,c14fac,re1312,re14to
     use mo_biomod,      only: abs_oce
     use mo_control_bgc, only: rmasks,use_FB_BGC_OCE,use_cisonew,use_AGG,use_CFC,use_natDIC,        &
                               use_BROMO, use_sedbypass
@@ -213,14 +213,14 @@ contains
             if (use_cisonew) then
               rco213=ocetra(i,j,k,isco213)/(ocetra(i,j,k,isco212)+safediv)
               rco214=ocetra(i,j,k,isco214)/(ocetra(i,j,k,isco212)+safediv)
-              ocetra(i,j,k,iphy13) =ocetra(i,j,k,iphy)*rco213*bifr13
-              ocetra(i,j,k,iphy14) =ocetra(i,j,k,iphy)*rco214*bifr14
-              ocetra(i,j,k,izoo13) =ocetra(i,j,k,izoo)*rco213*bifr13
-              ocetra(i,j,k,izoo14) =ocetra(i,j,k,izoo)*rco214*bifr14
-              ocetra(i,j,k,idoc13) =ocetra(i,j,k,idoc)*rco213*bifr13
-              ocetra(i,j,k,idoc14) =ocetra(i,j,k,idoc)*rco214*bifr14
-              ocetra(i,j,k,idet13) =ocetra(i,j,k,idet)*rco213*bifr13
-              ocetra(i,j,k,idet14) =ocetra(i,j,k,idet)*rco214*bifr14
+              ocetra(i,j,k,iphy13) =ocetra(i,j,k,iphy)*rco213*bifr13_ini
+              ocetra(i,j,k,iphy14) =ocetra(i,j,k,iphy)*rco214*bifr14_ini
+              ocetra(i,j,k,izoo13) =ocetra(i,j,k,izoo)*rco213*bifr13_ini
+              ocetra(i,j,k,izoo14) =ocetra(i,j,k,izoo)*rco214*bifr14_ini
+              ocetra(i,j,k,idoc13) =ocetra(i,j,k,idoc)*rco213*bifr13_ini
+              ocetra(i,j,k,idoc14) =ocetra(i,j,k,idoc)*rco214*bifr14_ini
+              ocetra(i,j,k,idet13) =ocetra(i,j,k,idet)*rco213*bifr13_ini
+              ocetra(i,j,k,idet14) =ocetra(i,j,k,idet)*rco214*bifr14_ini
               ocetra(i,j,k,icalc13)=ocetra(i,j,k,icalc)*rco213
               ocetra(i,j,k,icalc14)=ocetra(i,j,k,icalc)*rco214
             endif
@@ -268,10 +268,10 @@ contains
               if (use_cisonew) then
                 rco213=ocetra(i,j,kbo(i,j),isco213)/(ocetra(i,j,kbo(i,j),isco212)+safediv)
                 rco214=ocetra(i,j,kbo(i,j),isco214)/(ocetra(i,j,kbo(i,j),isco212)+safediv)
-                powtra(i,j,k,ipowc13)=powtra(i,j,k,ipowaic)*rco213*bifr13
-                powtra(i,j,k,ipowc14)=powtra(i,j,k,ipowaic)*rco214*bifr14
-                sedlay(i,j,k,issso13)=sedlay(i,j,k,issso12)*rco213*bifr13
-                sedlay(i,j,k,issso14)=sedlay(i,j,k,issso12)*rco214*bifr14
+                powtra(i,j,k,ipowc13)=powtra(i,j,k,ipowaic)*rco213*bifr13_ini
+                powtra(i,j,k,ipowc14)=powtra(i,j,k,ipowaic)*rco214*bifr14_ini
+                sedlay(i,j,k,issso13)=sedlay(i,j,k,issso12)*rco213*bifr13_ini
+                sedlay(i,j,k,issso14)=sedlay(i,j,k,issso12)*rco214*bifr14_ini
                 sedlay(i,j,k,isssc13)=sedlay(i,j,k,isssc12)*rco213
                 sedlay(i,j,k,isssc14)=sedlay(i,j,k,isssc12)*rco214
               endif

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -43,11 +43,11 @@ contains
     !  I.Kriest,              *GEOMAR*         2016-08-11
     !   - Modified stoichiometry for denitrification (affects NO3, N2, Alk)
     !  J.Schwinger,           *UNI-RESEARCH*   2017-08-30
-    !   - Removed split of the layer that only partly falls into the euphotic zone. Loops are 
+    !   - Removed split of the layer that only partly falls into the euphotic zone. Loops are
     !     now calculated over
     !      (1) layers that are completely or partly in the euphotoc zone
     !      (2) layers that do not lie within the euphotic zone.
-    !   - Moved the accumulation of global fields for output to routine hamocc4bgc. 
+    !   - Moved the accumulation of global fields for output to routine hamocc4bgc.
     !     The accumulation of local fields has been moved to the end of this routine.
     !  A.Moree,          *GFI, Bergen*   2018-04-12
     !   - new version of carbon isotope code
@@ -72,7 +72,7 @@ contains
                                 alow1,alow2,alow3,calmax,cellmass,                                 &
                                 cellsink,dustd1,dustd2,dustd3,dustsink,fractdim,                   &
                                 fse,fsh,nmldmin,plower,pupper,sinkexp,stick,tmfac,                 &
-                                tsfac,vsmall,zdis,wmin,wmax,wlin,rbro,bifr13,bifr14,               &
+                                tsfac,vsmall,zdis,wmin,wmax,wlin,rbro,                             &
                                 dmsp1,dmsp2,dmsp3,dmsp4,dmsp5,dmsp6,dms_gamma,                     &
                                 fbro1,fbro2,atten_f,atten_c,atten_uv,atten_w,bkopal,bkphy,bkzoo
     use mo_biomod,        only: bsiflx0100,bsiflx0500,bsiflx1000,bsiflx2000,bsiflx4000,bsiflx_bot, &
@@ -80,7 +80,7 @@ contains
                                 carflx0100,carflx0500,carflx1000,carflx2000,carflx4000,carflx_bot, &
                                 expoor,exposi,expoca,intdnit,intdms_bac,intdmsprod,intdms_uv,      &
                                 intphosy,int_chbr3_prod,int_chbr3_uv,                              &
-                                phosy3d,abs_oce,strahl,asize3d,wmass,wnumb,eps3d,bifr13_perm,      &
+                                phosy3d,abs_oce,strahl,asize3d,wmass,wnumb,eps3d,                  &
                                 growth_co2
     use mo_param1_bgc,    only: ialkali,ian2o,iano3,icalc,idet,idms,idoc,ifdust,                   &
                                 igasnit,iiron,iopal,ioxygen,iphosph,iphy,isco212,                  &
@@ -131,6 +131,7 @@ contains
     ! cisonew
     real :: phygrowth
     real :: phosy13,phosy14
+    real :: bifr13,bifr14,bifr13_perm
     real :: grazing13,grazing14
     real :: graton13,graton14
     real :: gratpoc13,gratpoc14
@@ -271,7 +272,7 @@ contains
     !$OMP  ,graton13,graton14,gratpoc13,gratpoc14,grawa13,grawa14         &
     !$OMP  ,phosy13,phosy14,bacfra13,bacfra14,phymor13,phymor14,zoomor13  &
     !$OMP  ,zoomor14,excdoc13,excdoc14,exud13,exud14,export13,export14    &
-    !$OMP  ,delcar13,delcar14,dtr13,dtr14,bifr13,bifr14                   &
+    !$OMP  ,delcar13,delcar14,dtr13,dtr14,bifr13,bifr14,bifr13_perm       &
     !$OMP  ,bro_beta,bro_uv                                               &
     !$OMP  ,i,k)
 

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -80,8 +80,7 @@ contains
                                 carflx0100,carflx0500,carflx1000,carflx2000,carflx4000,carflx_bot, &
                                 expoor,exposi,expoca,intdnit,intdms_bac,intdmsprod,intdms_uv,      &
                                 intphosy,int_chbr3_prod,int_chbr3_uv,                              &
-                                phosy3d,abs_oce,strahl,asize3d,wmass,wnumb,eps3d,                  &
-                                growth_co2
+                                phosy3d,abs_oce,strahl,asize3d,wmass,wnumb,eps3d
     use mo_param1_bgc,    only: ialkali,ian2o,iano3,icalc,idet,idms,idoc,ifdust,                   &
                                 igasnit,iiron,iopal,ioxygen,iphosph,iphy,isco212,                  &
                                 isilica,izoo,iadust,inos,ibromo,                                   &
@@ -131,6 +130,7 @@ contains
     ! cisonew
     real :: phygrowth
     real :: phosy13,phosy14
+    real :: growth_co2
     real :: bifr13,bifr14,bifr13_perm
     real :: grazing13,grazing14
     real :: graton13,graton14
@@ -273,6 +273,7 @@ contains
     !$OMP  ,phosy13,phosy14,bacfra13,bacfra14,phymor13,phymor14,zoomor13  &
     !$OMP  ,zoomor14,excdoc13,excdoc14,exud13,exud14,export13,export14    &
     !$OMP  ,delcar13,delcar14,dtr13,dtr14,bifr13,bifr14,bifr13_perm       &
+    !$OMP  ,growth_co2,phygrowth                                          &
     !$OMP  ,bro_beta,bro_uv                                               &
     !$OMP  ,i,k)
 

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -65,7 +65,7 @@ module mo_param_bgc
   public :: re14to,prei13,prei14,ctochl
   public :: atten_w,atten_c,atten_uv,atten_f
   public :: perc_diron,fesoly,phytomi,pi_alpha
-  public :: dyphy,tf2,tf1,tf0,tff,bifr13,bifr14,c14_t_half
+  public :: dyphy,tf2,tf1,tf0,tff,bifr13_ini,bifr14_ini,c14_t_half
   public :: rbro,fbro1,fbro2,grami
   public :: calmax,remido
   public :: dustd1,dustd2,dustd3,dustsink
@@ -168,8 +168,8 @@ module mo_param_bgc
   real, protected :: dyphy      = 0.004           ! 1/d -mortality rate of phytoplankton
 
   ! Initial fractionation during photosynthesis
-  real :: bifr13 = 0.98
-  real :: bifr14
+  real, protected :: bifr13_ini = 0.98
+  real, protected :: bifr14_ini
 
   ! N2-Fixation following the parameterization in Kriest and Oschlies, 2015.
   ! Factors tf2, tf1 and tf0 are a polynomial (2nd order)
@@ -415,7 +415,7 @@ contains
     ! AFTER reading the namelist:
     ! calulate parameters that depend on other tunable parameters
     !
-    bifr14  = bifr13**2
+    bifr14_ini  = bifr13_ini**2
 
     perc_diron = fetune * 0.035 * 0.01 / 55.85
 
@@ -591,8 +591,8 @@ contains
         write(io_stdo_bgc,*) '*   atm_c13      = ',atm_c13
         write(io_stdo_bgc,*) '*   d13C_atm     = ',d13C_atm
         write(io_stdo_bgc,*) '*   atm_c14      = ',atm_c14
-        write(io_stdo_bgc,*) '*   bifr13       = ',bifr13
-        write(io_stdo_bgc,*) '*   bifr14       = ',bifr14
+        write(io_stdo_bgc,*) '*   bifr13_ini   = ',bifr13_ini
+        write(io_stdo_bgc,*) '*   bifr14_ini   = ',bifr14_ini
         write(io_stdo_bgc,*) '*   c14fac       = ',c14fac
         write(io_stdo_bgc,*) '*   prei13       = ',prei13
         write(io_stdo_bgc,*) '*   prei14       = ',prei14


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger , this is the PR to properly declare and initialize the `bifrXX`. In addition, I cleaned `mo_biomod` from `growth_co2` since it was/is only used as local variable in `mo_ocprod`.

After this PR, I believe that the `beyond-CMIP6` branch is ready to be merged into `master`, which eventually breaks CMIP6 backward compatibility of `master` and makes it ready for NorESM2.1. Technically, the tagging #295 can then still be included in `master`...  