### PR TITLE
Disable CI test for macos with openmp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           # Do not build on macOS with MPI as that is having some dependency issues
           - os: macos-latest
             mpi: true
+          # Do not build on macOS with OpenMP. This cause an error as discussed in PR
+          # https://github.com/NorESMhub/BLOM/pull/317#issuecomment-2191552330
+          - os: macos-latest
+            openmp: 'enabled'
           # Run test (fuk95 executed with mpi=false) fails with ecosys
           - ecosys: true
             mpi: false

--- a/phy/mod_diapfl.F90
+++ b/phy/mod_diapfl.F90
@@ -91,6 +91,13 @@ contains
     ! Constant in the diffusion equation
     c = g*g*delt1/(alpha0*alpha0)
 
+    !! Technical note: 2024-06-27
+    !! This openMP code block breaks github CI test using macos-lates with
+    !! openmp enabled. The error seems to be specific to macos, and is
+    !! discussed in the PR
+    !! https://github.com/NorESMhub/BLOM/pull/317#issuecomment-2191552330
+    !! The CI test using macos-latest with openmp is now diabled.
+    !!
     !$omp parallel do private( &
     !$omp l,i,k,kn,ttem,ssal,delp,dens,sigr,nu,rstdns,ttem0,ssal0,delp0, &
     !$omp dens0,sigr0,nu0,kfpl,kmin,kmax,pres,fpu,fpl,delpu,delpl,nubbl, &


### PR DESCRIPTION
This PR disables the CI test for macos with openmp, as it cause an error after refactorization of the BLOM code.
I have made a comment in the `mod_diapfl.F90` file indicating the code block that triggers the error, and added the macos + openmp in the "exclude" list so that the test can easily be enabled by removing it from the list.
Closes #358 