### PR TITLE
new CESM stream relaxation capability for sss and sst

### DIFF
--- a/cesm/mod_cesm.F90
+++ b/cesm/mod_cesm.F90
@@ -27,11 +27,10 @@ module mod_cesm
    use mod_constants, only: pi
    use mod_time, only: nstep
    use mod_xc
-   use mod_forcing, only: trxday, srxday, swa, nsf, lip, sop, eva, rnf, rfi, &
+   use mod_forcing, only: swa, nsf, lip, sop, eva, rnf, rfi, &
                           fmltfz, sfl, ztx, mty, ustarw, slp, abswnd, &
                           lamult, lasl, ustokes, vstokes, atmco2, atmbrf, &
                           flxdms, flxbrf
-   use mod_ben02, only: initai, rdcsic, rdctsf, fnlzai
    use mod_seaice, only: ficem
    use mod_checksum, only: csdiag, chksummsk
 #ifdef HAMOCC
@@ -39,7 +38,6 @@ module mod_cesm
 #endif
 
    implicit none
-
    private
 
    character(len = 256) :: &
@@ -117,29 +115,9 @@ contains
    end subroutine inicon_cesm
 
    subroutine inifrc_cesm
-   ! ---------------------------------------------------------------------------
-   ! Initialize climatological fields for surface restoring and interpolation of
-   ! CESM forcing fields.
-   ! ---------------------------------------------------------------------------
-
-      ! If SST restoring is requested, prepare interpolation of surface fields
-      ! and read climatological sea-ice concentration and surface temperature.
-      if (trxday > 0._r8) then
-        call initai
-        call rdcsic
-        call rdctsf
-      endif
-
-      ! If SSS restoring is requested, read climatological sea surface salinity.
-      if (srxday > 0._r8) call rdcsss
 
       ! Initialize diagnosing/application of relaxation fluxes.
       call idarlx
-
-      ! Deallocate memory used for interpolation of surface fields.
-      if (trxday > 0._r8) then
-        call fnlzai
-      endif
 
       ! Initialize time level indexes
       l1ci = 1

--- a/cesm/mod_cesm.F90
+++ b/cesm/mod_cesm.F90
@@ -27,10 +27,11 @@ module mod_cesm
    use mod_constants, only: pi
    use mod_time, only: nstep
    use mod_xc
-   use mod_forcing, only: swa, nsf, lip, sop, eva, rnf, rfi, &
+   use mod_forcing, only: trxday, srxday, swa, nsf, lip, sop, eva, rnf, rfi, &
                           fmltfz, sfl, ztx, mty, ustarw, slp, abswnd, &
                           lamult, lasl, ustokes, vstokes, atmco2, atmbrf, &
-                          flxdms, flxbrf
+                          flxdms, flxbrf, use_stream_relaxation
+   use mod_ben02, only: initai, rdcsic, rdctsf, fnlzai
    use mod_seaice, only: ficem
    use mod_checksum, only: csdiag, chksummsk
 #ifdef HAMOCC
@@ -115,6 +116,22 @@ contains
    end subroutine inicon_cesm
 
    subroutine inifrc_cesm
+
+      ! If not using NUOPC stream capability
+      if (.not. use_stream_relaxation) then
+         ! If SST restoring is requested prepare interpolation and
+         ! read climatological sea-ice concentration and surface temperature.
+         if (trxday > 0._r8) then
+            call initai
+            call rdcsic
+            call rdctsf
+         endif
+
+         ! If SSS restoring is requested, read climatological sea surface salinity.
+         if (srxday > 0._r8) then
+            call rdcsss
+         end if
+      end if
 
       ! Initialize diagnosing/application of relaxation fluxes.
       call idarlx

--- a/cesm/thermf_cesm.F
+++ b/cesm/thermf_cesm.F
@@ -39,7 +39,7 @@ c
      .                       fmltfz, sfl, ustarw, surflx, surrlx,
      .                       sswflx, salflx, brnflx, salrlx, ustar,
      .                       t_rs_nonloc, s_rs_nonloc,
-     .                       sss_stream, srxday_stream, trxday_stream
+     .                       sss_stream, sst_stream, ice_stream
       use mod_cesm, only: hmlt, frzpot, mltpot
       use mod_utility, only: util1, util2, util3, util4
       use mod_checksum, only: csdiag, chksummsk
@@ -66,7 +66,6 @@ c
       real y,dpotl,hotl,totl,sotl,tice_f,fwflx,sstc,rice,dpmxl,hmxl,
      .     tmxl,trxflx,pbot,dprsi,sssc,smxl,srxflx,totsfl,totwfl,sflxc,
      .     totsrp,totsrn,qp,qn,A_cgs2mks
-      real srxday_day, trxday_day
 #ifdef TRC
       integer nt
       real, dimension(ntr,1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) ::
@@ -209,14 +208,12 @@ c
           surrlx(i,j)=0.
 c
 c --- --- If  trxday>0 , apply relaxation towards observed sst
-          if (trxday.gt.epsilt) then
-            sstc=intp1d(sstclm(i,j,l1mi),sstclm(i,j,l2mi),
-     .                  sstclm(i,j,l3mi),sstclm(i,j,l4mi),
-     .                  sstclm(i,j,l5mi),xmi)
-            rice=intp1d(ricclm(i,j,l1mi),ricclm(i,j,l2mi),
-     .                  ricclm(i,j,l3mi),ricclm(i,j,l4mi),
-     .                  ricclm(i,j,l5mi),xmi)
-            sstc=(1.-rice)*max(sstc,tice_f)+rice*tice_f
+          if (trxday > epsilt ) then
+
+            sstc = sst_stream(i,j)
+            rice = ice_stream(i,j)
+            sstc = (1.-rice)*max(sstc,tice_f) + rice*tice_f
+
             if (vcoord_type_tag == isopyc_bulkml) then
               dpmxl=dp(i,j,1+nn)+dp(i,j,2+nn)
               hmxl=dpmxl/onem
@@ -271,24 +268,14 @@ c
           salrlx(i,j)=0.
 c
 c --- --- if  srxday>0 , apply relaxation towards observed sss
-          if (srxday > epsilt .or. srxday_stream > epsilt ) then
-
-            ! calculate sssc(i,j)
-            if (srxday > epsilt) then
-              sssc=intp1d(sssclm(i,j,l1mi),sssclm(i,j,l2mi),
-     .                    sssclm(i,j,l3mi),sssclm(i,j,l4mi),
-     .                    sssclm(i,j,l5mi),xmi)
-              srxday_day = srxday * 86400.
-            else
-              sssc= sss_stream(i,j)
-              srxday_day = srxday_stream * 86400.
-            end if
+          if (srxday > epsilt ) then
+            sssc = sss_stream(i,j)
             if (vcoord_type_tag == isopyc_bulkml) then
               dpmxl=dp(i,j,1+nn)+dp(i,j,2+nn)
               hmxl=dpmxl/onem
               smxl=(saln(i,j,1+nn)*dp(i,j,1+nn)
      .             +saln(i,j,2+nn)*dp(i,j,2+nn))/dpmxl
-              srxflx=L_mks2cgs*min(hmxl,srxdpt)/(srxday_day)
+              srxflx=L_mks2cgs*min(hmxl,srxdpt)/(srxday*86400.)
      .               *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
             else
               pbot=p(i,j,1)
@@ -313,7 +300,7 @@ c --- --- if  srxday>0 , apply relaxation towards observed sss
               do kl=k,kk
                 s_rs_nonloc(i,j,kl+1)=0.
               enddo
