### PR TITLE
Keep only `user_nl_blom`-changed values for namelist `/bgcparams/`

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -260,6 +260,17 @@ def buildnml(case, caseroot, compname):
         # for now don't write out bgcparams - just create an empty namelist
         if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
              groups.append("bgcparams")
+             """
+             !!! The following line deletes all entries for group 'bgcparams' 
+             !!! that are ONLY present in namelist_definition_blom.xml 
+             !!! and keeps entries provided through user_nl_blom
+             !!! This makes sure that i) only Fortran-hard coded values from mo_param_bgc.F90
+             !!! are used and that ii) user_nl_blom enables tuning these default parameters.
+             !!! Note that an entry in namelist_definition_blom.xml for the tuning parameter 
+             !!! is still required, while its value can be set to None. 
+             !!! This is an interim solution and the line below can be simply deleted, once 
+             !!! xml is used as default for the bgcparams namelist as well.
+             """
              pg_blom.keep_usernml_only('bgcparams')
 
         pg_blom.write_nmlfile(namelist_file, groups)

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -258,10 +258,11 @@ def buildnml(case, caseroot, compname):
             groups.append("config_bgc")
 
         # for now don't write out bgcparams - just create an empty namelist
-        # if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
-        #     groups.append("bgcparams")
+        if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
+             groups.append("bgcparams")
+             pg_blom.keep_usernml_only('bgcparams')
 
-        pg_blom.write_nmlfile(namelist_file, groups, empty_namelists=["bgcparams"])
+        pg_blom.write_nmlfile(namelist_file, groups)
 
         # Replace MER_REGFLAG1 -> MER_REGFLAG4 with array syntax in ocn_in
         from pathlib import Path

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3981,7 +3981,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>4.e-8</value>
+      <value>None</value>
     </values>
     <desc>phytoplankton parameter: kmol/m3 - i.e. 0.04 mmol P/m3 half saturation constant</desc>
   </entry>
@@ -3991,7 +3991,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.004</value>
+      <value>None</value>
     </values>
     <desc>phytoplankton parameter: 1/d -mortality rate of phytoplankton </desc>
   </entry>
@@ -4001,7 +4001,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.005</value>
+      <value>None</value>
     </values>
     <desc>phytoplankton parameter: 1/d - nitrogen fixation rate by blue green algae (cyanobacteria)</desc>
   </entry>
@@ -4011,7 +4011,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>8.e-8</value>
+      <value>None</value>
     </values>
     <desc>zooplankton parameter: kmol/m3 - i.e. 0.08 mmol P/m3 half saturation constant</desc>
   </entry>
@@ -4021,7 +4021,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>1.2</value>
+      <value>None</value>
     </values>
     <desc>zooplankton parameter: 1/d -grazing rate</desc>
   </entry>
@@ -4031,7 +4031,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>3.e6</value>
+      <value>None</value>
     </values>
     <desc>zooplankton parameter: 1/d -mortality rate</desc>
   </entry>
@@ -4041,7 +4041,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.04</value>
+      <value>None</value>
     </values>
     <desc>zooplankton parameter: 1/d -exudation rate</desc>
   </entry>
@@ -4051,7 +4051,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.06</value>
+      <value>None</value>
     </values>
     <desc>zooplankton parameter: 1/d -excretion rate</desc>
   </entry>
@@ -4061,7 +4061,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.95</value>
+      <value>None</value>
     </values>
     <desc>zooplankton parameter: fraction of mortality as PO_4</desc>
   </entry>
@@ -4071,7 +4071,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.6</value>
+      <value>None</value>
       <value use_wlin="yes">0.7</value>
       <value use_agg="yes">0.5</value>
     </values>
@@ -4083,9 +4083,9 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.8</value>
-      <value use_wlin="yes">0.85</value>
-      <value use_agg="yes">0.9</value>
+      <value>None</value>
+      <value use_wlin="yes">None</value>
+      <value use_agg="yes">None</value>
     </values>
     <desc>zooplankton parameter: dimensionless fraction -fraction of grazing egested</desc>
   </entry>
@@ -4095,7 +4095,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>5.e-6</value>
+      <value>None</value>
     </values>
     <desc>shell production parameter: kmol/m3 - i.e. 4.0 mmol Si/m3 half saturation constant</desc>
   </entry>
@@ -4105,9 +4105,9 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>40.</value>
-      <value use_wlin="yes">33.</value>
-      <value use_agg="yes">14.</value>
+      <value>None</value>
+      <value use_wlin="yes">None</value>
+      <value use_agg="yes">None</value>
     </values>
     <desc>shell production parameter: calcium carbonate to organic phosphorous production ratio</desc>
   </entry>
@@ -4117,9 +4117,9 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>30.</value>
-      <value use_wlin="yes">45.</value>
-      <value use_agg="yes">10.5</value>
+      <value>None</value>
+      <value use_wlin="yes">None</value>
+      <value use_agg="yes">None</value>
     </values>
     <desc>shell production parameter:</desc>
   </entry>
