### PR TITLE
point to the correct location for stream sss relaxation

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6688,7 +6688,7 @@
     </desc>
     <values>
       <!-- <value>$DIN_LOC_ROOT/ocn/blom/bndcon/sss_clim_core_tnx1v4_20240510_cdf5.nc</value> -->
-      <value>/cluster/work/users/mvertens/noresm/sss_clim_core_tnx0.25v4_20240512_cdf5.nc</value>
+      <value>$DIN_LOC_ROOT/ocn/blom/bndcon/sss_clim_core_tnx0.25v4_20240512_cdf5.nc</value>
     </values>
   </entry>
   <entry id="stream_sss_varname">


### PR DESCRIPTION
In the latest PR to master - the new stream relaxation file was pointing to my own directory rather than inputdata. This PR fixes that.