### PR TITLE
remove unnecesarry unit conversion g<->kg for tracer field in thermf_cesm.F

### DIFF
--- a/cesm/thermf_cesm.F
+++ b/cesm/thermf_cesm.F
@@ -196,7 +196,7 @@ c
             endif
 #    endif
 #  endif
-            trflx(nt,i,j)=-trc(i,j,k1n,nt)*fwflx*g2kg
+            trflx(nt,i,j)=-trc(i,j,k1n,nt)*fwflx
             ttrsf(nt,i,j)=trflx(nt,i,j)*scp2(i,j)
             ttrav(nt,i,j)=trc(i,j,k1n,nt)*scp2(i,j)
           enddo
@@ -437,7 +437,7 @@ c$OMP PARALLEL DO PRIVATE(l,i)
           do l=1,isp(j)
           do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
             trflx(nt,i,j)=-(trflx(nt,i,j)+trflxc)
-     .                     *(kg2g*(M_mks2cgs/L_mks2cgs**2))
+     .                     *(M_mks2cgs/L_mks2cgs**2)
           enddo
           enddo
         enddo


### PR DESCRIPTION
In the calculation of virtual fluxes in `thermf_cesm` there is a conversion of units for the tracer field (back and forth), which has no function, is physically meaningless, and therefore confusing. This PR removes this unit conversion.

The results are not bit-for-bit, but in the range that is expected from numerical round-off (figure below show difference for the average of the 2nd year for a 2deg NOINYOC compset)

Surface DIC
![Screenshot from 2024-05-27 07-51-13](https://github.com/NorESMhub/BLOM/assets/17926665/14e68c92-b047-49db-8e70-3c05aa0a0f01)

surface pCO2 (note the output has been stored with scale-factor and offset, so even "numerical noise" can result in smooth differences if one of those changes - max in this figure is 5e-12 mu atm)
![Screenshot from 2024-05-27 08-06-14](https://github.com/NorESMhub/BLOM/assets/17926665/d4470ab0-4423-4db3-be8d-f3e8f44b972d)