-              srxflx=L_mks2cgs*srxdpt/(srxday_day)
+              srxflx=L_mks2cgs*srxdpt/(srxday*86400.)
      .               *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
             endif
             salrlx(i,j)=-srxflx

--- a/cesm/thermf_cesm.F
+++ b/cesm/thermf_cesm.F
@@ -38,7 +38,8 @@ c
      .                       swa, nsf, hmltfz, lip, sop, eva, rnf, rfi,
      .                       fmltfz, sfl, ustarw, surflx, surrlx,
      .                       sswflx, salflx, brnflx, salrlx, ustar,
-     .                       t_rs_nonloc, s_rs_nonloc
+     .                       t_rs_nonloc, s_rs_nonloc,
+     .                       sss_stream, srxday_stream, trxday_stream
       use mod_cesm, only: hmlt, frzpot, mltpot
       use mod_utility, only: util1, util2, util3, util4
       use mod_checksum, only: csdiag, chksummsk
@@ -65,6 +66,7 @@ c
       real y,dpotl,hotl,totl,sotl,tice_f,fwflx,sstc,rice,dpmxl,hmxl,
      .     tmxl,trxflx,pbot,dprsi,sssc,smxl,srxflx,totsfl,totwfl,sflxc,
      .     totsrp,totsrn,qp,qn,A_cgs2mks
+      real srxday_day, trxday_day
 #ifdef TRC
       integer nt
       real, dimension(ntr,1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) ::
@@ -269,16 +271,24 @@ c
           salrlx(i,j)=0.
 c
 c --- --- if  srxday>0 , apply relaxation towards observed sss
-          if (srxday.gt.epsilt) then
-            sssc=intp1d(sssclm(i,j,l1mi),sssclm(i,j,l2mi),
-     .                  sssclm(i,j,l3mi),sssclm(i,j,l4mi),
-     .                  sssclm(i,j,l5mi),xmi)
+          if (srxday > epsilt .or. srxday_stream > epsilt ) then
+
+            ! calculate sssc(i,j)
+            if (srxday > epsilt) then
+              sssc=intp1d(sssclm(i,j,l1mi),sssclm(i,j,l2mi),
+     .                    sssclm(i,j,l3mi),sssclm(i,j,l4mi),
+     .                    sssclm(i,j,l5mi),xmi)
+              srxday_day = srxday * 86400.
+            else
+              sssc= sss_stream(i,j)
+              srxday_day = srxday_stream * 86400.
+            end if
             if (vcoord_type_tag == isopyc_bulkml) then
               dpmxl=dp(i,j,1+nn)+dp(i,j,2+nn)
               hmxl=dpmxl/onem
               smxl=(saln(i,j,1+nn)*dp(i,j,1+nn)
      .             +saln(i,j,2+nn)*dp(i,j,2+nn))/dpmxl
-              srxflx=L_mks2cgs*min(hmxl,srxdpt)/(srxday*86400.)
+              srxflx=L_mks2cgs*min(hmxl,srxdpt)/(srxday_day)
      .               *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
             else
               pbot=p(i,j,1)
@@ -303,7 +313,7 @@ c --- --- if  srxday>0 , apply relaxation towards observed sss
               do kl=k,kk
                 s_rs_nonloc(i,j,kl+1)=0.
               enddo
-              srxflx=L_mks2cgs*srxdpt/(srxday*86400.)
+              srxflx=L_mks2cgs*srxdpt/(srxday_day)
      .               *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
             endif
             salrlx(i,j)=-srxflx
@@ -428,7 +438,7 @@ c$OMP PARALLEL DO PRIVATE(l,i)
           enddo
         enddo
 c$OMP END PARALLEL DO
-c 
+c
       enddo
 #endif
 c

--- a/cesm/thermf_cesm.F
+++ b/cesm/thermf_cesm.F
@@ -39,7 +39,8 @@ c
      .                       fmltfz, sfl, ustarw, surflx, surrlx,
      .                       sswflx, salflx, brnflx, salrlx, ustar,
      .                       t_rs_nonloc, s_rs_nonloc,
-     .                       sss_stream, sst_stream, ice_stream
+     .                       sss_stream, sst_stream, ice_stream,
+     .                       use_stream_relaxation
       use mod_cesm, only: hmlt, frzpot, mltpot
       use mod_utility, only: util1, util2, util3, util4
       use mod_checksum, only: csdiag, chksummsk
@@ -210,9 +211,19 @@ c
 c --- --- If  trxday>0 , apply relaxation towards observed sst
           if (trxday > epsilt ) then
 
-            sstc = sst_stream(i,j)
-            rice = ice_stream(i,j)
-            sstc = (1.-rice)*max(sstc,tice_f) + rice*tice_f
+            if (use_stream_relaxation) then
+              sstc = sst_stream(i,j)
+              rice = ice_stream(i,j)
+              sstc = (1.-rice)*max(sstc,tice_f) + rice*tice_f
+            else
+              sstc=intp1d(sstclm(i,j,l1mi),sstclm(i,j,l2mi),
+     .                    sstclm(i,j,l3mi),sstclm(i,j,l4mi),
+     .                    sstclm(i,j,l5mi),xmi)
+              rice=intp1d(ricclm(i,j,l1mi),ricclm(i,j,l2mi),
+     .                    ricclm(i,j,l3mi),ricclm(i,j,l4mi),
+     .                    ricclm(i,j,l5mi),xmi)
+              sstc=(1.-rice)*max(sstc,tice_f)+rice*tice_f
+            end if
 
             if (vcoord_type_tag == isopyc_bulkml) then
               dpmxl=dp(i,j,1+nn)+dp(i,j,2+nn)
@@ -269,7 +280,13 @@ c
 c
 c --- --- if  srxday>0 , apply relaxation towards observed sss
           if (srxday > epsilt ) then
-            sssc = sss_stream(i,j)
+            if (use_stream_relaxation) then
+              sssc = sss_stream(i,j)
+            else
+              sssc=intp1d(sssclm(i,j,l1mi),sssclm(i,j,l2mi),
+     .                    sssclm(i,j,l3mi),sssclm(i,j,l4mi),
+     .                    sssclm(i,j,l5mi),xmi)
+            end if
             if (vcoord_type_tag == isopyc_bulkml) then
               dpmxl=dp(i,j,1+nn)+dp(i,j,2+nn)
               hmxl=dpmxl/onem

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -244,7 +244,7 @@ def buildnml(case, caseroot, compname):
         namelist_file += inst_string
 
         # Create BLOM namelist
-        groups=['limits','diffusion','merdia','secdia','diaphy','stream_sss']
+        groups=['limits','diffusion','merdia','secdia','diaphy','stream_sss','stream_sst' ]
 
         groups.append('cwmod')
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -85,6 +85,7 @@ def buildnml(case, caseroot, compname):
     hamocc_sedspinup_yr_end   = case.get_value("HAMOCC_SEDSPINUP_YR_END")
     hamocc_sedspinup_ncycle   = case.get_value("HAMOCC_SEDSPINUP_NCYCLE")
     is_test                   = case.get_value("TEST")
+    comp_interface            = case.get_value("COMP_INTERFACE")
 
     blom_vcoord = case.get_value("BLOM_VCOORD")
     turbclo = case.get_value("BLOM_TURBULENT_CLOSURE")
@@ -188,6 +189,7 @@ def buildnml(case, caseroot, compname):
         config["hamocc_sedspinup_yr_end"] = hamocc_sedspinup_yr_end
         config["hamocc_sedspinup_ncycle"] = hamocc_sedspinup_ncycle
         config["is_test"] = "yes" if is_test else "no"
