### PR TITLE
new mechanism for configuring noresm to send dms and bromo from ocn -> atm

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -322,6 +322,17 @@ def buildnml(case, caseroot, compname):
                     fwrite.write(line)
     shutil.move(namelist_file_temp, namelist_file)
 
+    # change xml variable settings if appropriate
+    if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
+        dms_emis = case.get_value("DMS_EMIS")
+        if dms_emis is not None or dms_emis is False:
+            case.set_value('DMS_EMIS','TRUE')
+            print ("   ***Resetting DMS_EMIS to TRUE***")
+        brf_emis = pg_blom.get_value('use_bromo')
+        if brf_emis == ".true.":
+            case.set_value('BRF_EMIS','TRUE')
+            print ("   ***Resetting BRF_EMIS to TRUE***")
+
 ###############################################################################
 def _main_func():
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -323,14 +323,17 @@ def buildnml(case, caseroot, compname):
     shutil.move(namelist_file_temp, namelist_file)
 
     # change xml variable settings if appropriate
+    # Note - this does not change the blom namelist - it changes xml variables that are then
+    # used by cmeps to change attributes that are sent to the atm
+    # TODO: add n2o_emis and nh3_emis logic
     if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
         dms_emis = case.get_value("DMS_EMIS")
         if dms_emis is not None or dms_emis is False:
-            case.set_value('DMS_EMIS','TRUE')
-            print ("   ***Resetting DMS_EMIS to TRUE***")
+            case.set_value('DMS_EMIS_OCN','TRUE')
+            print ("   ***Resetting DMS_EMIS_OCN to TRUE***")
         brf_emis = pg_blom.get_value('use_bromo')
         if brf_emis == ".true.":
-            case.set_value('BRF_EMIS','TRUE')
+            case.set_value('BRF_EMIS_OCN','TRUE')
             print ("   ***Resetting BRF_EMIS to TRUE***")
 
 ###############################################################################


### PR DESCRIPTION
This is a simple change to the blom buildnml that will enable CAM to determine if DMS, BROMO (and upcoming NH3 and N2O) and fluxes are being sent from the ocean and need to be received by CAM.
The logic is the following:
-  CMEPS will introduce new logical xml variables DMS_EMIS_OCN and BRF_EMIS_OCN - by default these will be FALSE. 
-  BLOM buildnml will determine if these variables should be set to TRUE - and reset them in the $CASEROOT.
-  CMEPS will generate new namelist variables flds_dms and flds_brf based on the setting of the these xml variables. These are treated by the system as ESMF config variables that all components have access to.
- CAM will check on the status of the presence and status of flds_dms and flds_brf and advertise that these are import fields, etc.
This change should be backwards compatible with MCT - since if the xml variables are not in CASEROOT,  buildnml will simply not do anythign.