### PR TITLE
Update meson and remove build with intel compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: python -m pip install meson==${{ env.MESON_VERSION }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Setup Python for newer version of Meson
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Install Meson
         run: python -m pip install meson==${{ env.MESON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload test log
         if: ${{ matrix.mpi == false }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: testlog-${{ runner.os }}-gcc
           path: builddir/meson-logs/testlog.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Setup Python for newer version of Meson
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install Meson
         run: python -m pip install meson==${{ env.MESON_VERSION }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload test log
         if: ${{ matrix.mpi == false }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: testlog-${{ runner.os }}-gcc
           path: builddir/meson-logs/testlog.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 env:
   # This version of Meson should be available as an EasyBuild on Fram and Betzy
-  MESON_VERSION: '0.55.1'
+  MESON_VERSION: '1.1.1'
 jobs:
   build:
     name: Build BLOM on Github provided OS
@@ -67,100 +67,3 @@ jobs:
           name: testlog-${{ runner.os }}-gcc
           path: builddir/meson-logs/testlog.txt
 
-  intel:
-    name: Build BLOM using Intel compilers
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        mpi: [true, false]
-        openmp: ['enabled', 'disabled']
-        ecosys: [true, false]
-        exclude:
-          # Run test (fuk95 executed with mpi=false) fails with ecosys
-          - ecosys: true
-            mpi: false
-    # Tell Meson to use Intel compilers
-    env:
-      CC: icc
-      FC: ifort
-      NFDIR: '/opt/netcdf'
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build libnetcdf-dev
-      - name: Cache Intel setup
-        id: cache-intel
-        uses: actions/cache@v2
-        with:
-          path: /opt/intel/
-          key: intel-${{ runner.os }}-compiler
-
-      - name: Setup Intel compiler
-        if: steps.cache-intel.outputs.cache-hit != 'true'
-        run: |
-          wget -q https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt update
-          sudo apt install -y\
-            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic\
-            intel-oneapi-compiler-fortran intel-oneapi-mpi-devel
-
-      - name: Cache netCDF install
-        id: cache-netcdf
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.NFDIR }}
-          key: netcdf-4.5.2-${{ runner.os }}-intel
-
-      - name: Checkout netCDF for compiling with Intel
-        if: steps.cache-netcdf.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
-        with:
-          repository: 'Unidata/netcdf-fortran'
-          ref: 'v4.5.2'
-
-      - name: Compile and install custom netCDF
-        if: steps.cache-netcdf.outputs.cache-hit != 'true'
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          ./configure --prefix="$NFDIR"
-          make
-          sudo make install
-
-      - name: Setup netCDF environment
-        run: |
-          echo "${NFDIR}/bin" >> $GITHUB_PATH
-          echo "PKG_CONFIG_PATH=${NFDIR}/lib/pkgconfig" >> $GITHUB_ENV
-
-      - name: Setup Python for newer version of Meson
-        uses: actions/setup-python@v2
-
-      - name: Install Meson
-        run: python -m pip install meson==${{ env.MESON_VERSION }}
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-
-      - name: Build with Intel compilers
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          meson setup builddir -Dmpi=${{ matrix.mpi }} -Dopenmp=${{ matrix.openmp }} -Decosys=${{ matrix.ecosys }} --buildtype=debugoptimized
-          meson compile -C builddir
-
-      - name: Test code
-        if: ${{ matrix.mpi == false }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          meson test -C builddir
-
-      - name: Upload test log
-        uses: actions/upload-artifact@v2
-        if: ${{ matrix.mpi == false }}
-        with:
-          name: testlog-${{ runner.os }}-intel
-          path: builddir/meson-logs/testlog.txt


### PR DESCRIPTION
The build with intel compiler seems to be permanently broken, so all PRs to the main repository produce CI errors. The setup for intel compilers is linked to specific version and not straight forward to update. Unless someone has time to dig into the origin of these errors and preferably come up with a generic way to keep this up to date, I suggest to remove intel compiler tests from the CI test procedure,