### PR TITLE
Hamocc kwrbioz off - enable remin and primary prod throughout full water column

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3653,6 +3653,16 @@
     <desc>Switch for cyano-bluefix in euphotic zone only</desc>
   </entry>
 
+  <entry id="lkwrbioz_off">
+    <type>logical</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>.true.</value>
+    </values>
+    <desc>Switch for primary production and remineralization throughout the whole water column</desc>
+  </entry>
+
   <entry id="do_oalk">
     <type>logical</type>
     <category>bgcnml</category>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3658,7 +3658,7 @@
     <category>bgcnml</category>
     <group>bgcnml</group>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
     </values>
     <desc>Switch for primary production and remineralization throughout the whole water column</desc>
   </entry>

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -61,7 +61,8 @@ module mo_control_bgc
   logical           :: do_oalk                = .false. ! apply ocean alkalinization
   logical           :: with_dmsph             = .false. ! apply DMS with pH dependence
   logical           :: use_M4AGO              = .false. ! run with M4AGO settling scheme
-  logical           :: leuphotic_cya          = .true. ! allow cyanobacteria to grow only in euphotic zone
+  logical           :: leuphotic_cya          = .true.  ! allow cyanobacteria to grow only in euphotic zone
+  logical           :: lkwrbioz_off           = .true.  ! if true, allow remin and primary prod throughout full water column
   integer           :: sedspin_yr_s           = -1      ! start year for sediment spin-up
   integer           :: sedspin_yr_e           = -1      ! end   year for sediment spin-up
   integer           :: sedspin_ncyc           = -1      ! sediment spin-up sub-cycles

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -62,7 +62,7 @@ module mo_control_bgc
   logical           :: with_dmsph             = .false. ! apply DMS with pH dependence
   logical           :: use_M4AGO              = .false. ! run with M4AGO settling scheme
   logical           :: leuphotic_cya          = .true.  ! allow cyanobacteria to grow only in euphotic zone
-  logical           :: lkwrbioz_off           = .true.  ! if true, allow remin and primary prod throughout full water column
+  logical           :: lkwrbioz_off           = .false. ! if true, allow remin and primary prod throughout full water column
   integer           :: sedspin_yr_s           = -1      ! start year for sediment spin-up
   integer           :: sedspin_yr_e           = -1      ! end   year for sediment spin-up
   integer           :: sedspin_ncyc           = -1      ! sediment spin-up sub-cycles

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -43,7 +43,7 @@ contains
                               do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                 &
                               dtb,dtbgc,io_stdo_bgc,ldtbgc,                                        &
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
-                              do_ndep_coupled,leuphotic_cya,do_n2onh3_coupled,                     &
+                              do_ndep_coupled,leuphotic_cya,lkwrbioz_off,do_n2onh3_coupled,        &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
     use mo_param_bgc,   only: ini_parambgc
@@ -81,7 +81,7 @@ contains
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,swaclimfile,       &
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
-         &            leuphotic_cya, do_ndep_coupled,do_n2onh3_coupled
+         &            leuphotic_cya, do_ndep_coupled,do_n2onh3_coupled,lkwrbioz_off
     !
     ! --- Set io units and some control parameters
     !

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -356,13 +356,12 @@ contains
             gratpoc = (1.-epsher)*grazing
             grawa = epsher*zinges*grazing
             phythresh = max(0.,(ocetra(i,j,k,iphy)-2.*phytomi))
+            phymor = dyphy*phythresh
             zoothresh = max(0.,(ocetra(i,j,k,izoo)-2.*grami))
             if (lkwrbioz_off) then
               bacfra = 0.
-              phymor = 0.
             else
               bacfra = remido*ocetra(i,j,k,idoc)
-              phymor = dyphy*phythresh
             endif
             exud = gammap*phythresh
             zoomor = spemor*zoothresh*zoothresh           ! *10 compared to linear in tropics (tinka)
@@ -409,16 +408,14 @@ contains
               if (lkwrbioz_off) then
                 bacfra13 = 0.
                 bacfra14 = 0.
-
-                phymor13 = 0.
-                phymor14 = 0.
               else
                 bacfra13 = remido*ocetra(i,j,k,idoc13)
                 bacfra14 = remido*ocetra(i,j,k,idoc14)
-
-                phymor13 = phymor*rphy13
-                phymor14 = phymor*rphy14
               endif
+
+              phymor13 = phymor*rphy13
+              phymor14 = phymor*rphy14
+
               zoomor13 = zoomor*rzoo13
               zoomor14 = zoomor*rzoo14
 
