### PR TITLE
New ocn2glc capability

### DIFF
--- a/cime_config/buildlib_2.2
+++ b/cime_config/buildlib_2.2
@@ -66,7 +66,6 @@ def _main_func():
                      os.path.join(comp_root_dir_ocn, "channel"),
                      os.path.join(comp_root_dir_ocn, "single_column"),
                      os.path.join(comp_root_dir_ocn, "pkgs", "CVMix-src", "src", "shared"),
-                     os.path.join(comp_root_dir_ocn, "pkgs", "M4AGO-sinking-scheme", "src"),
                      os.path.join(comp_root_dir_ocn, "phy"),
                      os.path.join(comp_root_dir_ocn, "trc"),
                      os.path.join(comp_root_dir_ocn, "idlage")]
@@ -77,6 +76,7 @@ def _main_func():
                         continue
                     elif module == "ecosys":
                         paths.append(os.path.join(comp_root_dir_ocn, "hamocc"))
+                        paths.append(os.path.join(comp_root_dir_ocn, "pkgs", "M4AGO-sinking-scheme", "src"))
                     else:
                         expect(False, "tracer module {} is not recognized".format(module))
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -38,12 +38,12 @@
 
   <compset>
     <alias>NOINY_WW3</alias>
-    <lname>2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV</lname>
+    <lname>2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3</lname>
   </compset>
 
   <compset>
     <alias>NOINYOC_WW3</alias>
-    <lname>2000_DATM%NYF_SLND_CICE_BLOM%ECO_DROF%NYF_SGLC_WW3DEV</lname>
+    <lname>2000_DATM%NYF_SLND_CICE_BLOM%ECO_DROF%NYF_SGLC_WW3</lname>
   </compset>
 
   <compset>

--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -20,6 +20,11 @@
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
   </test>
+  <test name="ERS_Ld3" grid="T62_tn14" compset="NOINYOC" testmods="blom/hybrid_hamocc">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+  </test>
   <test name="ERP_Ld3" grid="T62_tn14" compset="NOINY">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>

--- a/cime_config/testdefs/testmods_dirs/blom/hybrid_hammocc/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/blom/hybrid_hammocc/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange BLOM_TURBULENT_CLOSURE=
+./xmlchange BLOM_VCOORD=cntiso_hybrid

--- a/drivers/nuopc/mod_nuopc_methods.F90
+++ b/drivers/nuopc/mod_nuopc_methods.F90
@@ -551,15 +551,10 @@ contains
       ! Accumulate fields in send buffer
       ! -----------------
 
-      ! What is commented out here is what is used in mod_dia.F90
-      ! but this does not seem to work here
-      ! m = mod(nstep+1,2) + 1
-      ! n = mod(nstep  ,2) + 1
-
-      m = mod(nstep  ,2)+1
-      n = mod(nstep+1,2)+1
-      mm = (m-1)*kk
-      nn = (n-1)*kk
+      m = mod(nstep + 1, 2) + 1
+      n = mod(nstep    , 2) + 1
+      mm = (m - 1)*kk
+      nn = (n - 1)*kk
       k1m = 1 + mm
       k1n = 1 + nn
 

--- a/drivers/nuopc/mod_nuopc_methods.F90
+++ b/drivers/nuopc/mod_nuopc_methods.F90
@@ -24,6 +24,9 @@ module mod_nuopc_methods
 ! ------------------------------------------------------------------------------
 
    use shr_const_mod,  only: SHR_CONST_RHOSW, SHR_CONST_LATICE, SHR_CONST_TKFRZ
+   use shr_const_mod,  only: SHR_CONST_SPVAL
+   use dimensions,     only: kdm
+   use mod_dia,        only: depthslev
    use mod_types,      only: r8
    use mod_constants,  only: rearth, onem, L_mks2cgs
    use mod_time,       only: nstep, baclin, delt1, dlt
@@ -58,7 +61,8 @@ module mod_nuopc_methods
       character(len=128) :: stdname
       integer :: ungridded_lbound = 0
       integer :: ungridded_ubound = 0
-      real(r8), dimension(:), pointer :: dataptr
+      real(r8), dimension(:)  , pointer :: dataptr
+      real(r8), dimension(:,:), pointer :: dataptr2d
    end type fldlist_type
    integer, parameter :: fldsMax = 100
 
@@ -76,6 +80,8 @@ module mod_nuopc_methods
    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: acc_fbrf
    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: acc_fn2o
    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: acc_fnh3
