### PR TITLE
Add lon,lat info in iHAMOCC output to more comply to cdo commands 

### DIFF
--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -31,8 +31,8 @@ contains
     ! **********************************************************************************************
 
     use mod_time,       only: date0,date,calendar,nstep,nstep_in_day,nday_of_year,time0,time
-    use mod_xc,         only: kdm,mnproc,itdm,jtdm,lp
-    use mod_grid,       only: depths
+    use mod_xc,         only: kdm,mnproc,itdm,jtdm,lp,idm,jdm,nbdy
+    use mod_grid,       only: depths,plat,plon
     use mod_dia,        only: diafnm,sigmar1,iotype,ddm,depthslev,depthslev_bnds
     use mo_control_bgc, only: dtbgc,use_cisonew,use_AGG,use_CFC,use_natDIC,use_BROMO,              &
                               use_sedbypass,use_BOXATM,use_M4AGO,use_extNcycle
@@ -294,6 +294,13 @@ contains
     call ncwrt1('sigma','sigma',sigmar1)
     call ncwrt1('depth','depth',depthslev)
     call ncwrt1('depth_bnds','bounds depth',depthslev_bnds)
+    if (cmpflg.ne.0) then
+      call ncwrt1('plon','pcomp',plon(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
+      call ncwrt1('plat','pcomp',plat(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
+    else
+      call ncwrt1('plon','x y',plon(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
+      call ncwrt1('plat','x y',plat(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
+    endif
 
     ! --- finalize accumulation
     call finlyr(jphyto(iogrp),jdp(iogrp))
@@ -1346,6 +1353,22 @@ contains
     call ncattr('positive','down')
     call ncattr('bounds','depth_bnds')
     call ncdefvar('depth_bnds','bounds depth',ndouble,8)
+
+    if (cmpflg == 1) then
+      call ncdefvar('plon','pcomp',ndouble,8)
+    else
+      call ncdefvar('plon','x y',ndouble,8)
+    endif
+    call ncattr('long_name','longitude')
+    call ncattr('units','degrees_east')
+    if (cmpflg == 1) then
+      call ncdefvar('plat','pcomp',ndouble,8)
+    else
+      call ncdefvar('plat','x y',ndouble,8)
+    endif
+    call ncattr('long_name','latitude')
+    call ncattr('units','degrees_north')
+
     call ncdefvar3d(SRF_KWCO2(iogrp),cmpflg,'p',                                &
          &   'kwco2','CO2 piston velocity',' ','m s-1',0)
     call ncdefvar3d(SRF_KWCO2KHM(iogrp),cmpflg,'p',                             &

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -38,7 +38,7 @@ contains
                               use_sedbypass,use_BOXATM,use_M4AGO,use_extNcycle
     use mo_vgrid,       only: k0100,k0500,k1000,k2000,k4000
     use mo_param1_bgc,  only: ks
-    use mod_nctools,    only: ncwrt1,ncdims,nctime,ncfcls,ncfopn,ncdimc,ncputr,ncputi
+    use mod_nctools,    only: ncwrt1,ncdims,nctime,ncfcls,ncfopn,ncdimc,ncputr,ncputi,ncwrtr
     use mo_bgcmean,     only: domassfluxes,flx_ndepnoy,flx_oalk,                                   &
                               flx_cal0100,flx_cal0500,flx_cal1000,                                 &
                               flx_cal2000,flx_cal4000,flx_cal_bot,                                 &
@@ -221,6 +221,7 @@ contains
     character(len=20)        :: startdate
     character(len=30)        :: timeunits
     real                     :: datenum,rnacc
+    integer,dimension(2,2)   :: dummy
 
     data append2file /nbgcmax*.false./
 
@@ -294,12 +295,13 @@ contains
     call ncwrt1('sigma','sigma',sigmar1)
     call ncwrt1('depth','depth',depthslev)
     call ncwrt1('depth_bnds','bounds depth',depthslev_bnds)
+    dummy = 0
     if (cmpflg.ne.0) then
-      call ncwrt1('plon','pcomp',plon(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
-      call ncwrt1('plat','pcomp',plat(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
+      call ncwrtr('plon','pcomp',plon(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy),dummy,0,1.,0.,8)
+      call ncwrtr('plat','pcomp',plat(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy),dummy,0,1.,0.,8)
     else
-      call ncwrt1('plon','x y',plon(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
-      call ncwrt1('plat','x y',plat(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy))
+      call ncwrtr('plon','x y',plon(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy),dummy,0,1.,0.,8)
+      call ncwrtr('plat','x y',plat(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy),dummy,0,1.,0.,8)
     endif
 
     ! --- finalize accumulation
@@ -1355,16 +1357,16 @@ contains
     call ncdefvar('depth_bnds','bounds depth',ndouble,8)
 
     if (cmpflg == 1) then
-      call ncdefvar('plon','pcomp',ndouble,8)
+      call ncdefvar('plon','pcomp',ndouble,0)
     else
-      call ncdefvar('plon','x y',ndouble,8)
+      call ncdefvar('plon','x y',ndouble,0)
     endif
     call ncattr('long_name','longitude')
     call ncattr('units','degrees_east')
     if (cmpflg == 1) then
-      call ncdefvar('plat','pcomp',ndouble,8)
+      call ncdefvar('plat','pcomp',ndouble,0)
     else
-      call ncdefvar('plat','x y',ndouble,8)
+      call ncdefvar('plat','x y',ndouble,0)
     endif
     call ncattr('long_name','latitude')
     call ncattr('units','degrees_north')


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik , after listing up #340, I thought it might be useful to integrate the cdo-compatibility already now to make more use of the `v1.6.0+` (by merging this enhancement also into `v1.6.0`). 

With this PR, it becomes possible to e.g. performing a simple regridding:
```
module load CDO/1.9.8-intel-2019b
cdo -remapbil,r360x180 -selvar,silvl test_lonlat.blom.hbgcm.0001-01.nc remapped.nc
```
For a conservative regridding, we would also need to add the cell corners in the output (while I once had issues with the order, BLOM has them in the grid file, if I remember correctly). If that is wished, I can try to incorporate this as well - while I see this use case less often. It runs through with the `GLB_COMPFLAG` (after moving to the xml-list by Mariana now reachable via `GLB_COMPFLAG@DIABGC`), but at least ncview doesn't like the output (as in it doesn't show the output as usual - not sure, if this is the typical behavior). 