+        config["comp_interface"] = comp_interface
 
         # TODO: the following needs to have new ways to turn this to "yes"
         config["use_agg"] = "no"

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -244,7 +244,7 @@ def buildnml(case, caseroot, compname):
         namelist_file += inst_string
 
         # Create BLOM namelist
-        groups=['limits','diffusion','merdia','secdia','diaphy']
+        groups=['limits','diffusion','merdia','secdia','diaphy','stream_sss']
 
         groups.append('cwmod')
 
@@ -261,14 +261,14 @@ def buildnml(case, caseroot, compname):
         if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
              groups.append("bgcparams")
              """
-             !!! The following line deletes all entries for group 'bgcparams' 
-             !!! that are ONLY present in namelist_definition_blom.xml 
+             !!! The following line deletes all entries for group 'bgcparams'
+             !!! that are ONLY present in namelist_definition_blom.xml
              !!! and keeps entries provided through user_nl_blom
              !!! This makes sure that i) only Fortran-hard coded values from mo_param_bgc.F90
              !!! are used and that ii) user_nl_blom enables tuning these default parameters.
-             !!! Note that an entry in namelist_definition_blom.xml for the tuning parameter 
-             !!! is still required, while its value can be set to None. 
-             !!! This is an interim solution and the line below can be simply deleted, once 
+             !!! Note that an entry in namelist_definition_blom.xml for the tuning parameter
+             !!! is still required, while its value can be set to None.
+             !!! This is an interim solution and the line below can be simply deleted, once
              !!! xml is used as default for the bgcparams namelist as well.
              """
              pg_blom.keep_usernml_only('bgcparams')

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -516,6 +516,17 @@
     </desc>
   </entry>
 
+  <entry id="use_stream_relaxation">
+    <type>logical</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.false.</value>
+      <value comp_interface="nuopc">.true.</value>
+    </values>
+    <desc>if .true., use NUOPC stream relaxation capability</desc>
+  </entry>
+
   <entry id="trxday">
     <type>real</type>
     <category>limits</category>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6691,8 +6691,7 @@
       file name(s) containing salinity relaxation data
     </desc>
     <values>
-      <!-- <value>/cluster/work/users/mvertens/noresm/blom_sss_stream/run/sss.NCO2x4_f19_tn14_20190624.blom.hd.0001_cdf5.nc</value> -->
-      <value>/cluster/projects/nn10013k/adagj/sss_clim/sss_climatology_N1850_f19_tn14_20190621_1600-1699_cdf5.nc</value>
+      <value>$DIN_LOC_ROOT/ocn/blom/bndcon/sss_clim_core_tnx1v4_20240510_cdf5.nc</value>
     </values>
   </entry>
   <entry id="stream_sss_varname">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6706,7 +6706,7 @@
     </values>
   </entry>
   <entry id="stream_sss_data_filename">
-    <type>char</type>
+    <type>char(10)</type>
     <category>stream_sss</category>
     <group>stream_sss</group>
     <desc>
@@ -6762,6 +6762,73 @@
     </values>
   </entry>
 
+  <!-- =========================  -->
+  <!-- namelist group: stream_sst -->
+  <!-- =========================  -->
 
+  <entry id="stream_sst_mesh_filename">
+    <type>char</type>
+    <category>stream_sst</category>
+    <group>stream_sst</group>
+    <desc>stream mesh file</desc>
+    <values>
+      <value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029_ESMFmesh_120520.nc</value>
+    </values>
+  </entry>
+  <entry id="stream_sst_data_filename">
+    <type>char(10)</type>
+    <category>stream_sst</category>
+    <group>stream_sst</group>
+    <desc>
+      file name(s) containing sst relaxation data
+    </desc>
+    <values>
+      <value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2017_c180507_cdf5.nc</value>
+    </values>
+  </entry>
+  <entry id="stream_sst_varname">
+    <type>char(2)</type>
+    <category>stream_sst</category>
+    <group>stream_sst</group>
+    <desc>
+      variable name on stream file
+    </desc>
+    <values>
+      <value>SST_cpl, ice_cov</value>
+    </values>
+  </entry>
+  <entry id="stream_sst_year_first">
+    <type>integer</type>
+    <category>stream_sst</category>
+    <group>stream_sst</group>
+    <desc>
+      First year in stream to use
+    </desc>
+    <values>
+      <value>1850</value>
+    </values>
+  </entry>
+  <entry id="stream_sst_year_last">
+    <type>integer</type>
+    <category>stream_sst</category>
+    <group>stream_sst</group>
+    <desc>
+      Last year in stream to use
+    </desc>
+    <values>
+      <value>1850</value>
+    </values>
+  </entry>
+  <entry id="stream_sst_year_align">
+    <type>integer</type>
+    <category>stream_sst</category>
+    <group>stream_sst</group>
+    <desc>
+      Align stream_year_first with this model year
+    </desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
 
 </entry_id_pg>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -538,28 +538,6 @@
     <desc>e-folding time scale (days) for SSS relax., if 0 no relax. (f)</desc>
   </entry>
 
-  <entry id="trxday_stream">
-    <type>real</type>
-    <category>limits</category>
-    <group>limits</group>
-    <values>
-      <value>0.</value>
-    </values>
-    <desc>e-folding time scale (days) for SST relax. from stream data, if 0 no relax. (f)</desc>
-  </entry>
-
-  <entry id="srxday_stream">
-    <type>real</type>
-    <category>limits</category>
-    <group>limits</group>
-    <values>
-      <value>0.</value>
-      <value blom_coupling="partial">60.</value>
-      <value blom_coupling="partial" blom_vcoord="isopyc_bulkml">6.</value>
-    </values>
-    <desc>e-folding time scale (days) for SSS relax. from stream data, if 0 no relax. (f)</desc>
-  </entry>
-
   <entry id="trxdpt">
     <type>real</type>
     <category>limits</category>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6680,7 +6680,8 @@
     <group>stream_sss</group>
     <desc>stream mesh file</desc>
     <values>
-      <value>$DIN_LOC_ROOT/share/meshes/tnx1v4_20170601_cdf5_ESMFmesh.nc</value>
+      <!-- <value>$DIN_LOC_ROOT/share/meshes/tnx1v4_20170601_cdf5_ESMFmesh.nc</value> -->
+      <value>$DIN_LOC_ROOT/share/meshes/tnx0.25v4_ESMFmesh_cdf5_c20231006.nc</value>
     </values>
   </entry>
   <entry id="stream_sss_data_filename">
@@ -6691,7 +6692,8 @@
       file name(s) containing salinity relaxation data
     </desc>
     <values>
-      <value>$DIN_LOC_ROOT/ocn/blom/bndcon/sss_clim_core_tnx1v4_20240510_cdf5.nc</value>
+      <!-- <value>$DIN_LOC_ROOT/ocn/blom/bndcon/sss_clim_core_tnx1v4_20240510_cdf5.nc</value> -->
+      <value>/cluster/work/users/mvertens/noresm/sss_clim_core_tnx0.25v4_20240512_cdf5.nc</value>
     </values>
   </entry>
   <entry id="stream_sss_varname">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6692,4 +6692,76 @@
     <desc>(ssster) [mol m-3]</desc>
   </entry>
 
