### PR TITLE
Add missing configurations for the ATRC option

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -80,6 +80,7 @@ def buildcpp(case):
     ocn_grid = case.get_value("OCN_GRID")
     turbclo = case.get_value("BLOM_TURBULENT_CLOSURE")
     tracers = case.get_value("BLOM_TRACER_MODULES")
+    blom_atrc = case.get_value("BLOM_ATRC")
     blom_unit = case.get_value("BLOM_UNIT")
     pio_typename = case.get_value("PIO_TYPENAME", subgroup="OCN")
 
@@ -124,6 +125,9 @@ def buildcpp(case):
                 blom_cppdefs = blom_cppdefs + " -DHAMOCC"
             else:
                 expect(False, "tracer module {} is not recognized".format(module))
+
+    if blom_atrc:
+        blom_cppdefs = blom_cppdefs + " -DATRC"
 
     if blom_unit == "mks":
         blom_cppdefs = blom_cppdefs + " -DMKS"

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -78,6 +78,7 @@ def buildnml(case, caseroot, compname):
     blom_ndep_scenario        = case.get_value("BLOM_NDEP_SCENARIO")
     blom_coupling             = case.get_value("BLOM_COUPLING")
     blom_tracer_modules       = case.get_value("BLOM_TRACER_MODULES")
+    blom_atrc                 = case.get_value("BLOM_ATRC")
     hamocc_ciso               = case.get_value("HAMOCC_CISO")
     hamocc_sedbypass          = case.get_value("HAMOCC_SEDBYPASS")
     hamocc_sedspinup          = case.get_value("HAMOCC_SEDSPINUP")
@@ -182,6 +183,7 @@ def buildnml(case, caseroot, compname):
         config["blom_n_deposition"] = "yes" if blom_n_deposition else "no"
         config["blom_coupling"] = blom_coupling
         config["blom_tracer_modules"] = blom_tracer_modules
+        config["blom_atrc"] = blom_atrc
         config["hamocc_ciso"] = "yes" if hamocc_ciso else "no"
         config["hamocc_sedbypass"] = "yes" if hamocc_sedbypass else "no"
         config["hamocc_sedspinup"] = "yes" if hamocc_sedspinup else "no"

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -25,6 +25,15 @@
     <desc>Optional ocean tracers.  Valid values are Any combination of: iage ecosys</desc>
   </entry>
 
+  <entry id="BLOM_ATRC">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_component_blom</group>
+    <file>env_build.xml</file>
+    <desc>Set preprocessor option to activate age tracer code. Requires module iage or ecosys</desc>
+  </entry>
+
   <entry id="BLOM_TURBULENT_CLOSURE">
     <type>char</type>
     <valid_values></valid_values>

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,10 @@ if get_option('iage') or turbclo.length() > 0 or get_option('ecosys')
   subdir('trc')
 endif
 
+if get_option('atrc')
+  add_project_arguments('-DATRC', language: 'fortran')
+endif
+
 if turbclo.length() > 0
   if not (turbclo.contains('oneeq') or turbclo.contains('twoeq'))
     error('For turbulent closure, either twoeq or oneeq must be provided as options!')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,8 @@ option('iage', type: 'boolean',
        description: 'Enable ideal age tracer', value: true)
 option('ecosys', type: 'boolean',
        description: 'Enable HAMOCC as ecosystem module', value: false)
+option('atrc', type: 'boolean',
+       description: 'Enable age tracer in BLOM', value: false)
 option('hamocc_agg', type: 'boolean',
        description: 'Enable Kriest aggregation scheme in HAMOCC', value: false)
 option('hamocc_boxatm', type: 'boolean',

--- a/phy/mod_remap.F
+++ b/phy/mod_remap.F
@@ -28,7 +28,7 @@ c
       use mod_xc
       use mod_constants, only: P_mks2cgs
 #ifdef TRC
-      use mod_tracers, only: ntr, itrtke, itrgls
+      use mod_tracers, only: ntr, natr, itrtke, itrgls
 #endif
 c
       implicit none


### PR DESCRIPTION
add missing configurations for the ATRC option

ATRC is used as compiler option in BLOM, but it is not defined.

add ATRC option in the namelist building script and in the XML files.

This PR duplicates the essence of #341, but use the updated `master` branch as a starting point. This PR differs from #341 only with respect to changes that have been introduced for build config files, specifically `buildnml` and `buildcpp` replacing functionality that was previously in `buildlib`.

This PR technically allows activation of the ATRC CPP flag. I don't know if this option is up to date.

If this functionality is needed for CMIP6-type simulations, I suggest to start from the `v1.4.0` tag and make an update on the `NorESM2.0.7` release branch.