+   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm) :: acc_t_depth
+   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm) :: acc_s_depth
 
    real(r8) :: tlast_coupled
    integer :: jjcpl
@@ -131,7 +137,17 @@ module mod_nuopc_methods
         index_Faoo_fdms  = -1, &
         index_Faoo_fbrf  = -1, &
         index_Faoo_fn2o  = -1, &
-        index_Faoo_fnh3  = -1
+        index_Faoo_fnh3  = -1, &
+        index_So_t_depth = -1, &
+        index_So_s_depth = -1
+
+   ! Define export levels for multi-level fields.
+   ! note: BLOM levels are defined in mod_dia.F90 in the array depthslev - which is public
+   integer, parameter :: nlev_export = 30
+   real(r8) :: vertical_levels(nlev_export) = (/  &
+        30., 90., 150., 210., 270., 330., 390., 450., 510., 570., &
+        630., 690., 750., 810., 870., 930., 990., 1050., 1110., 1170., &
+        1230., 1290., 1350., 1410., 1470., 1530., 1590., 1650., 1710., 1770. /)
 
 contains
 
@@ -170,6 +186,7 @@ contains
       index = num
 
       if (present(ungridded_lbound) .and. present(ungridded_ubound)) then
+         write(6,*)'DEBUG: adding upper bound to field '//trim(stdname),ungridded_ubound,num
          fldlist(num)%ungridded_lbound = ungridded_lbound
          fldlist(num)%ungridded_ubound = ungridded_ubound
       endif
@@ -240,7 +257,8 @@ contains
 
    end subroutine blom_advertise_imports
 
-   subroutine blom_advertise_exports(flds_scalar_name, fldsFrOcn_num, fldsFrOcn)
+   subroutine blom_advertise_exports(flds_scalar_name, fldsFrOcn_num, fldsFrOcn, &
+        ocn2glc_coupling)
      ! -------------------------------------------------------------------
      ! Determine fldsToOcn for export fields
      ! -------------------------------------------------------------------
@@ -248,6 +266,7 @@ contains
      character(len=*)   , intent(in)    :: flds_scalar_name
      integer            , intent(inout) :: fldsFrOcn_num
      type(fldlist_type) , intent(inout) :: fldsFrOcn(:)
+     logical            , intent(in)    :: ocn2glc_coupling
 
      integer :: index_scalar
 
@@ -271,6 +290,12 @@ contains
         call fldlist_add(fldsFrOcn_num, fldsFrOcn, 'Faoo_fbrf_ocn', index_Faoo_fbrf)
      end if
 #endif
+     if (ocn2glc_coupling) then
+        call fldList_add(fldsFrOcn_num, fldsFrOcn, 'So_t_depth', index_So_t_depth, &
+             ungridded_lbound=1, ungridded_ubound=nlev_export)
+        call fldList_add(fldsFrOcn_num, fldsFrOcn, 'So_s_depth', index_So_s_depth, &
+             ungridded_lbound=1, ungridded_ubound=nlev_export)
+     end if
 
    end subroutine blom_advertise_exports
 
@@ -477,13 +502,13 @@ contains
 
       ! Local variables.
       real(r8) :: q
-      integer m, n, mm, nn, k1m, k1n, i, j, l
-      logical :: first_call = .true.
+      integer  :: m, n, mm, nn, k1m, k1n, i, j, l, k
+      logical  :: first_call = .true.
 
-      ! ------------------------------------------------------------------------
+      ! -----------------
       ! Set accumulation arrays to zero if this is the first call after a
       ! coupling interval.
-      ! ------------------------------------------------------------------------
+      ! -----------------
 
       if (tlast_coupled == 0._r8) then
          acc_u     (:,:) = 0._r8
@@ -499,11 +524,13 @@ contains
          acc_fbrf  (:,:) = 0._r8
          acc_fn2o  (:,:) = 0._r8
          acc_fnh3  (:,:) = 0._r8
+         acc_t_depth(:,:,:) = 0._r8
+         acc_s_depth(:,:,:) = 0._r8
       endif
 
-      ! ------------------------------------------------------------------------
+      ! -----------------
       ! Accumulate fields in send buffer
-      ! ------------------------------------------------------------------------
+      ! -----------------
 
       m = mod(nstep + 1, 2) + 1
       n = mod(nstep    , 2) + 1