@@ -621,34 +618,43 @@ contains
               avmass = ocetra(i,j,k,iphy)+ocetra(i,j,k,idet)
             endif
             temp = min(40.,max(-3.,ptho(i,j,k)))
-            phythresh = max(0.,(ocetra(i,j,k,iphy)-2.*phytomi))
-            zoothresh = max(0.,(ocetra(i,j,k,izoo)-2.*grami))
-            sterph = 0.5*dyphy*phythresh                                ! phytoplankton to detritus
-            sterzo = spemor*zoothresh*zoothresh                         ! quadratic mortality
-            if (use_cisonew) then
-              rphy13 = ocetra(i,j,k,iphy13)/(ocetra(i,j,k,iphy)+safediv)
-              rphy14 = ocetra(i,j,k,iphy14)/(ocetra(i,j,k,iphy)+safediv)
-              rzoo13 = ocetra(i,j,k,izoo13)/(ocetra(i,j,k,izoo)+safediv)
-              rzoo14 = ocetra(i,j,k,izoo14)/(ocetra(i,j,k,izoo)+safediv)
-              rdet13 = ocetra(i,j,k,idet13)/(ocetra(i,j,k,idet)+safediv)
-              rdet14 = ocetra(i,j,k,idet14)/(ocetra(i,j,k,idet)+safediv)
-              rdoc13 = ocetra(i,j,k,idoc13)/(ocetra(i,j,k,idoc)+safediv)
-              rdoc14 = ocetra(i,j,k,idoc14)/(ocetra(i,j,k,idoc)+safediv)
 
-              sterph13 = sterph*rphy13
-              sterph14 = sterph*rphy14
-              sterzo13 = sterzo*rzoo13
-              sterzo14 = sterzo*rzoo14
-            endif
-            ocetra(i,j,k,iphy) = ocetra(i,j,k,iphy)-sterph
-            ocetra(i,j,k,izoo) = ocetra(i,j,k,izoo)-sterzo
-            if (use_cisonew) then
-              ocetra(i,j,k,iphy13) = ocetra(i,j,k,iphy13)-sterph13
-              ocetra(i,j,k,iphy14) = ocetra(i,j,k,iphy14)-sterph14
-              ocetra(i,j,k,izoo13) = ocetra(i,j,k,izoo13)-sterzo13
-              ocetra(i,j,k,izoo14) = ocetra(i,j,k,izoo14)-sterzo14
-            endif
+            if (lkwrbioz_off) then
+              sterph   = 0.
+              sterzo   = 0.
+              sterph13 = 0.
+              sterph14 = 0.
+              sterzo13 = 0.
+              sterzo14 = 0.
+            else
+              phythresh = max(0.,(ocetra(i,j,k,iphy)-2.*phytomi))
+              zoothresh = max(0.,(ocetra(i,j,k,izoo)-2.*grami))
+              sterph = 0.5*dyphy*phythresh                                ! phytoplankton to detritus
+              sterzo = spemor*zoothresh*zoothresh                         ! quadratic mortality
+              if (use_cisonew) then
+                rphy13 = ocetra(i,j,k,iphy13)/(ocetra(i,j,k,iphy)+safediv)
+                rphy14 = ocetra(i,j,k,iphy14)/(ocetra(i,j,k,iphy)+safediv)
+                rzoo13 = ocetra(i,j,k,izoo13)/(ocetra(i,j,k,izoo)+safediv)
+                rzoo14 = ocetra(i,j,k,izoo14)/(ocetra(i,j,k,izoo)+safediv)
+                rdet13 = ocetra(i,j,k,idet13)/(ocetra(i,j,k,idet)+safediv)
+                rdet14 = ocetra(i,j,k,idet14)/(ocetra(i,j,k,idet)+safediv)
+                rdoc13 = ocetra(i,j,k,idoc13)/(ocetra(i,j,k,idoc)+safediv)
+                rdoc14 = ocetra(i,j,k,idoc14)/(ocetra(i,j,k,idoc)+safediv)
 
+                sterph13 = sterph*rphy13
+                sterph14 = sterph*rphy14
+                sterzo13 = sterzo*rzoo13
+                sterzo14 = sterzo*rzoo14
+              endif
+              ocetra(i,j,k,iphy) = ocetra(i,j,k,iphy)-sterph
+              ocetra(i,j,k,izoo) = ocetra(i,j,k,izoo)-sterzo
+              if (use_cisonew) then
+                ocetra(i,j,k,iphy13) = ocetra(i,j,k,iphy13)-sterph13
+                ocetra(i,j,k,iphy14) = ocetra(i,j,k,iphy14)-sterph14
+                ocetra(i,j,k,izoo13) = ocetra(i,j,k,izoo13)-sterzo13
+                ocetra(i,j,k,izoo14) = ocetra(i,j,k,izoo14)-sterzo14
+              endif
+            endif
             if(ocetra(i,j,k,ioxygen) > 5.e-8) then
               if (use_M4AGO) then
                 if (.not. use_extNcycle) then