+  <!-- =========================  -->
+  <!-- namelist group: stream_sss -->
+  <!-- =========================  -->
+
+  <entry id="stream_sss_mesh_filename">
+    <type>char</type>
+    <category>stream_sss</category>
+    <group>stream_sss</group>
+    <desc>stream mesh file</desc>
+    <values>
+      <value>$DIN_LOC_ROOT/share/meshes/tnx1v4_20170601_cdf5_ESMFmesh.nc</value>
+    </values>
+  </entry>
+  <entry id="stream_sss_data_filename">
+    <type>char</type>
+    <category>stream_sss</category>
+    <group>stream_sss</group>
+    <desc>
+      file name(s) containing salinity relaxation data
+    </desc>
+    <values>
+      <!-- <value>/cluster/work/users/mvertens/noresm/blom_sss_stream/run/sss.NCO2x4_f19_tn14_20190624.blom.hd.0001_cdf5.nc</value> -->
+      <value>/cluster/projects/nn10013k/adagj/sss_clim/sss_climatology_N1850_f19_tn14_20190621_1600-1699_cdf5.nc</value>
+    </values>
+  </entry>
+  <entry id="stream_sss_varname">
+    <type>char</type>
+    <category>stream_sss</category>
+    <group>stream_sss</group>
+    <desc>
+      variable name on stream file
+    </desc>
+    <values>
+      <value>sss</value>
+    </values>
+  </entry>
+  <entry id="stream_sss_year_first">
+    <type>integer</type>
+    <category>stream_sss</category>
+    <group>stream_sss</group>
+    <desc>
+      First year in stream to use
+    </desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+  <entry id="stream_sss_year_last">
+    <type>integer</type>
+    <category>stream_sss</category>
+    <group>stream_sss</group>
+    <desc>
+      Last year in stream to use
+    </desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+  <entry id="stream_sss_year_align">
+    <type>integer</type>
+    <category>stream_sss</category>
+    <group>stream_sss</group>
+    <desc>
+      Align stream_year_first with this model year
+    </desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+
+
+
 </entry_id_pg>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -538,6 +538,28 @@
     <desc>e-folding time scale (days) for SSS relax., if 0 no relax. (f)</desc>
   </entry>
 
+  <entry id="trxday_stream">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>0.</value>
+    </values>
+    <desc>e-folding time scale (days) for SST relax. from stream data, if 0 no relax. (f)</desc>
+  </entry>
+
+  <entry id="srxday_stream">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>0.</value>
+      <value blom_coupling="partial">60.</value>
+      <value blom_coupling="partial" blom_vcoord="isopyc_bulkml">6.</value>
+    </values>
+    <desc>e-folding time scale (days) for SSS relax. from stream data, if 0 no relax. (f)</desc>
+  </entry>
+
   <entry id="trxdpt">
     <type>real</type>
     <category>limits</category>

--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -584,7 +584,7 @@ contains
       integer(ESMF_KIND_I4), dimension(:), pointer :: maskMesh(:)
       integer, allocatable, dimension(:) :: gindex
       integer :: n, spatialDim, numOwnedElements, nx_global, ny_global