@@ -614,6 +641,7 @@ contains
 
       if (index_Faoo_fn2o > 0) then
          ! Pack nitrous oxide flux (kg N2O/m^2/s), if requested
+         !$omp parallel do private(l, i)
          do j = 1, jj
             do l = 1, isp(j)
             do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
@@ -626,6 +654,7 @@ contains
 
       if (index_Faoo_fnh3 > 0) then
          ! Pack nitrous oxide flux (kg NH3/m^2/s), if requested
+         !$omp parallel do private(l, i)
          do j = 1, jj
             do l = 1, isp(j)
             do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
@@ -636,9 +665,22 @@ contains
          !$omp end parallel do
       end if
 
-      ! ------------------------------------------------------------------------
+      if (index_So_t_depth > 0 .and. index_So_s_depth > 0) then
+         do k = 1,kdm
+            do j = 1, jj
+               do l = 1, isp(j)
+               do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
+                  acc_t_depth(i,j,k) = acc_t_depth(i,j,k) + temp(i,j,k)*baclin
+                  acc_s_depth(i,j,k) = acc_s_depth(i,j,k) + saln(i,j,k)*baclin
+               enddo
+               end do
+            end do
+         end do
+      end if
+
+      ! -----------------
       ! Increment time since last coupling.
-      ! ------------------------------------------------------------------------
+      ! -----------------
 
       tlast_coupled = tlast_coupled + baclin
 
@@ -986,8 +1028,10 @@ contains
 
       ! Local variables.
       real(r8) :: tfac, utmp, vtmp
-      integer  :: n, l, i, j
-      logical, save :: first_call = .true.
+      integer  :: n, l, i, j, ko, ki
+      logical  :: level_found
+      real(r8) :: factor
+      logical  :: first_call = .true.
 
       tfac = 1._r8/tlast_coupled
 
@@ -1009,6 +1053,10 @@ contains
       fldlist(index_So_s)%dataptr(:) = 0._r8
       fldlist(index_So_bldepth)%dataptr(:) = 0._r8
       fldlist(index_Fioo_q)%dataptr(:) = 0._r8
+      if (index_So_t_depth > 0 .and. index_So_s_depth > 0) then
+         fldlist(index_So_t_depth)%dataptr2d(:,:) = SHR_CONST_SPVAL
+         fldlist(index_So_s_depth)%dataptr2d(:,:) = SHR_CONST_SPVAL
+      end if
 
       !$omp parallel do private(l, i, n, utmp, vtmp)
       do j = 1, jjcpl
@@ -1143,6 +1191,44 @@ contains
          !$omp end parallel do
       else
         if (mnproc == 1 .and. first_call) write(lp,*) subname//': nh3 flux not sent to coupler'
+      end if
+
+      if (index_So_t_depth > 0 .and. index_So_s_depth > 0) then
+         ! Multi-level saninity and temperature
+         ! interpolate acc_saln and acc_temp to output levels and then sent
+         do j = 1, jjcpl
+            do l = 1, isp(j)
+            do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
+               n = (j - 1)*ii + i
+               do ko = 1,nlev_export
+                  level_found = .false.
+                  do ki = 1,kdm-1
+                     if (vertical_levels(ko) > depthslev(ki) .and. vertical_levels(ko) <= depthslev(ki+1)) then
+                        if (mnproc == 1 .and. first_call) then
+                           write(lp,'(a,3(i5,2x),3(f13.5,2x))') &
+                                'vertical interpolation: ki,ko,ki+1,lev(ki),lev(ko),lev(ki+1) = ',&
+                                ki,ko,ki+1,depthslev(ki), vertical_levels(ko), depthslev(ki+1)
+                        end if
+                        level_found = .true.
+                        factor = (acc_t_depth(i,j,ki+1) - acc_t_depth(i,j,ki))/(depthslev(ki+1)-depthslev(ki))
+                        fldlist(index_So_t_depth)%dataptr2d(ko,n) = acc_t_depth(i,j,ki)*tfac &
+                                                                  + (vertical_levels(ko)-depthslev(ki))*factor  &
+                                                                  + SHR_CONST_TKFRZ
+                        factor = (acc_s_depth(i,j,ki+1) - acc_s_depth(i,j,ki))/(depthslev(ki+1)-depthslev(ki))
+                        fldlist(index_So_s_depth)%dataptr2d(ko,n) = acc_s_depth(i,j,ki)*tfac &
+                                                                  + (vertical_levels(ko)-depthslev(ki))*factor
+                     end if
+                  end do
+                  if (.not. level_found) then
+                     write(lp,'(a)') trim(subname)//&
+                          ': BLOM ERROR: could not find level bounds for vertical interpolation'
+                     call xchalt(subname)
+                     stop subname
+                  end if
+               enddo
+            end do
+            end do
+         end do
       end if
 
       if (first_call) then

