### PR TITLE
Hybrid coordinate enhancements 3

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -65,8 +65,8 @@
     <type>char</type>
     <valid_values>isopyc_bulkml,cntiso_hybrid</valid_values>
     <default_value>isopyc_bulkml</default_value>
-    <group>run_component_blom</group>
-    <file>env_run.xml</file>
+    <group>build_component_blom</group>
+    <file>env_build.xml</file>
     <desc>Vertical coordinate type of BLOM</desc>
   </entry>
 

--- a/phy/mod_difest.F
+++ b/phy/mod_difest.F
@@ -1650,13 +1650,7 @@ c --- --- Eady growth rate.
                     egrup(i)=egrlo
                     if (edsprs.or.edanis) then
                       if (eddf2d) then
-                        if (p(i,j,k+1).gt.
-     .                      min(p(i-1,j,kk+1),p(i+1,j,kk+1),
-     .                          p(i,j-1,kk+1),p(i,j+1,kk+1))) then
-                          q=0.
-                        else
-                          q=max(0.,p(i,j,k+1)-p(i,j,k))
-                        endif
+                        q=max(0.,p(i,j,k+1)-p(i,j,k))
                       else
                         q=max(0.,min(p(i,j,kfil(i,j))+dpgrav,
      .                               p(i,j,k+1))-p(i,j,k))
@@ -1765,13 +1759,7 @@ c --- --------- Accumulate diffusivities and estimate and accumulate
 c --- --------- anisotrophy if requested.
 c
                 if (eddf2d) then
-                  if (p(i,j,k+1).gt.
-     .                min(p(i-1,j,kk+1),p(i+1,j,kk+1),
-     .                    p(i,j-1,kk+1),p(i,j+1,kk+1))) then
-                    q=0.
-                  else
-                    q=max(0.,p(i,j,k+1)-p(i,j,k))
-                  endif
+                  q=max(0.,p(i,j,k+1)-p(i,j,k))
                 else
 c
 c --- ----------- Only consider a region below the first physical layer

--- a/phy/mod_vcoord.F90
+++ b/phy/mod_vcoord.F90
@@ -622,7 +622,7 @@ contains
                            /(p_src(kl+1,i) - p_src(kl,i))
             if (sigmar_1d(kt) > sig_pmin(kt)) then
                ktzmin = max(2, kt - dktzu)
-               ktzmax = min(ksmx(i), kdmx(i), kt + dktzl)
+               ktzmax = min(ksmx(i) + 1, kt + dktzl)
                if (ktzmin < kt .and. ktzmax - ktzmin > 1) tzfound = .true.
                exit
             endif
@@ -748,7 +748,7 @@ contains
             if (d > 0._r8) then
                do k = ktzmin, ktzmax-1
                   rk = k - ktzmin + ckt
-                  p_dst(k,i) = a + rk*(b + rk*(c + rk*d))
+                  p_dst(k,i) = max(p_dst(k,i), a + rk*(b + rk*(c + rk*d)))
                enddo
             endif
          endif

--- a/phy/mod_vcoord.F90
+++ b/phy/mod_vcoord.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2021-2022 Mats Bentsen, Mehmet Ilicak
+! Copyright (C) 2021-2023 Mats Bentsen, Mehmet Ilicak
 !
 ! This file is part of BLOM.
 !


### PR DESCRIPTION
Hybrid coordinate enhancements that includes:
- Modified the transition between isopycnic and constant pressure interfaces to make it less sensitive to bathymetry variations.
- Modified the estimation of neutral slope vector times Brunt-Vaisala frequency in the vicinity of bathymetry to make Eady growth rate estimates more robust.
- Moved BLOM_VCOORD from run_component_blom to build_component_blom group (BLOM_VCOORD is needed for building since it defines the number of vertical layers used).

Model results change when using hybrid coordinate, but are unchanged with isopycnic coordinate.