### PR TITLE
add missing configurations for the ATRC option

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -16,6 +16,7 @@ set OCN_NCPL = `./xmlquery OCN_NCPL --value`
 set BLOM_COUPLING = `./xmlquery BLOM_COUPLING --value`
 set RUNDIR = `./xmlquery  RUNDIR --value`
 set BLOM_TRACER_MODULES = `./xmlquery BLOM_TRACER_MODULES --value`
+set BLOM_ATRC = `./xmlquery BLOM_ATRC --value`
 set BLOM_TURBULENT_CLOSURE = `./xmlquery BLOM_TURBULENT_CLOSURE --value`
 set HAMOCC_CFC = `./xmlquery HAMOCC_CFC --value`
 set HAMOCC_NATTRC = `./xmlquery HAMOCC_NATTRC --value`
@@ -46,6 +47,7 @@ EOF1
 
 set turbclo = (`echo $BLOM_TURBULENT_CLOSURE`)
 set tracers = (`echo $BLOM_TRACER_MODULES`)
+set atrc = (`echo $BLOM_ATRC`)
 set co2type = (`echo $OCN_CO2_TYPE`)
 
 set cpp_ocn = "-DMPI"
@@ -124,6 +126,9 @@ if ($#tracers != 0) then
       exit -1
     endif
   end
+  if ($atrc == TRUE ) then
+    set cpp_ocn = "$cpp_ocn -DATRC"
+  endif
 endif
 
 #------------------------------------------------------------------------------

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -43,6 +43,15 @@
     <desc>Optional ocean tracers.  Valid values are Any combination of: iage ecosys</desc>
   </entry>
 
+  <entry id="BLOM_ATRC">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_component_blom</group>
+    <file>env_build.xml</file>
+    <desc>Set preprocessor option to activate age tracer code. Requires module iage or ecosys</desc>
+  </entry>
+
   <entry id="BLOM_COUPLING">
     <type>char</type>
     <valid_values>full,partial</valid_values>

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,10 @@ if get_option('iage') or get_option('turbclo').length() > 0 or get_option('ecosy
   subdir('trc')
 endif
 
+if get_option('atrc')
+  add_project_arguments('-DATRC', language: 'fortran')
+endif
+
 if get_option('turbclo').length() > 0
   if not (get_option('turbclo').contains('oneeq') or get_option('turbclo').contains('twoeq'))
     error('For turbulent closure, either twoeq or oneeq must be provided as options!')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,8 @@ option('iage', type: 'boolean',
        description: 'Enable ideal age tracer', value: true)
 option('ecosys', type: 'boolean',
        description: 'Enable HAMOCC as ecosystem module', value: false)
+option('blom_atrc', type: 'boolean',
+       description: 'Enable age tracer in BLOM', value: false)
 option('hamocc_cfc', type: 'boolean',
        description: 'Enable CFCs in HAMOCC', value: false)
 option('hamocc_nattrc', type: 'boolean',

--- a/phy/mod_remap.F
+++ b/phy/mod_remap.F
@@ -27,7 +27,7 @@ c
       use mod_types, only: r8
       use mod_xc
 #ifdef TRC
-      use mod_tracers, only: ntr, itrtke, itrgls
+      use mod_tracers, only: ntr, natr, itrtke, itrgls
 #endif
 c
       implicit none


### PR DESCRIPTION
add missing configurations for the ATRC option

ATRC is used as compiler option in BLOM, but it is not defined.

add ATRC option in the namelist building script and in the XML files.