--- a/drivers/nuopc/mod_nuopc_methods.F90
+++ b/drivers/nuopc/mod_nuopc_methods.F90
@@ -1219,8 +1219,16 @@ contains
                do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
                   n = (j - 1)*ii + i
                   do ko = 1,nlev_export
-                     fldlist(index_So_t_depth)%dataptr2d(ko,n) = acc_t_depth(i,j,ko)*tfac + SHR_CONST_TKFRZ
-                     fldlist(index_So_s_depth)%dataptr2d(ko,n) = acc_s_depth(i,j,ko)*tfac
+                     if (acc_t_depth(i,j,ko) == 0._r8) then
+                        fldlist(index_So_t_depth)%dataptr2d(ko,n) = shr_const_spval
+                     else
+                        fldlist(index_So_t_depth)%dataptr2d(ko,n) = acc_t_depth(i,j,ko)*tfac + SHR_CONST_TKFRZ
+                     end if
+                     if (acc_s_depth(i,j,ko) == 0._r8) then
+                        fldlist(index_So_s_depth)%dataptr2d(ko,n) = shr_const_spval
+                     else
+                        fldlist(index_So_s_depth)%dataptr2d(ko,n) = acc_s_depth(i,j,ko)*tfac
+                     end if
                   end do
                end do
             end do

--- a/drivers/nuopc/mod_vertinterp.F90
+++ b/drivers/nuopc/mod_vertinterp.F90
@@ -1,0 +1,127 @@
+module mod_vertinterp
+
+  use mod_types,     only: r8
+  use mod_constants, only: epsil
+  use mod_xc,        only: idm, jdm, jj, kk, nbdy, ifp, ilp, isp
+  use mod_grid,      only: depths
+  use mod_state,     only: dp
+  use mod_time,      only: nstep
+
+  implicit none
+  public
+
+contains
+
+  subroutine vertinterp_weights(k, nlevs, vlevs, vlevs_bnds, ind1, ind2, weights)
+
+    ! Arguments
+    integer , intent(in) :: k
+    integer , intent(in) :: nlevs
+    real(r8), intent(in) :: vlevs(nlevs)
+    real(r8), intent(in) :: vlevs_bnds(2,nlevs)
+    integer , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)     :: ind1
+    integer , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)     :: ind2
+    real    , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlevs) :: weights
+
+    ! Local variables
+    integer  :: m,mm
+    integer  :: d,i,j,l,kl,km,kml,k1m
+    real(r8) :: r,dzeps,dpeps
+    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kk)    , save :: ztop
+    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kk)    , save :: zbot
+    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlevs) , save :: dlevp
+    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)       , save :: pbath
+    logical  :: iniflg = .true.
+
+    ! Define thresholds
+    dzeps = 1e1*epsilp
+    dpeps = 1e5*epsilp
+
+    ! Sort out stuff related to time stepping
+    m = mod(nstep,2) + 1
+    mm = (m-1)*kk
+    km  = k+mm
+    k1m = 1+mm
+
+    ! Adjust bounds of levitus levels according to model bathymetry
+    if (iniflg) then
+      do j = 1,jj+1
+        do l = 1,isp(j)
+          do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+            pbath(i,j) = depths(i,j)
+          end do
+        end do
+      end do
+      do j = 1,jj+1
+        do d = 1,nlevs
+          do l = 1,isp(j)
+            do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+              dlevp(i,j,d) = max(dzeps,min(pbath(i,j),vlevs_bnds(2,d))-vlevs_bnds(1,d))
+            end do
+          end do
+        end do
+      end do
+
+      iniflg = .false.
+    end if
+
+    ! Compute top and bottom depths of density layers
+    if (k == 1) then
+      do j = 1,jj
+        do l = 1,isp(j)
+          do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+            zbot(i,j,1) = dp(i,j,k1m)
+          end do
+        end do
+        do kl = 2,kk
+          kml = kl+mm
+          do l = 1,isp(j)
+            do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+              zbot(i,j,kl) = zbot(i,j,kl-1) + dp(i,j,kml)
+            end do
+          end do
+        end do
+        do l = 1,isp(j)
+          do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+            zbot(i,j,1) = zbot(i,j,1)*pbath(i,j)/zbot(i,j,kk)
+            ztop(i,j,1) = 0.
+            ind1(i,j) = 1
+          end do
+        end do
+        do kl = 2,kk
+          do l = 1,isp(j)
+            do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+              zbot(i,j,kl) = zbot(i,j,kl)*pbath(i,j)/zbot(i,j,kk)
+              ztop(i,j,kl) = zbot(i,j,kl-1)
+            end do
+          end do
+        end do
+      end do
+    end if
+
+    ! Compute interpolation weights
+    do j = 1,jj
+      do l = 1,isp(j)
+        do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+          ind2(i,j) = 0
+          if (dp(i,j,km) > dpeps) then
+            do d = ind1(i,j),nlevs
+              if (vlevs_bnds(2,d) <= ztop(i,j,k)) then
+                ind1(i,j) = d+1
+                cycle
+              else if (vlevs_bnds(1,d) >= zbot(i,j,k)) then
+                exit
+              end if
+              ind2(i,j) = d
+              weights(i,j,d) = ( min(zbot(i,j,k),vlevs_bnds(2,d))   &
+                                -max(ztop(i,j,k),vlevs_bnds(1,d)) ) &
+                                /dlevp(i,j,d)
+            end do
+          end if
+        end do
+      end do
+    end do
+
+  end subroutine vertinterp_weights
+
+end module mod_vertinterp

