### PR TITLE
Decrease opal dissolution rate in sediments and switch on sediment spinup by default

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -152,7 +152,7 @@
   <entry id="HAMOCC_SEDSPINUP">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+    <default_value>TRUE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Activate sediment spinup. HAMOCC_SEDSPINUP_YR_START and HAMOCC_SEDSPINUP_YR_END 
@@ -162,7 +162,7 @@
   <entry id="HAMOCC_SEDSPINUP_YR_START">
     <type>integer</type>
     <valid_values/>
-    <default_value>-1</default_value>
+    <default_value>1</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set start year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE. 
@@ -172,7 +172,7 @@
   <entry id="HAMOCC_SEDSPINUP_YR_END">
     <type>integer</type>
     <valid_values/>
-    <default_value>-1</default_value>
+    <default_value>800</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set end year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE. 
@@ -182,7 +182,7 @@
   <entry id="HAMOCC_SEDSPINUP_NCYCLE">
     <type>integer</type>
     <valid_values/>
-    <default_value>-1</default_value>
+    <default_value>20</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set the number of sub-cycles for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE. 

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -269,11 +269,7 @@ module mo_param_bgc
   real, protected :: sedict      = 1.e-9          ! m2/s Molecular diffusion coefficient
   real, protected :: silsat      = 0.001          ! kmol/m3 Silicate saturation concentration is 1 mol/m3
   real, protected :: disso_poc   = 0.01 / 86400.  ! 1/(kmol O2/m3 s) disso=3.e-5 was quite high - Degradation rate constant of POP
-  real, protected :: disso_sil   = 1.e-6          ! 1/(kmol Si(OH)4/m3 s) Dissolution rate constant of opal
-  ! THIS NEEDS TO BE CHANGED TO disso=3.e-8! THIS IS ONLY KEPT FOR THE MOMENT
-  ! FOR BACKWARDS COMPATIBILITY
-  ! disso_sil = 3.e-8*dtbgc  ! (2011-01-04) EMR
-  ! disso_sil = 1.e-6*dtbgc  ! test vom 03.03.04 half live sil ca. 20.000 yr
+  real, protected :: disso_sil   = 3.e-8          ! 1/(kmol Si(OH)4/m3 s) Dissolution rate constant of opal
   real, protected :: disso_caco3 = 1.e-7          ! 1/(kmol CO3--/m3 s) Dissolution rate constant of CaCO3
   real, protected :: sed_denit   = 0.01/86400.    ! 1/s Denitrification rate constant of POP
 


### PR DESCRIPTION
This PR fixes the use of a way too large opal dissolution rate in the sediments. This has relatively large consequences on the results. Therefore, switch on the sediment acceleration scheme by default, since this largely counteracts the effects of the decreased sediment opal dissolution. This PR has been tested in long simulations using the tnx2v1 ocean-only setup. Simulation results are very reasonable, such that they can go into the master branch, for further testing with other developments. Some further tuning might be necessary later on.