### PR TITLE
Changed default eddy parameterization for isopycnic vertical coordinate

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -996,8 +996,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>.false.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">.true.</value>
+      <value>.true.</value>
     </values>
     <desc>If true, eddy diffusivity has a 2d structure (l)</desc>
   </entry>
@@ -1007,8 +1006,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>.true.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">.false.</value>
+      <value>.false.</value>
     </values>
     <desc>Apply eddy mixing suppression away from steering level (l)</desc>
   </entry>
@@ -1018,10 +1016,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>0.85</value>
-      <value blom_vcoord="isopyc_bulkml" ocn_grid="tnx2v1">0.5</value>
-      <value blom_vcoord="isopyc_bulkml" ocn_grid="tnx1.5v1">0.5</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">3.0</value>
+      <value>3.0</value>
     </values>
     <desc>Parameter c in Eden and Greatbatch (2008) parameterization (f)</desc>
   </entry>
@@ -1052,10 +1047,8 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>100.</value>
-      <value blom_unit="cgs">100.e4</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">1.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4" blom_unit="cgs">1.e4</value>
+      <value>1.</value>
+      <value blom_unit="cgs">1.e4</value>
       <value ocn_grid="tnx0.125v4">0.</value>
       <value ocn_grid="tnx0.125v4" blom_unit="cgs">0.</value>
     </values>
@@ -1067,14 +1060,8 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>1500.</value>
-      <value blom_unit="cgs">1500.e4</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">2500.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4" blom_unit="cgs">2500.e4</value>
-      <value ocn_grid="tnx2v1">1000.</value>
-      <value ocn_grid="tnx2v1" blom_unit="cgs">1000.e4</value>
-      <value ocn_grid="tnx1.5v1">1000.</value>
-      <value ocn_grid="tnx1.5v1" blom_unit="cgs">1000.e4</value>
+      <value>2500.</value>
+      <value blom_unit="cgs">2500.e4</value>
       <value ocn_grid="tnx0.125v4">0.</value>
       <value ocn_grid="tnx0.125v4" blom_unit="mks">0.</value>
     </values>
@@ -1110,8 +1097,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>0.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">0.5</value>
+      <value>0.5</value>
     </values>
     <desc>Linear scaling parameter for topographic rhines scale () (f)</desc>
   </entry>
@@ -1121,8 +1107,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>.false.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">.true.</value>
+      <value>.true.</value>
     </values>
     <desc>If true, apply anisotropy correction to eddy diffusivity (l)</desc>
   </entry>
@@ -1142,8 +1127,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>.false.</value>
-      <value blom_vcoord="cntiso_hybrid" ocn_grid="tnx1v4">.true.</value>
+      <value>.true.</value>
     </values>
     <desc>If true, use the minimum of planetary and topographic beta</desc>
   </entry>


### PR DESCRIPTION
Changed the default eddy parameterization for vcoord_type = isopyc_bulkml to the same that is currently default for vcoord_type = cntiso_hybrid.

The associated previous default namelist values for vcoord_type = isopyc_bulkml were:

```
EDANIS = .false.
EDDF2D = .false.
EDSPRS = .true.
RHSCTP = .false.
EGC = 0.85
EGMNDF = 100.
EGMXDF = 1500.
RHISCF = 0.
```

Note that EGC and EGMXDF had grid specific values and that EGMNDF and EGMXDF are dimensional parameters, here provided with unit m<sup>2</sup>s<sup>-1</sup>. New default namelist values are:

```
EDANIS = .true.
EDDF2D = .true.
EDSPRS = .false.
RHSCTP = .true.
EGC = 3.0
EGMNDF = 1.
EGMXDF = 2500.
RHISCF = 0.5
```