--- a/drivers/nuopc/mod_vertinterp.F90
+++ b/drivers/nuopc/mod_vertinterp.F90
@@ -1,127 +1,177 @@
 module mod_vertinterp
 
-  use mod_types,     only: r8
-  use mod_constants, only: epsil
-  use mod_xc,        only: idm, jdm, jj, kk, nbdy, ifp, ilp, isp
-  use mod_grid,      only: depths
-  use mod_state,     only: dp
-  use mod_time,      only: nstep
+   use mod_types,     only: r8
+   use mod_constants, only: epsilp
+   use mod_xc,        only: idm, jdm, ii, jj, kk, nbdy, ifp, ilp, isp
+   use mod_grid,      only: depths
+   use mod_state,     only: dp
+   use mod_time,      only: nstep, baclin
 
-  implicit none
-  public
+   implicit none
+   private
+
+   public :: vertinterp_wghts
+   public :: vertinterp_accum
+
+   real(r8), allocatable :: dlevp(:,:,:)
+   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kk) :: ztop
+   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kk) :: zbot
+   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)    :: pbath
 
 contains
 
-  subroutine vertinterp_weights(k, nlevs, vlevs, vlevs_bnds, ind1, ind2, weights)
+   ! ---------------------------------------------------------------------------
+   subroutine vertinterp_wghts(k, nlevs, vlevs, vlevs_bnds, ind1, ind2, wghts)
 
-    ! Arguments
-    integer , intent(in) :: k
-    integer , intent(in) :: nlevs
-    real(r8), intent(in) :: vlevs(nlevs)
-    real(r8), intent(in) :: vlevs_bnds(2,nlevs)
-    integer , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)     :: ind1
-    integer , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)     :: ind2
-    real    , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlevs) :: weights
+      ! Arguments
+      integer , intent(in) :: k
+      integer , intent(in) :: nlevs
+      real(r8), intent(in) :: vlevs(nlevs)
+      real(r8), intent(in) :: vlevs_bnds(2,nlevs)
+      integer , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)     :: ind1
+      integer , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)     :: ind2
+      real    , intent(out), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlevs) :: wghts
 
-    ! Local variables
-    integer  :: m,mm
-    integer  :: d,i,j,l,kl,km,kml,k1m
-    real(r8) :: r,dzeps,dpeps
-    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kk)    , save :: ztop
-    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kk)    , save :: zbot
-    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlevs) , save :: dlevp
-    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)       , save :: pbath
-    logical  :: iniflg = .true.
+      ! Local variables
+      integer  :: m,mm
+      integer  :: d,i,j,l,kl,km,kml,k1m
+      real(r8) :: r,dzeps,dpeps
+      logical  :: iniflg = .true.
 
