### PR TITLE
group call to apply_fedep together with other routines for external inputs

### DIFF
--- a/hamocc/mo_hamocc4bcm.F90
+++ b/hamocc/mo_hamocc4bcm.F90
@@ -208,13 +208,6 @@ contains
     !---------------------------------------------------------------------
     ! Biogeochemistry
     !
-    ! Apply dust (iron) deposition
-    ! This routine should be moved to the other routines that handle
-    ! external inputs below for consistency. For now we keep it here
-    ! to maintain bit-for-bit reproducibility with the CMIP6 version of
-    ! the model
-    call apply_fedep(kpie,kpje,kpke,pddpo,omask,dust)
-
     call ocprod(kpie,kpje,kpke,kbnd,pdlxp,pdlyp,pddpo,omask,ptho,pi_ph,psao,ppao,prho)
 
     if (use_PBGC_CK_TIMESTEP   ) then
@@ -266,6 +259,9 @@ contains
       endif
       call inventory_bgc(kpie,kpje,kpke,pdlxp,pdlyp,pddpo,omask,0)
     endif
+
+    ! Apply dust (iron) deposition
+    call apply_fedep(kpie,kpje,kpke,pddpo,omask,dust)
 
     ! Apply n-deposition
     call apply_ndep(kpie,kpje,kpke,pddpo,omask,ndep)


### PR DESCRIPTION
This PR provides a minor improvement of HAMOCC's code logic by grouping together all calls to routines that provide external inputs (dust, N-deposition, riverine input). Results are not bit-for-bit, but the differences are very small (tested with a 200 year NOINYOC_T62_tn21 run).

If there are preferences to wait with this PR until after #269 is merged please indicate this here.