@@ -4129,7 +4129,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.004</value>
+      <value>None</value>
     </values>
     <desc>remineralization and dissolution parameter: 1/d -remineralization rate (of DOM)</desc>
   </entry>
@@ -4139,7 +4139,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.025</value>
+      <value>None</value>
     </values>
     <desc>remineralization and dissolution parameter: 1/d Aerob remineralization rate detritus</desc>
   </entry>
@@ -4149,7 +4149,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.003</value>
+      <value>None</value>
     </values>
     <desc>remineralization and dissolution parameter: 1/d Dissolution rate for opal</desc>
   </entry>
@@ -4159,7 +4159,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.01</value>
+      <value>None</value>
     </values>
     <desc>remineralization and dissolution parameter: 1/d Remineralization rate of detritus on N2O</desc>
   </entry>
@@ -4169,7 +4169,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.005</value>
+      <value>None</value>
     </values>
     <desc>remineralization and dissolution parameter: 1/d Remineralization rate for sulphate reduction </desc>
   </entry>
@@ -4179,7 +4179,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>0.6</value>
+      <value>None</value>
     </values>
     <desc>Dust deposition and iron solubility parameter: factor introduced to tune deposition/solubility</desc>
   </entry>
@@ -4200,7 +4200,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>5.</value>
+      <value>None</value>
     </values>
     <desc>Sinking parameter: m/d   Sinking speed of detritus iris : 5.</desc>
   </entry>
@@ -4210,7 +4210,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>30.</value>
+      <value>None</value>
     </values>
     <desc>Sinking parameter: m/d   Sinking speed of CaCO3 shell material</desc>
   </entry>
@@ -4220,7 +4220,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>30.</value>
+      <value>None</value>
     </values>
     <desc>Sinking parameter: m/d Sinking speed of opal iris : 60</desc>
   </entry>
@@ -4230,7 +4230,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>1.</value>
+      <value>None</value>
     </values>
     <desc>Sinking parameter: m/d minimum sinking speed</desc>
   </entry>
@@ -4240,7 +4240,7 @@
     <category>bgcparams</category>
     <group>bgcparams</group>
     <values>
-      <value>60.</value>
+      <value>None</value>
     </values>
     <desc>Sinking parameter: m/d maximum sinking speed</desc>
   </entry>

--- a/cime_config/ocn_in_paramgen.py
+++ b/cime_config/ocn_in_paramgen.py
@@ -815,6 +815,7 @@ class OcnInParamGen(ParamGen):
         #of all namelist groups and variables:
         self.__nml_def_groups = {}
         self.__nml_def_vars   = {}
+        self.__usernml_def_vars = {}
 
         #Set variables needed for ParamGen "reduction":
         self.__case = None
@@ -1471,6 +1472,7 @@ class OcnInParamGen(ParamGen):
 
             #Append new user_nl_blom object to main ocn_in namelist object:
             self.append(pg_user)
+            self.__usernml_def_vars.update(_data)
         #End if
     ####
 
@@ -1698,6 +1700,19 @@ class OcnInParamGen(ParamGen):
 
         #Return value if found:
         return val
+
+    def keep_usernml_only(self,groupname):
+        """
+        For groupname, keep only attributes changed via the nml
+        """
+        # go through entries found in namelist_definition_blom.xml for groupname
+        for entry in sorted (self._data[groupname]):
+            # if the user_nl_blom didn't hold any values corresponding to groupname
+            # delete entries
+            if groupname not in list(self._OcnInParamGen__usernml_def_vars.keys()):
+              del self._data[groupname][entry]
+            elif entry not in list(self._OcnInParamGen__usernml_def_vars[groupname].keys()):
+              del self._data[groupname][entry]
 
 ############
 #End of file

--- a/cime_config/ocn_in_paramgen.py
+++ b/cime_config/ocn_in_paramgen.py
@@ -1472,6 +1472,7 @@ class OcnInParamGen(ParamGen):
 
             #Append new user_nl_blom object to main ocn_in namelist object:
             self.append(pg_user)
+            # Keep track, which parameters were provided through the user_nl_blom
             self.__usernml_def_vars.update(_data)
         #End if
     ####


### PR DESCRIPTION
This is a suggestion on how to tackle the issue on hard-coded versus xml-coded parameters. Only parameters changed through `user_nl_blom` will be kept to write into the nml-group `/bgcparams/`. All other groups are not affected with this approach and it is minimally invasive. I tested with some parameters set to `None` in the `namelist_definition_blom.xml` (to avoid confusions) and it works as well. Model build works as well for ocean only setups and coupled simulations (tested until `./case.build`).

This means that essentially all variables can be defined in the Fortran part (and with `None`-value in the `namelist_definition_blom.xml` and only tuning parameters set via the `user_nl_blom` will be forwarded to `ocn_in`. No further preprocessor-flag is required to distinguish between coupled or standalone runs and in case that at some point we decide that the xml-way is the only way, all infrastructure is already there - only the values need to be once transferred.   

Closes #327 