-    ! Define thresholds
-    dzeps = 1e1*epsilp
-    dpeps = 1e5*epsilp
+      ! Define thresholds
+      dzeps = 1e1*epsilp
+      dpeps = 1e5*epsilp
 
-    ! Sort out stuff related to time stepping
-    m = mod(nstep,2) + 1
-    mm = (m-1)*kk
-    km  = k+mm
-    k1m = 1+mm
+      ! Sort out stuff related to time stepping
+      m = mod(nstep,2) + 1
+      mm = (m-1)*kk
+      km  = k+mm
+      k1m = 1+mm
 
-    ! Adjust bounds of levitus levels according to model bathymetry
-    if (iniflg) then
-      do j = 1,jj+1
-        do l = 1,isp(j)
-          do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-            pbath(i,j) = depths(i,j)
-          end do
-        end do
-      end do
-      do j = 1,jj+1
-        do d = 1,nlevs
-          do l = 1,isp(j)
-            do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              dlevp(i,j,d) = max(dzeps,min(pbath(i,j),vlevs_bnds(2,d))-vlevs_bnds(1,d))
+      ! Adjust bounds of levitus levels according to model bathymetry
+      if (iniflg) then
+         do j = 1,jj+1
+            do l = 1,isp(j)
+               do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+                  pbath(i,j) = depths(i,j)
+               end do
             end do
-          end do
-        end do
-      end do
+         end do
 
-      iniflg = .false.
-    end if
+         allocate (dlevp(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlevs))
+         do j = 1,jj+1
+            do d = 1,nlevs
+               do l = 1,isp(j)
+                  do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+                     dlevp(i,j,d) = max(dzeps,min(pbath(i,j),vlevs_bnds(2,d))-vlevs_bnds(1,d))
+                  end do
+               end do
+            end do
+         end do
 
-    ! Compute top and bottom depths of density layers
-    if (k == 1) then
+         iniflg = .false.
+      end if
+
+      ! Compute top and bottom depths of density layers
+      if (k == 1) then
+         do j = 1,jj
+            do l = 1,isp(j)
+               do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+                  zbot(i,j,1) = dp(i,j,k1m)
+               end do
+            end do
+            do kl = 2,kk
+               kml = kl+mm
+               do l = 1,isp(j)
+                  do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+                     zbot(i,j,kl) = zbot(i,j,kl-1) + dp(i,j,kml)
+                  end do
+               end do
+            end do
+            do l = 1,isp(j)
+               do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+                  zbot(i,j,1) = zbot(i,j,1)*pbath(i,j)/zbot(i,j,kk)
+                  ztop(i,j,1) = 0.
+                  ind1(i,j) = 1
+               end do
+            end do
+            do kl = 2,kk
+               do l = 1,isp(j)
+                  do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+                     zbot(i,j,kl) = zbot(i,j,kl)*pbath(i,j)/zbot(i,j,kk)
+                     ztop(i,j,kl) = zbot(i,j,kl-1)
+                  end do
+               end do
+            end do
+         end do
+      end if
+
+      ! Compute interpolation wghts
       do j = 1,jj
-        do l = 1,isp(j)
-          do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-            zbot(i,j,1) = dp(i,j,k1m)
-          end do
-        end do
-        do kl = 2,kk
-          kml = kl+mm
-          do l = 1,isp(j)
+         do l = 1,isp(j)
             do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              zbot(i,j,kl) = zbot(i,j,kl-1) + dp(i,j,kml)
+               ind2(i,j) = 0
+               if (dp(i,j,km) > dpeps) then
+                  do d = ind1(i,j),nlevs
+                     if (vlevs_bnds(2,d) <= ztop(i,j,k)) then
+                        ind1(i,j) = d+1
+                        cycle
+                     else if (vlevs_bnds(1,d) >= zbot(i,j,k)) then
+                        exit
+                     end if
+                     ind2(i,j) = d
+                     wghts(i,j,d) = ( min(zbot(i,j,k),vlevs_bnds(2,d))   &
+                          -max(ztop(i,j,k),vlevs_bnds(1,d)) ) &
+                          /dlevp(i,j,d)
+                  end do
+               end if
             end do