@@ -671,6 +677,10 @@ contains
                 pocrem = min(o2lim*pocrem,              0.33*ocetra(i,j,k,ioxygen)/ro2utammo)
                 docrem = min(remido*ocetra(i,j,k,idoc), 0.33*ocetra(i,j,k,ioxygen)/ro2utammo)
                 phyrem = min(0.5*dyphy*phythresh,       0.33*ocetra(i,j,k,ioxygen)/ro2utammo)
+              endif
+
+              if (lkwrbioz_off) then
+                phyrem = 0.
               endif
 
               if (use_cisonew) then

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -94,7 +94,7 @@ contains
     use mo_control_bgc,   only: dtb,io_stdo_bgc,with_dmsph,                                        &
                                 use_BROMO,use_AGG,use_PBGC_OCNP_TIMESTEP,use_FB_BGC_OCE,           &
                                 use_AGG,use_cisonew,use_natDIC, use_WLIN,use_sedbypass,use_M4AGO,  &
-                                use_extNcycle
+                                use_extNcycle,lkwrbioz_off
     use mo_vgrid,         only: dp_min,dp_min_sink,k0100,k0500,k1000,k2000,k4000,kwrbioz,ptiestu
     use mo_vgrid,         only: kmle
     use mo_clim_swa,      only: swa_clim

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -618,43 +618,44 @@ contains
               avmass = ocetra(i,j,k,iphy)+ocetra(i,j,k,idet)
             endif
             temp = min(40.,max(-3.,ptho(i,j,k)))
+            phythresh = max(0.,(ocetra(i,j,k,iphy)-2.*phytomi))
+            zoothresh = max(0.,(ocetra(i,j,k,izoo)-2.*grami))
+            sterph = 0.5*dyphy*phythresh                                ! phytoplankton to detritus
+            sterzo = spemor*zoothresh*zoothresh                         ! quadratic mortality
+            if (use_cisonew) then
+              rphy13 = ocetra(i,j,k,iphy13)/(ocetra(i,j,k,iphy)+safediv)
+              rphy14 = ocetra(i,j,k,iphy14)/(ocetra(i,j,k,iphy)+safediv)
+              rzoo13 = ocetra(i,j,k,izoo13)/(ocetra(i,j,k,izoo)+safediv)
+              rzoo14 = ocetra(i,j,k,izoo14)/(ocetra(i,j,k,izoo)+safediv)
+              rdet13 = ocetra(i,j,k,idet13)/(ocetra(i,j,k,idet)+safediv)
+              rdet14 = ocetra(i,j,k,idet14)/(ocetra(i,j,k,idet)+safediv)
+              rdoc13 = ocetra(i,j,k,idoc13)/(ocetra(i,j,k,idoc)+safediv)
+              rdoc14 = ocetra(i,j,k,idoc14)/(ocetra(i,j,k,idoc)+safediv)
 
-            if (lkwrbioz_off) then
+              sterph13 = sterph*rphy13
+              sterph14 = sterph*rphy14
+              sterzo13 = sterzo*rzoo13
+              sterzo14 = sterzo*rzoo14
+            endif
+
+            if (lkwrbioz_off) then ! dying before in PP loop
               sterph   = 0.
               sterzo   = 0.
               sterph13 = 0.
               sterph14 = 0.
               sterzo13 = 0.
               sterzo14 = 0.