-      character(len=cslen)  :: cvalue
+      character(len=cllen)  :: cvalue
 
       if (dbug > 5) call ESMF_LogWrite(subname//': called', ESMF_LOGMSG_INFO)
 

--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -51,7 +51,7 @@ module ocn_comp_nuopc
    use mod_cesm, only: runid_cesm, runtyp_cesm, ocn_cpl_dt_cesm
    use mod_config, only: inst_index, inst_name, inst_suffix
    use mod_time, only: blom_time
-   use mod_forcing, only : trxday_stream, srxday_stream
+   use mod_forcing, only : trxday_stream, srxday_stream, trxday, srxday
    use mod_constants, only : epsilt
    use ocn_stream_sss, only : ocn_stream_sss_init, ocn_stream_sss_interp
 
@@ -677,6 +677,12 @@ contains
       ! Initialize sdat for relaxation to sss if appropriate
 
       if (srxday_stream > epsilt) then
+         if (srxday > epsilt) then
+            write(lp,'(a)') subname// ': BLOM ERROR: both srxday_stream and srxday cannot both be > 0'
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+               call ESMF_Finalize(endflag=ESMF_END_ABORT)
+            end if
+         end if
          call ocn_stream_sss_init(Emesh, clock, rc)
          if (ChkErr(rc, __LINE__, u_FILE_u)) return
       end if

--- a/drivers/nuopc/ocn_stream_sss.F90
+++ b/drivers/nuopc/ocn_stream_sss.F90
@@ -1,0 +1,260 @@
+module ocn_stream_sss
+
+   !-----------------------------------------------------------------------
+   ! Contains methods for reading in nitrogen deposition data file
+   ! Also includes functions for dynamic sss file handling and
+   ! interpolation.
+   !-----------------------------------------------------------------------
+   !
+   use ESMF
+   ! use ESMF              , only : ESMF_Clock, ESMF_Mesh, ESMF_Time, ESMF_ClockGet, ESMF_TimeGet
+   ! use ESMF              , only : ESMF_SUCCESS, ESMF_LOGERR_PASSTHRU, ESMF_END_ABORT
+   ! use ESMF              , only : ESMF_Finalize, ESMF_LogFoundError
+   use nuopc_shr_methods , only : chkerr
+   use dshr_strdata_mod  , only : shr_strdata_type
+   use shr_kind_mod      , only : r8 => shr_kind_r8, CL => shr_kind_cl, CS => shr_kind_cs
+   use shr_log_mod       , only : errMsg => shr_log_errMsg
+   use shr_sys_mod       , only : shr_sys_abort
+   use mod_xc
+
+   implicit none
+   private
+
+   include 'mpif.h'
+
+   public :: ocn_stream_sss_init      ! position datasets for dynamic sss
+   public :: ocn_stream_sss_interp    ! interpolates between two years of sss file data
+
+   type(shr_strdata_type) :: sdat_sss                      ! input data stream
+   character(len=CS)      :: stream_varlist_sss(1)
+
+   character(len=*), parameter :: sourcefile = &
+        __FILE__
+
+!==============================================================================
+contains
+!==============================================================================
+
+   subroutine ocn_stream_sss_init(model_mesh, model_clock, rc)
+      !
+      ! Initialize data stream information.
+
+      ! Uses:
+      use shr_nl_mod       , only: shr_nl_find_group_name
+      use dshr_strdata_mod , only: shr_strdata_init_from_inline
+
+      ! input/output variables
+      type(ESMF_CLock), intent(in)  :: model_clock
+      type(ESMF_Mesh) , intent(in)  :: model_mesh
+      integer         , intent(out) :: rc
+
+      ! local variables
+      integer                 :: nu_nml                ! unit for namelist file
+      integer                 :: nml_error             ! namelist i/o error flag
+      character(len=CL)       :: stream_sss_data_filename
+      character(len=CL)       :: stream_sss_mesh_filename
+      character(len=CL)       :: filein                ! ocn namelist file
+      integer                 :: stream_sss_year_first ! first year in stream to use
+      integer                 :: stream_sss_year_last  ! last year in stream to use
+      integer                 :: stream_sss_year_align ! align stream_year_firstsss with
+      integer                 :: ierr
+      character(*), parameter :: subName = "('stream_sss_init')"
+      !-----------------------------------------------------------------------
+
+      namelist /sss_stream_nl/      &
+           stream_sss_data_filename, &
+           stream_sss_mesh_filename, &
+           stream_sss_year_first,    &
+           stream_sss_year_last,     &
+           stream_sss_year_align
+
+      rc = ESMF_SUCCESS
+
+      ! Default values for namelist
+      stream_sss_data_filename = ' '
+      stream_sss_mesh_filename = ' '
+      stream_sss_year_first    = 1 ! first year in stream to use
+      stream_sss_year_last     = 1 ! last  year in stream to use
+      stream_sss_year_align    = 1 ! align stream_sss_year_first with this model year
+
+      ! For now variable list in stream data file is hard-wired
+      stream_varlist_sss = (/'sss'/)
+      stream_sss_mesh_filename = &
+           "/cluster/shared/noresm/inputdata/share/meshes/tnx1v4_20170601_cdf5_ESMFmesh.nc"
+      !stream_sss_data_filename = &
+      !    "/nird/datalake/NS9560K/adagj/blom_sss_daily/sss.NCO2x4_f19_tn14_20190624.blom.hd.0001.nc"
+      ! stream_sss_data_filename = &
+      !      "/cluster/work/users/mvertens/noresm/blom_sss_stream/run/sss_climatology_N1850_f19_tn14_20190621_1600-1699_cdf5.nc"
+      stream_sss_data_filename = &
+           "/cluster/work/users/mvertens/noresm/blom_sss_stream/run/sss.NCO2x4_f19_tn14_20190624.blom.hd.0001_cdf5.nc"
+
+      ! Read sss_stream namelist
+      ! if (mnproc == 1) then
+      !    filein = "ocn_in"
+      !    open( newunit=nu_nml, file=trim(filein), status='old', iostat=nml_error )
+      !    if (nml_error /= 0) then
+      !       call shr_sys_abort(subName//': ERROR opening '//trim(filein)//errMsg(sourcefile, __LINE__))
+      !    end if
+      !    call shr_nl_find_group_name(nu_nml, 'sss_stream_nl', status=nml_error)
+      !    if (nml_error == 0) then
+      !       read(nu_nml, nml=sss_stream_nl, iostat=nml_error)
+      !       if (nml_error /= 0) then
+      !          call shr_sys_abort(' ERROR reading sss_stream_nl namelist'//errMsg(sourcefile, __LINE__))
+      !       end if
+      !    else
+      !       call shr_sys_abort(' ERROR finding sss_stream_nl namelist'//errMsg(sourcefile, __LINE__))
+      !    end if
+      !    close(nu_nml)
+      ! endif
+      ! call mpi_bcast(stream_sss_mesh_filename, len(stream_sss_mesh_filename), mpi_character, 0, mpicom, ierr)
+      ! if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_sss_mesh_filename")
+      ! call mpi_bcast(stream_sss_data_filename, len(stream_sss_data_filename), mpi_character, 0, mpicom, ierr)
+      ! if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_sss_data_filename")
+      ! call mpi_bcast(stream_sss_year_first, 1, mpi_integer, 0, mpicom, ierr)
+      ! if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_sss_year_first")
+      ! call mpi_bcast(stream_sss_year_last, 1, mpi_integer, 0, mpicom, ierr)
+      ! if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_sss_year_last")
+      ! call mpi_bcast(stream_sss_year_align, 1, mpi_integer, 0, mpicom, ierr)
+      ! if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_sss_year_align")
+
+      if (mnproc == 1) then
+         write(lp,'(a)'   ) ' '
+         write(lp,'(a,i8)')  'stream sss settings:'
+         write(lp,'(a,a)' )  '  stream_sss_data_filename = ',trim(stream_sss_data_filename)
+         write(lp,'(a,a)' )  '  stream_sss_mesh_filename = ',trim(stream_sss_mesh_filename)
+         write(lp,'(a,a,a)') '  stream_varlist_sss       = ',trim(stream_varlist_sss(1))
+         write(lp,'(a,i8)')  '  stream_sss_year_first    = ',stream_sss_year_first
+         write(lp,'(a,i8)')  '  stream_sss_year_last     = ',stream_sss_year_last
+         write(lp,'(a,i8)')  '  stream_sss_year_align    = ',stream_sss_year_align
+         write(lp,'(a)'   )  ' '
+      endif
+
+      ! Initialize the cdeps data type sdat_sss
+      call shr_strdata_init_from_inline(sdat_sss,                    &
+           my_task             = mnproc,                             &
+           logunit             = lp,                                 &
+           compname            = 'OCN',                              &
+           model_clock         = model_clock,                        &
+           model_mesh          = model_mesh,                         &
+           stream_meshfile     = trim(stream_sss_mesh_filename),     &
+           stream_filenames    = (/trim(stream_sss_data_filename)/), &
+           stream_yearFirst    = stream_sss_year_first,              &
+           stream_yearLast     = stream_sss_year_last,               &
+           stream_yearAlign    = stream_sss_year_align,              &
+           stream_fldlistFile  = stream_varlist_sss,                 &
+           stream_fldListModel = stream_varlist_sss,                 &
+           stream_lev_dimname  = 'null',                             &
+           stream_mapalgo      = 'bilinear',                         &
+           stream_offset       = 0,                                  &
+           stream_taxmode      = 'cycle',                            &
+           stream_dtlimit      = 1.0e30_r8,                          &
+           stream_tintalgo     = 'linear',                           &
+           stream_name         = 'Sea surface salinity ',            &
+           rc                  = rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+         call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      end if
+
+   end subroutine ocn_stream_sss_init
+
+   !================================================================
+   subroutine ocn_stream_sss_interp(model_clock, rc)
+
+      use dshr_strdata_mod , only : shr_strdata_advance
+      use dshr_methods_mod , only : dshr_fldbun_getfldptr
+      use mod_forcing      , only : sss_stream
+      use mod_checksum     , only : chksummsk
+
+      ! input/output variables
+      type(ESMF_Clock), intent(in)  :: model_clock
+      integer         , intent(out) :: rc
+
+      ! local variables
+      type(ESMF_Time)     :: date
+      integer             :: i,j,n
+      integer             :: jjcpl
+      integer             :: year    ! year (0, ...) for nstep+1
+      integer             :: mon     ! month (1, ..., 12) for nstep+1
+      integer             :: day     ! day of month (1, ..., 31) for nstep+1
+      integer             :: sec     ! seconds into current date for nstep+1
+      integer             :: mcdate  ! Current model date (yyyymmdd)
+      real(r8), pointer   :: dataptr(:)
+      real(r8), parameter :: mval = -1.e12_r8
+      real(r8), parameter :: fval = -1.e13_r8
+      !
+      ! integer                         :: fieldCount
+      ! character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
+      ! integer                         :: fieldnum
+      ! character(ESMF_MAXSTR)          :: fieldname
+      !-----------------------------------------------------------------------
+
+      ! Advance sdat stream
+      call ESMF_ClockGet( model_clock, currTime=date, rc=rc )
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+         call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      end if
+      call ESMF_TimeGet(date, yy=year, mm=mon, dd=day, s=sec, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+         call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      end if
+      mcdate = year*10000 + mon*100 + day
+
+      ! call ESMF_FieldBundleGet(sdat_sss%pstrm(1)%fldbun_model, fieldCount=fieldCount, rc=rc)
+      ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+      !    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      ! end if
+      ! allocate(lfieldnamelist(fieldCount))
+      ! call ESMF_FieldBundleGet(sdat_sss%pstrm(1)%fldbun_model, fieldNameList=lfieldnamelist, rc=rc)
+      ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+      !    call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      ! end if
+      ! write(6,*)'DEBUG: fieldcount= ',fieldcount
+      ! write(6,*)'DEBUG: lfieldnamelist = ',trim(lfieldnamelist(1))
+      ! deallocate(lfieldnamelist)
+
+      call shr_strdata_advance(sdat_sss, ymd=mcdate, tod=sec, logunit=lp, istr='sssdyn', rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+         call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      end if
+
+      ! Get pointer for stream data that is time and spatially interpolated to model time and grid
+      call dshr_fldbun_getFldPtr(sdat_sss%pstrm(1)%fldbun_model, stream_varlist_sss(1), fldptr1=dataptr, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+         call ESMF_Finalize(endflag=ESMF_END_ABORT)
+      end if
+
+      ! Set the j-extent of the local ocean domain to be exchanged. Needed because of
+      ! duplication of the last global domain row when using a tripolar grid.
+      ! dimensions.F is created at build time by the bash script blom_dimensions and contains
+      ! the following hard-wired variables
+      ! nreg  - region type
+      ! nproc - the number of processors
+      ! ipr   - 1st 2-D node dimension (<=iqr)
+      ! jpr   - 2nd 2-D node dimension (<=jqr)
+
+      if (nreg == 2 .and. nproc == jpr) then
+         jjcpl = jj - 1
+      else
+         jjcpl = jj
+      endif
+
+      do j = 1, jjcpl
+         do i = 1, ii
+            if (ip(i,j) == 0) then
+               sss_stream(i,j) = mval
+            elseif (cplmsk(i,j) == 0) then
+               sss_stream(i,j) = fval
+            else
+               n = (j - 1)*ii + i
+               sss_stream(i,j) = dataptr(n)
+            end if
+         end do
+      end do
+
+      call fill_global(mval, fval, halo_ps, sss_stream(1-nbdy,1-nbdy))
+
+      call chksummsk(sss_stream(1-nbdy,1-nbdy),ip,1,'sst_stream')
+
+   end subroutine ocn_stream_sss_interp
+
+end module ocn_stream_sss

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -54,6 +54,11 @@ module mod_forcing
                       ! [deg C].
       srxlim          ! Maximum absolute value of SSS difference in relaxation
                       ! [g kg-1].
+
+   real(r8) :: &
+      trxday_stream, &  ! e-folding relaxation time scale for SST [days] using streams
+      srxday_stream     ! e-folding relaxation time scale for SSS [days] using streams
+
    character(len = 256) :: &
       scfile, &       ! Name of file containing monthly SSS climatology.
       wavsrc          ! Source of wave fields. Valid source: 'none', 'param',
@@ -89,6 +94,10 @@ module mod_forcing
       sstclm, &       ! Sea-surface temperature [deg C].
       ricclm, &       ! Sea-ice concentration [].
       sssclm          ! Sea-surface salinity [g kg-1].
+
+   real(r8), dimension(1 - nbdy:idm + nbdy, 1 - nbdy:jdm + nbdy) :: &
+      sst_stream, &    ! Sea-surface temperature [deg C] from stream data.
+      sss_stream       ! Sea-surface salinity [g kg-1] from stream data.
 
    ! Variables related to balancing the freshwater forcing budget.
    real(r8) :: &
@@ -164,7 +173,8 @@ module mod_forcing
              atmco2, flxco2, flxdms, flxbrf, atmbrf, &
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
              ustar, ustarb, ustar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
-             s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal
+             s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
+             trxday_stream, srxday_stream, sss_stream, sst_stream
 
 contains
 

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -55,10 +55,6 @@ module mod_forcing
       srxlim          ! Maximum absolute value of SSS difference in relaxation
                       ! [g kg-1].
 
-   real(r8) :: &
-      trxday_stream, &  ! e-folding relaxation time scale for SST [days] using streams
-      srxday_stream     ! e-folding relaxation time scale for SSS [days] using streams
-
    character(len = 256) :: &
       scfile, &       ! Name of file containing monthly SSS climatology.
       wavsrc          ! Source of wave fields. Valid source: 'none', 'param',
@@ -175,7 +171,7 @@ module mod_forcing
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
              ustar, ustarb, ustar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
              s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
-             trxday_stream, srxday_stream, sss_stream, sst_stream, ice_stream
+             sss_stream, sst_stream, ice_stream
 
 contains
 

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -97,6 +97,7 @@ module mod_forcing
 
    real(r8), dimension(1 - nbdy:idm + nbdy, 1 - nbdy:jdm + nbdy) :: &
       sst_stream, &    ! Sea-surface temperature [deg C] from stream data.
+      ice_stream, &    ! Sea-ice concentration [] from stream data.
       sss_stream       ! Sea-surface salinity [g kg-1] from stream data.
 
    ! Variables related to balancing the freshwater forcing budget.
@@ -174,7 +175,7 @@ module mod_forcing
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
              ustar, ustarb, ustar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
              s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
-             trxday_stream, srxday_stream, sss_stream, sst_stream
+             trxday_stream, srxday_stream, sss_stream, sst_stream, ice_stream
 
 contains
 

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -96,6 +96,8 @@ module mod_forcing
       ice_stream, &    ! Sea-ice concentration [] from stream data.
       sss_stream       ! Sea-surface salinity [g kg-1] from stream data.
 
+   logical :: use_stream_relaxation ! If true, use nuopc stream relaxation capability
+
    ! Variables related to balancing the freshwater forcing budget.
    real(r8) :: &
       prfac           ! Correction factor for precipitation and runoff [].
@@ -171,7 +173,7 @@ module mod_forcing
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
              ustar, ustarb, ustar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
              s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
-             sss_stream, sst_stream, ice_stream
+             sss_stream, sst_stream, ice_stream, use_stream_relaxation
 
 contains
 

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -43,7 +43,7 @@ c
      .                      cbar, cb, mommth
       use mod_barotp, only: cwbdts, cwbdls
       use mod_forcing, only: aptflx, apsflx, ditflx, disflx,
-     .                       scfile,
+     .                       scfile, 
      .                       wavsrc, wavsrc_opt, wavsrc_none,
      .                       wavsrc_param, wavsrc_extern,
      .                       trxday, srxday, trxdpt, srxdpt, trxlim,
@@ -109,9 +109,9 @@ c
         read (unit=nfu,nml=LIMITS)
         close (unit=nfu)
 c
-c --- - print limits namelist to stdout
+c --- - print limits namelist to stdout 
         write (lp,*)
-        write (lp,*) 'rdlim: BLOM LIMITS NAMELIST GROUP:'
+        write (lp,*) 'rdlim: BLOM LIMITS NAMELIST GROUP:' 
         write (lp,*) 'NDAY1',NDAY1
         write (lp,*) 'NDAY2',NDAY2
         write (lp,*) 'IDATE',IDATE
@@ -289,9 +289,9 @@ c
         close (unit=nfu)
 c
 c --- - determine number of io groups
-        nphy=0
-        do n=1,nphymax
-          if (GLB_AVEPERIO(n).ne.-999) nphy=nphy+1
+        nphy=0  
+        do n=1,nphymax 
+          if (GLB_AVEPERIO(n).ne.-999) nphy=nphy+1 
         enddo
 c
 c --- - modify diaphy namelist variables based on dependency with other
@@ -358,7 +358,7 @@ c --- - variables set in namelists
 c
 c --- - print diaphy namelist
         write (lp,*)
-        write (lp,*) 'rdlim: BLOM DIAPHY NAMELIST GROUP:'
+        write (lp,*) 'rdlim: BLOM DIAPHY NAMELIST GROUP:' 
         write (lp,*) 'GLB_FNAMETAG',GLB_FNAMETAG(1:nphy)
         write (lp,*) 'GLB_AVEPERIO',GLB_AVEPERIO(1:nphy)
         write (lp,*) 'GLB_FILEFREQ',GLB_FILEFREQ(1:nphy)
@@ -717,7 +717,7 @@ c
       call xcbcst(GLB_FILEFREQ)
       call xcbcst(GLB_COMPFLAG)
       call xcbcst(GLB_NCFORMAT)
-      do n=1,nphymax
+      do n=1,nphymax 
         call xcbcst(GLB_FNAMETAG(n))
       enddo
 c
@@ -804,7 +804,7 @@ c
 c
       endif
 c
-c --- convert integer dates
+c --- convert integer dates 
       date%year=sign(abs(idate)/10000,idate)
       date%month=abs(idate)/100-abs(date%year)*100
       date%day=abs(idate)-abs(date%year)*10000-date%month*100
@@ -908,7 +908,7 @@ c
           nday1=nint(time-time0)
 c
           if (runtyp.eq.'hybrid') then
-c
+c 
 c --- ----- When runtyp equal 'hybrid' the ocean integration starts
 c --- ----- after first coupling interval.
             n=1
@@ -1036,7 +1036,7 @@ c --- represent time between restarts in time steps
       rstfrq=nstep_in_day*max(1.,rstfrq)
 c
 c --- represent time between diagnostics in time steps
-      do n=1,nphy
+      do n=1,nphy 
         GLB_FILEFREQ(n)=max(GLB_AVEPERIO(n),GLB_FILEFREQ(n))
 c
         if (GLB_AVEPERIO(n).lt.0) then

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -47,8 +47,7 @@ c
      .                       wavsrc, wavsrc_opt, wavsrc_none,
      .                       wavsrc_param, wavsrc_extern,
      .                       trxday, srxday, trxdpt, srxdpt, trxlim,
-     .                       srxlim, srxbal, sprfac,
-     .                       srxday_stream, trxday_stream
+     .                       srxlim, srxbal, sprfac
       use mod_swabs, only: swamth, jwtype, chlopt, ccfile
       use mod_diffusion, only: readnml_diffusion
       use mod_mxlayr, only: rm0, rm5, ce, mlrttp
@@ -85,8 +84,7 @@ c
      .  itest,jtest,
      .  cnsvdi,
      .  csdiag,
-     .  rstfrq,rstfmt,rstcmp,iotype,
-     .  srxday_stream, trxday_stream
+     .  rstfrq,rstfmt,rstcmp,iotype
 c
 c --- read limits namelist
 c
@@ -156,8 +154,6 @@ c --- - print limits namelist to stdout
         write (lp,*) 'CCFILE ',trim(CCFILE)
         write (lp,*) 'TRXDAY',TRXDAY
         write (lp,*) 'SRXDAY',SRXDAY
-        write (lp,*) 'SRXDAY_STREAM',SRXDAY_STREAM
-        write (lp,*) 'TRXDAY_STREAM',TRXDAY_STREAM
         write (lp,*) 'TRXDPT',TRXDPT
         write (lp,*) 'SRXDPT',SRXDPT
         write (lp,*) 'TRXLIM',TRXLIM
@@ -230,8 +226,6 @@ c
       call xcbcst(trxday)
       call xcbcst(srxday)
       call xcbcst(trxdpt)
-      call xcbcst(srxday_stream)
-      call xcbcst(trxday_stream)
       call xcbcst(srxdpt)
       call xcbcst(trxlim)
       call xcbcst(srxlim)

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -43,11 +43,12 @@ c
      .                      cbar, cb, mommth
       use mod_barotp, only: cwbdts, cwbdls
       use mod_forcing, only: aptflx, apsflx, ditflx, disflx,
-     .                       scfile, 
+     .                       scfile,
      .                       wavsrc, wavsrc_opt, wavsrc_none,
      .                       wavsrc_param, wavsrc_extern,
      .                       trxday, srxday, trxdpt, srxdpt, trxlim,
-     .                       srxlim, srxbal, sprfac
+     .                       srxlim, srxbal, sprfac,
+     .                       use_stream_relaxation
       use mod_swabs, only: swamth, jwtype, chlopt, ccfile
       use mod_diffusion, only: readnml_diffusion
       use mod_mxlayr, only: rm0, rm5, ce, mlrttp
@@ -84,7 +85,8 @@ c
      .  itest,jtest,
      .  cnsvdi,
      .  csdiag,
-     .  rstfrq,rstfmt,rstcmp,iotype
+     .  rstfrq,rstfmt,rstcmp,iotype,
+     .  use_stream_relaxation
 c
 c --- read limits namelist
 c
@@ -109,9 +111,9 @@ c
         read (unit=nfu,nml=LIMITS)
         close (unit=nfu)
 c
-c --- - print limits namelist to stdout 
+c --- - print limits namelist to stdout
         write (lp,*)
-        write (lp,*) 'rdlim: BLOM LIMITS NAMELIST GROUP:' 
+        write (lp,*) 'rdlim: BLOM LIMITS NAMELIST GROUP:'
         write (lp,*) 'NDAY1',NDAY1
         write (lp,*) 'NDAY2',NDAY2
         write (lp,*) 'IDATE',IDATE
@@ -176,6 +178,8 @@ c --- - print limits namelist to stdout
         write (lp,*) 'RSTFMT',RSTFMT
         write (lp,*) 'RSTCMP',RSTCMP
         write (lp,*) 'IOTYPE',IOTYPE
+        write (lp,*) 'USE_STREAM_RELAXATION',
+     .                use_stream_relaxation
         write (lp,*)
 c
       endif
@@ -247,6 +251,7 @@ c
       call xcbcst(rstfmt)
       call xcbcst(rstcmp)
       call xcbcst(iotype)
+      call xcbcst(use_stream_relaxation)
 c
 c --- resolve options
       select case (trim(wavsrc))
@@ -289,9 +294,9 @@ c
         close (unit=nfu)
 c
 c --- - determine number of io groups
-        nphy=0  
-        do n=1,nphymax 
-          if (GLB_AVEPERIO(n).ne.-999) nphy=nphy+1 
+        nphy=0
+        do n=1,nphymax
+          if (GLB_AVEPERIO(n).ne.-999) nphy=nphy+1
         enddo
 c
 c --- - modify diaphy namelist variables based on dependency with other
@@ -358,7 +363,7 @@ c --- - variables set in namelists
 c
 c --- - print diaphy namelist
         write (lp,*)
-        write (lp,*) 'rdlim: BLOM DIAPHY NAMELIST GROUP:' 
+        write (lp,*) 'rdlim: BLOM DIAPHY NAMELIST GROUP:'
         write (lp,*) 'GLB_FNAMETAG',GLB_FNAMETAG(1:nphy)
         write (lp,*) 'GLB_AVEPERIO',GLB_AVEPERIO(1:nphy)
         write (lp,*) 'GLB_FILEFREQ',GLB_FILEFREQ(1:nphy)
@@ -717,7 +722,7 @@ c
       call xcbcst(GLB_FILEFREQ)
       call xcbcst(GLB_COMPFLAG)
       call xcbcst(GLB_NCFORMAT)
-      do n=1,nphymax 
+      do n=1,nphymax
         call xcbcst(GLB_FNAMETAG(n))
       enddo
 c
@@ -804,7 +809,7 @@ c
 c
       endif
 c
-c --- convert integer dates 
+c --- convert integer dates
       date%year=sign(abs(idate)/10000,idate)
       date%month=abs(idate)/100-abs(date%year)*100
       date%day=abs(idate)-abs(date%year)*10000-date%month*100
@@ -908,7 +913,7 @@ c
           nday1=nint(time-time0)
 c
           if (runtyp.eq.'hybrid') then
-c 
+c
 c --- ----- When runtyp equal 'hybrid' the ocean integration starts
 c --- ----- after first coupling interval.
             n=1
@@ -1036,7 +1041,7 @@ c --- represent time between restarts in time steps
       rstfrq=nstep_in_day*max(1.,rstfrq)
 c
 c --- represent time between diagnostics in time steps
-      do n=1,nphy 
+      do n=1,nphy
         GLB_FILEFREQ(n)=max(GLB_AVEPERIO(n),GLB_FILEFREQ(n))
 c
         if (GLB_AVEPERIO(n).lt.0) then

--- a/phy/rdlim.F
+++ b/phy/rdlim.F
@@ -43,11 +43,12 @@ c
      .                      cbar, cb, mommth
       use mod_barotp, only: cwbdts, cwbdls
       use mod_forcing, only: aptflx, apsflx, ditflx, disflx,
-     .                       scfile, 
+     .                       scfile,
      .                       wavsrc, wavsrc_opt, wavsrc_none,
      .                       wavsrc_param, wavsrc_extern,
      .                       trxday, srxday, trxdpt, srxdpt, trxlim,
-     .                       srxlim, srxbal, sprfac
+     .                       srxlim, srxbal, sprfac,
+     .                       srxday_stream, trxday_stream
       use mod_swabs, only: swamth, jwtype, chlopt, ccfile
       use mod_diffusion, only: readnml_diffusion
       use mod_mxlayr, only: rm0, rm5, ce, mlrttp
@@ -84,7 +85,8 @@ c
      .  itest,jtest,
      .  cnsvdi,
      .  csdiag,
-     .  rstfrq,rstfmt,rstcmp,iotype
+     .  rstfrq,rstfmt,rstcmp,iotype,
+     .  srxday_stream, trxday_stream
 c
 c --- read limits namelist
 c
@@ -109,9 +111,9 @@ c
         read (unit=nfu,nml=LIMITS)
         close (unit=nfu)
 c
-c --- - print limits namelist to stdout 
+c --- - print limits namelist to stdout
         write (lp,*)
-        write (lp,*) 'rdlim: BLOM LIMITS NAMELIST GROUP:' 
+        write (lp,*) 'rdlim: BLOM LIMITS NAMELIST GROUP:'
         write (lp,*) 'NDAY1',NDAY1
         write (lp,*) 'NDAY2',NDAY2
         write (lp,*) 'IDATE',IDATE
@@ -154,6 +156,8 @@ c --- - print limits namelist to stdout
         write (lp,*) 'CCFILE ',trim(CCFILE)
         write (lp,*) 'TRXDAY',TRXDAY
         write (lp,*) 'SRXDAY',SRXDAY
+        write (lp,*) 'SRXDAY_STREAM',SRXDAY_STREAM
+        write (lp,*) 'TRXDAY_STREAM',TRXDAY_STREAM
         write (lp,*) 'TRXDPT',TRXDPT
         write (lp,*) 'SRXDPT',SRXDPT
         write (lp,*) 'TRXLIM',TRXLIM
@@ -226,6 +230,8 @@ c
       call xcbcst(trxday)
       call xcbcst(srxday)
       call xcbcst(trxdpt)
+      call xcbcst(srxday_stream)
+      call xcbcst(trxday_stream)
       call xcbcst(srxdpt)
       call xcbcst(trxlim)
       call xcbcst(srxlim)
@@ -289,9 +295,9 @@ c
         close (unit=nfu)
 c
 c --- - determine number of io groups
-        nphy=0  
-        do n=1,nphymax 
-          if (GLB_AVEPERIO(n).ne.-999) nphy=nphy+1 
+        nphy=0
+        do n=1,nphymax
+          if (GLB_AVEPERIO(n).ne.-999) nphy=nphy+1
         enddo
 c
 c --- - modify diaphy namelist variables based on dependency with other
@@ -358,7 +364,7 @@ c --- - variables set in namelists
 c
 c --- - print diaphy namelist
         write (lp,*)
-        write (lp,*) 'rdlim: BLOM DIAPHY NAMELIST GROUP:' 
+        write (lp,*) 'rdlim: BLOM DIAPHY NAMELIST GROUP:'
         write (lp,*) 'GLB_FNAMETAG',GLB_FNAMETAG(1:nphy)
         write (lp,*) 'GLB_AVEPERIO',GLB_AVEPERIO(1:nphy)
         write (lp,*) 'GLB_FILEFREQ',GLB_FILEFREQ(1:nphy)
@@ -717,7 +723,7 @@ c
       call xcbcst(GLB_FILEFREQ)
       call xcbcst(GLB_COMPFLAG)
       call xcbcst(GLB_NCFORMAT)
-      do n=1,nphymax 
+      do n=1,nphymax
         call xcbcst(GLB_FNAMETAG(n))
       enddo
 c
@@ -804,7 +810,7 @@ c
 c
       endif
 c
-c --- convert integer dates 
+c --- convert integer dates
       date%year=sign(abs(idate)/10000,idate)
       date%month=abs(idate)/100-abs(date%year)*100
       date%day=abs(idate)-abs(date%year)*10000-date%month*100
@@ -908,7 +914,7 @@ c
           nday1=nint(time-time0)
 c
           if (runtyp.eq.'hybrid') then
-c 
+c
 c --- ----- When runtyp equal 'hybrid' the ocean integration starts
 c --- ----- after first coupling interval.
             n=1
@@ -1036,7 +1042,7 @@ c --- represent time between restarts in time steps
       rstfrq=nstep_in_day*max(1.,rstfrq)
 c
 c --- represent time between diagnostics in time steps
-      do n=1,nphy 
+      do n=1,nphy
         GLB_FILEFREQ(n)=max(GLB_AVEPERIO(n),GLB_FILEFREQ(n))
 c
         if (GLB_AVEPERIO(n).lt.0) then


### PR DESCRIPTION
This introduces new CDEPS stream capability for use of BLOM in CESM to permit new relaxation to salinity and temperature. 
The capability is still triggered by trxday and srxday - but the new time and spatial interpolation are done in the new files:
`drivers/nuopc/ocn_stream_sss.F90 and drivers/nuopc/ocn_stream_sst.F90`

This capability permits spatial interpolation of forcing data as well as the ability to use multi-year time samples (for example daily data for a number of years). The data is not all read in at once - but only two time periods are read in at a time to do the time interpolation. **The advantage of this new capability is that only one relaxation file can be specified and can be used for multiple resolutions.**

The code uses the CDEPS inline stream capability in $SRCROOT/components/cdeps/streams.

New namelist groups stream_sss and stream_sst are introduced that turn this new capability on:

```F90
&stream_sss
  STREAM_SSS_DATA_FILENAME = '/cluster/work/users/mvertens/noresm/blom_sss_stream/run/sss_climatology_N1850_f19_tn14_20190621_1600-1699_cdf5.nc'
  STREAM_SSS_MESH_FILENAME = '/cluster/shared/noresm/inputdata/share/meshes/tnx1v4_20170601_cdf5_ESMFmesh.nc'
  STREAM_SSS_VARNAME = 'sss'
  STREAM_SSS_YEAR_ALIGN = 1
  STREAM_SSS_YEAR_FIRST = 1
  STREAM_SSS_YEAR_LAST = 1
/

&stream_sst
  STREAM_SST_DATA_FILENAME = '/cluster/shared/noresm/inputdata/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2017_c180507_cdf5.nc'
  STREAM_SST_MESH_FILENAME = '/cluster/shared/noresm/inputdata/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029_ESMFmesh_120520.nc'
  STREAM_SST_VARNAME = 'SST_cpl', 'ice_cov'
  STREAM_SST_YEAR_ALIGN = 1
  STREAM_SST_YEAR_FIRST = 1850
  STREAM_SST_YEAR_LAST = 1850
/
```

Still to do:

- [x]  A preliminary validation was done to show that the salinity and sst using these new streams was reasonable. I've also show the effect of the horizontal interpolation below. 
- [x]  The full BLOM test suite has been run successfully. No baseline comparison was made since the changes are expected to change answers.
