### PR TITLE
New and updated topographic beta files.

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1097,7 +1097,10 @@
     <group>diffusion</group>
     <values>
       <value>unset</value>
-      <value ocn_grid="tnx1v4">$DIN_LOC_ROOT/ocn/blom/bndcon/topo_beta_tnx1v4_20170622_python_coarse_nc64bitoffset.nc</value>
+      <value ocn_grid="tnx2v1">$DIN_LOC_ROOT/ocn/blom/bndcon/topo_beta_tnx2v1_20130206_depth_python_SYNBATH_V1.1_3minute_filt_max100km_nc64bitoffset.nc</value>
+      <value ocn_grid="tnx1v4">$DIN_LOC_ROOT/ocn/blom/bndcon/topo_beta_tnx1v4_20170622_depth_python_SYNBATH_V1.1_3minute_filt_max100km_nc64bitoffset.nc</value>
+      <value ocn_grid="tnx0.25v4">$DIN_LOC_ROOT/ocn/blom/bndcon/topo_beta_tnx0.125v4_20221013_depth_python_SYNBATH_V1.1_3minute_filt_max100km_nc64bitoffset.nc</value>
+      <value ocn_grid="tnx0.125v4">$DIN_LOC_ROOT/ocn/blom/bndcon/topo_beta_tnx0.125v4_20221013_depth_python_SYNBATH_V1.1_3minute_filt_max100km_nc64bitoffset.nc</value>
     </values>
     <desc>Name of file containing topographic beta parameter (a)Name of file containing topographic beta parameter</desc>
   </entry>


### PR DESCRIPTION
New and updated topographic beta files, prepared by Aleksi Nummelin, are specified for grids tnx2v1, tnx1v4, tnx0.25v4 and tnx0.125v4. The updated topographic beta file for grid tnx1v4 has been tested for one cycle of the OMIP2 protocol. Diagnostics with the previous topographic beta file can be found here:

https://ns1012k.web.sigma2.no/diagnostics/noresm/matsbn/NOIIAJRAOC20TR_TL319_tn14_ppm_notz_20240312/

while diagnostics with the updated topographic beta file can be found here:

https://ns1012k.web.sigma2.no/diagnostics/noresm/matsbn/NOIIAJRAOC20TR_TL319_tn14_topobeta_20240410/