-            else
-              phythresh = max(0.,(ocetra(i,j,k,iphy)-2.*phytomi))
-              zoothresh = max(0.,(ocetra(i,j,k,izoo)-2.*grami))
-              sterph = 0.5*dyphy*phythresh                                ! phytoplankton to detritus
-              sterzo = spemor*zoothresh*zoothresh                         ! quadratic mortality
-              if (use_cisonew) then
-                rphy13 = ocetra(i,j,k,iphy13)/(ocetra(i,j,k,iphy)+safediv)
-                rphy14 = ocetra(i,j,k,iphy14)/(ocetra(i,j,k,iphy)+safediv)
-                rzoo13 = ocetra(i,j,k,izoo13)/(ocetra(i,j,k,izoo)+safediv)
-                rzoo14 = ocetra(i,j,k,izoo14)/(ocetra(i,j,k,izoo)+safediv)
-                rdet13 = ocetra(i,j,k,idet13)/(ocetra(i,j,k,idet)+safediv)
-                rdet14 = ocetra(i,j,k,idet14)/(ocetra(i,j,k,idet)+safediv)
-                rdoc13 = ocetra(i,j,k,idoc13)/(ocetra(i,j,k,idoc)+safediv)
-                rdoc14 = ocetra(i,j,k,idoc14)/(ocetra(i,j,k,idoc)+safediv)
-
-                sterph13 = sterph*rphy13
-                sterph14 = sterph*rphy14
-                sterzo13 = sterzo*rzoo13
-                sterzo14 = sterzo*rzoo14
-              endif
-              ocetra(i,j,k,iphy) = ocetra(i,j,k,iphy)-sterph
-              ocetra(i,j,k,izoo) = ocetra(i,j,k,izoo)-sterzo
-              if (use_cisonew) then
-                ocetra(i,j,k,iphy13) = ocetra(i,j,k,iphy13)-sterph13
-                ocetra(i,j,k,iphy14) = ocetra(i,j,k,iphy14)-sterph14
-                ocetra(i,j,k,izoo13) = ocetra(i,j,k,izoo13)-sterzo13
-                ocetra(i,j,k,izoo14) = ocetra(i,j,k,izoo14)-sterzo14
-              endif
             endif
+
+            ocetra(i,j,k,iphy) = ocetra(i,j,k,iphy)-sterph
+            ocetra(i,j,k,izoo) = ocetra(i,j,k,izoo)-sterzo
+            if (use_cisonew) then
+              ocetra(i,j,k,iphy13) = ocetra(i,j,k,iphy13)-sterph13
+              ocetra(i,j,k,iphy14) = ocetra(i,j,k,iphy14)-sterph14
+              ocetra(i,j,k,izoo13) = ocetra(i,j,k,izoo13)-sterzo13
+              ocetra(i,j,k,izoo14) = ocetra(i,j,k,izoo14)-sterzo14
+            endif
+
             if(ocetra(i,j,k,ioxygen) > 5.e-8) then
               if (use_M4AGO) then
                 if (.not. use_extNcycle) then
@@ -679,7 +680,7 @@ contains
                 phyrem = min(0.5*dyphy*phythresh,       0.33*ocetra(i,j,k,ioxygen)/ro2utammo)
               endif
 
-              if (lkwrbioz_off) then
+              if (lkwrbioz_off) then ! dying before in PP loop
                 phyrem = 0.
               endif
 

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -37,7 +37,8 @@ module mo_param_bgc
                             do_ndep,do_oalk,do_rivinpt,do_sedspinup,l_3Dvarsedpor,                 &
                             use_BOXATM,use_CFC,use_PBGC_CK_TIMESTEP,                               &
                             use_sedbypass,with_dmsph,use_PBGC_OCNP_TIMESTEP,ocn_co2_type,use_M4AGO,&
-                            leuphotic_cya,do_ndep_coupled,do_n2onh3_coupled,use_extNcycle
+                            leuphotic_cya,do_ndep_coupled,do_n2onh3_coupled,use_extNcycle,         &
+                            lkwrbioz_off
   use mod_xc,         only: mnproc
 
   implicit none
@@ -834,6 +835,7 @@ contains
       call cinfo_add_entry('do_sedspinup',           do_sedspinup)
       call cinfo_add_entry('l_3Dvarsedpor',          l_3Dvarsedpor)
       call cinfo_add_entry('leuphotic_cya',          leuphotic_cya)
+      call cinfo_add_entry('lkwrbioz_off',           lkwrbioz_off)
       call cinfo_add_entry('use_M4AGO',              use_M4AGO)
       if (use_extNcycle) then
         call cinfo_add_entry('do_ndep_coupled',        do_ndep_coupled)


### PR DESCRIPTION
This is a first draft PR to introduce the possibility to perform the processes of remineralization and primary production throughout the whole water column (#365). I essentially switch off any remineralization-related processes in the primary production-oriented loop and leave those to the second loop, if `lkwrbioz_off=true`, while keeping phytoplankton and zooplankton mortality in the primary production loop.

There are remaining issues with the current version:
- How to best define export production and related values? I currently would stick to the definitions as they are - likely making only a small error when it comes to the vertical resolution, since most production likely takes place as before in the euphotic zone - only the remineralization part will differ (and will influence primary production) 

Once the version is tested, one could consider removing the flexibility completely and use the current setting (`lkwrbioz_off=true`) as default by deleting unnecessary code parts.

Closes #365