-          end do
-        end do
-        do l = 1,isp(j)
-          do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-            zbot(i,j,1) = zbot(i,j,1)*pbath(i,j)/zbot(i,j,kk)
-            ztop(i,j,1) = 0.
-            ind1(i,j) = 1
-          end do
-        end do
-        do kl = 2,kk
-          do l = 1,isp(j)
+         end do
+      end do
+
+   end subroutine vertinterp_wghts
+
+   ! ---------------------------------------------------------------------------
+   subroutine vertinterp_accum(nlev_in, nlev_out, k, ind1, ind2, wghts, fld_in, fld_out)
+
+      !---------------------------------------------------------------
+      ! Description: accumulate layer fields mapped to levels
+      !
+      ! Arguments:
+      !   int  nlev_in  (in)  : number of levels of input field
+      !   int  nlev_out (in)  : number of levels of output field
+      !   int  k        (in)  : layer index of input fld
+      !   int  ind1     (in)  : index field for first accumulated level
+      !   int  ind2     (in)  : index field for last accumulated level
+      !   real wghts    (in)  : weights used for accumulation
+      !   real fld_in   (in)  : input data used for accumulation
+      !   real fld_out  (out) : output mapped and accumulated data
+      !---------------------------------------------------------------
+
+      integer  , intent(in) :: nlev_in
+      integer  , intent(in) :: nlev_out
+      integer  , intent(in) :: k
+      integer  , intent(in)  , dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)          :: ind1
+      integer  , intent(in)  , dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)          :: ind2
+      real(r8) , intent(in)  , dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlev_out) :: wghts
+      real(r8) , intent(in)  , dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlev_in)  :: fld_in
+      real(r8) , intent(out) , dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,nlev_out) :: fld_out
+
+      ! Local variables
+      integer :: d,i,j,l
+
+      !$omp parallel do private(l,i,d)
+      do j = 1,jj
+         do l = 1,isp(j)
             do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              zbot(i,j,kl) = zbot(i,j,kl)*pbath(i,j)/zbot(i,j,kk)
-              ztop(i,j,kl) = zbot(i,j,kl-1)
+               do d = ind1(i,j),ind2(i,j)
+                  fld_out(i,j,d) = fld_out(i,j,d) + fld_in(i,j,k)*wghts(i,j,d)*baclin
+               end do
             end do
-          end do
-        end do
+         end do
       end do
-    end if
+      !$omp end parallel do
 
-    ! Compute interpolation weights
-    do j = 1,jj
-      do l = 1,isp(j)
-        do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-          ind2(i,j) = 0
-          if (dp(i,j,km) > dpeps) then
-            do d = ind1(i,j),nlevs
-              if (vlevs_bnds(2,d) <= ztop(i,j,k)) then
-                ind1(i,j) = d+1
-                cycle
-              else if (vlevs_bnds(1,d) >= zbot(i,j,k)) then
-                exit
-              end if
-              ind2(i,j) = d
-              weights(i,j,d) = ( min(zbot(i,j,k),vlevs_bnds(2,d))   &
-                                -max(ztop(i,j,k),vlevs_bnds(1,d)) ) &
-                                /dlevp(i,j,d)
-            end do
-          end if
-        end do
-      end do
-    end do
-
-  end subroutine vertinterp_weights
+   end subroutine vertinterp_accum
 
 end module mod_vertinterp

--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -284,7 +284,6 @@ contains
                                field=field, rc=rc)
             if (ChkErr(rc, __LINE__, u_FILE_u)) return
             if (fldsFrOcn(n)%ungridded_lbound > 0 .and. fldsFrOcn(n)%ungridded_ubound > 0) then
-              write(6,'(a)')'DEBUG: setting dataptr2d for field '//trim(fldsFrOcn(n)%stdname)
               call ESMF_FieldGet(field, farrayPtr=fldsFrOcn(n)%dataptr2d, rc=rc)
               if (ChkErr(rc, __LINE__, u_FILE_u)) return
             else


### PR DESCRIPTION
This PR provides new temperature and salinity fields at multiple levels that are sent to the mediator and then used by CISM.
There is already capability in DOCN%MULTILEVEL to do this. 
The following test case showed that the fields sent to the mediator look reasonable:

```
code base: https://github.com/mvertens/NorESM/tree/feature/noresm2_5_alpha03_v2
compset: 1850_CAM60_CLM51%SP_CICE_BLOM_MOSART_CISM2%AIS-EVOLVE%GRIS-EVOLVE_SWAV
res: a%0.9x1.25_l%0.9x1.25_oi%tnx1v4_r%null_g%ais8:gris4_w%null_z%null_m%tnx1v4
```

NOTE: Regression testing must still be carried out.