### PR TITLE
More transparent co2 gas-exchange formulation

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5413,7 +5413,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Surface fugacity [uatm]</desc>
+    <desc>Surface CO2 fugacity [uatm]</desc>
   </entry>
 
   <entry id="srf_pco2">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5428,6 +5428,18 @@
     <desc>Surface pCO2 [uatm]</desc>
   </entry>
 
+  <entry id="srf_xco2">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>CO2 dry air mixing ratio that would be in equilibrium with the surface ocean [ppm]</desc>
+  </entry>
+
   <entry id="srf_pco2_gex">
     <type>integer(3)</type>
     <category>diabgc</category>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5413,7 +5413,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Surface fugacity at 1 atm total pressure [uatm]</desc>
+    <desc>Surface fugacity [uatm]</desc>
   </entry>
 
   <entry id="srf_pco2">
@@ -5425,7 +5425,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Surface pCO2 at 1 atm total pressure [uatm]</desc>
+    <desc>Surface pCO2 [uatm]</desc>
   </entry>
 
   <entry id="srf_pco2_gex">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5380,7 +5380,7 @@
     <desc>Piston velocity (kwco2)  [m s-1]</desc>
   </entry>
 
-  <entry id="srf_kwco2khm">
+  <entry id="srf_kwco2sol">
     <type>integer(3)</type>
     <category>diabgc</category>
     <group>diabgc</group>
@@ -5389,10 +5389,10 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Piston velocity times solubility (kwco2*kh; moist air) [m s-1 mol kg-1 uatm-1]</desc>
+    <desc>Piston velocity times solubility (kwco2*kh0) [m s-1 mol kg-1 uatm-1]</desc>
   </entry>
 
-  <entry id="srf_co2kh">
+  <entry id="srf_co2sol">
     <type>integer(3)</type>
     <category>diabgc</category>
     <group>diabgc</group>
@@ -5401,10 +5401,10 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Piston velocity times solubility (kwco2*kh; moist air) [m s-1 mol kg-1 uatm-1]</desc>
+    <desc>CO2 solubility (kh0) [mol kg-1 uatm-1]</desc>
   </entry>
 
-  <entry id="srf_co2khm">
+  <entry id="srf_fco2">
     <type>integer(3)</type>
     <category>diabgc</category>
     <group>diabgc</group>
@@ -5413,7 +5413,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>CO2 solubility under moist air assumption (kh) [mol kg-1 atm-1] </desc>
+    <desc>Surface fugacity at 1 atm total pressure [uatm]</desc>
   </entry>
 
   <entry id="srf_pco2">
@@ -5425,10 +5425,10 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Natural surface PCO2 (spco2) [uatm]</desc>
+    <desc>Surface pCO2 at 1 atm total pressure [uatm]</desc>
   </entry>
 
-  <entry id="srf_pco2m">
+  <entry id="srf_pco2_gex">
     <type>integer(3)</type>
     <category>diabgc</category>
     <group>diabgc</group>
@@ -5437,7 +5437,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Surface PCO2 under moist air assumption [uatm]</desc>
+    <desc>Atmospheric pCO2 at the air-sea interface as seen by the gas-exchange parameterization [uatm]</desc>
   </entry>
 
   <entry id="srf_co2fxd">

--- a/hamocc/mo_accfields.F90
+++ b/hamocc/mo_accfields.F90
@@ -42,10 +42,10 @@ contains
     use mod_xc,           only: mnproc
     use mod_dia,          only: ddm
     use mo_carbch,        only: atm,atmflx,co2fxd,co2fxu,co3,hi,kwco2sol,                          &
-                                ndepnoyflx,rivinflx,oalkflx,ocetra,omegaa,omegac,pco2d,            &
-                                satoxy,sedfluxo,sedfluxb,pco2m,kwco2d,co2sold,co2solm,pn2om,       &
+                                ndepnoyflx,rivinflx,oalkflx,ocetra,omegaa,omegac,fco2,pco2,        &
+                                pco2_gex,satoxy,sedfluxo,sedfluxb,kwco2a,co2sol,pn2om,             &
                                 co213fxd,co213fxu,co214fxd,co214fxu,                               &
-                                natco3,nathi,natomegaa,natomegac,natpco2d,pnh3,ndepnhxflx
+                                natco3,nathi,natomegaa,natomegac,natpco2,pnh3,ndepnhxflx
     use mo_biomod,        only: bsiflx_bot,bsiflx0100,bsiflx0500,bsiflx1000,                       &
                                 bsiflx2000,bsiflx4000,calflx_bot,calflx0100,calflx0500,            &
                                 calflx1000,calflx2000,calflx4000,carflx_bot,carflx0100,            &
@@ -86,8 +86,8 @@ contains
                                 jprorca,jprcaca,jsilpro,jpodiic,jpodial,jpodiph,                   &
                                 jpodiox,jpodin2,jpodino3,jpodisi,jndepnoy,jndepnhx,joalk,          &
                                 jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,                 &
-                                joxflux,joxygen,jpco2,jpco2m,jkwco2khm,jco2khm,                    &
-                                jco2kh,jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                    &
+                                joxflux,joxygen,jfco2,jpco2,jpco2_gex,jkwco2sol,jco2sol,           &
+                                jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                           &
                                 jprefdic,jprefo2,jprefpo4,jsilica,jsrfalkali,                      &
                                 jsrfano3,jsrfdic,jsrfiron,jsrfoxygen,jsrfphosph,                   &
                                 jsrfphyto,jsrfsilica,jsrfph,jwnos,jwphy,jndepnoyfx,                &
@@ -281,12 +281,12 @@ contains
     endif
 
     ! Accumulate 2d diagnostics
-    call accsrf(jpco2,pco2d,omask,0)
-    call accsrf(jpco2m,pco2m,omask,0)
-    call accsrf(jkwco2khm,kwco2sol,omask,0)
-    call accsrf(jkwco2,kwco2d,omask,0)
-    call accsrf(jco2kh,co2sold,omask,0)
-    call accsrf(jco2khm,co2solm,omask,0)
+    call accsrf(jfco2,fco2,omask,0)
+    call accsrf(jpco2,pco2,omask,0)
+    call accsrf(jpco2_gex,pco2_gex,omask,0)
+    call accsrf(jkwco2sol,kwco2sol,omask,0)
+    call accsrf(jkwco2,kwco2a,omask,0)
+    call accsrf(jco2sol,co2sol,omask,0)
     call accsrf(jsrfphosph,ocetra(1,1,1,iphosph),omask,0)
     call accsrf(jsrfoxygen,ocetra(1,1,1,ioxygen),omask,0)
     call accsrf(jsrfiron,ocetra(1,1,1,iiron),omask,0)
@@ -310,7 +310,7 @@ contains
     if (use_natDIC) then
       call accsrf(jsrfnatdic,ocetra(1,1,1,inatsco212),omask,0)
       call accsrf(jsrfnatalk,ocetra(1,1,1,inatalkali),omask,0)
-      call accsrf(jnatpco2,natpco2d,omask,0)
+      call accsrf(jnatpco2,natpco2,omask,0)
       call accsrf(jsrfnatph,nathi(1,1,1),omask,0)
     endif
     if (use_BROMO) then

--- a/hamocc/mo_accfields.F90
+++ b/hamocc/mo_accfields.F90
@@ -42,7 +42,7 @@ contains
     use mod_xc,           only: mnproc
     use mod_dia,          only: ddm
     use mo_carbch,        only: atm,atmflx,co2fxd,co2fxu,co3,hi,kwco2sol,                          &
-                                ndepnoyflx,rivinflx,oalkflx,ocetra,omegaa,omegac,fco2,pco2,        &
+                                ndepnoyflx,rivinflx,oalkflx,ocetra,omegaa,omegac,fco2,pco2,xco2,   &
                                 pco2_gex,satoxy,sedfluxo,sedfluxb,kwco2a,co2sol,pn2om,             &
                                 co213fxd,co213fxu,co214fxd,co214fxu,                               &
                                 natco3,nathi,natomegaa,natomegac,natpco2,pnh3,ndepnhxflx
@@ -86,7 +86,7 @@ contains
                                 jprorca,jprcaca,jsilpro,jpodiic,jpodial,jpodiph,                   &
                                 jpodiox,jpodin2,jpodino3,jpodisi,jndepnoy,jndepnhx,joalk,          &
                                 jniflux,jnos,jo2flux,jo2sat,jomegaa,jomegac,jopal,                 &
-                                joxflux,joxygen,jfco2,jpco2,jpco2_gex,jkwco2sol,jco2sol,           &
+                                joxflux,joxygen,jfco2,jpco2,jxco2,jpco2_gex,jkwco2sol,jco2sol,     &
                                 jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                           &
                                 jprefdic,jprefo2,jprefpo4,jsilica,jsrfalkali,                      &
                                 jsrfano3,jsrfdic,jsrfiron,jsrfoxygen,jsrfphosph,                   &
@@ -283,6 +283,7 @@ contains
     ! Accumulate 2d diagnostics
     call accsrf(jfco2,fco2,omask,0)
     call accsrf(jpco2,pco2,omask,0)
+    call accsrf(jxco2,xco2,omask,0)
     call accsrf(jpco2_gex,pco2_gex,omask,0)
     call accsrf(jkwco2sol,kwco2sol,omask,0)
     call accsrf(jkwco2,kwco2a,omask,0)

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -94,6 +94,7 @@ module mo_bgcmean
   ! --- Namelist for diagnostic output
   integer, dimension(nbgcmax) ::                                          &
        & SRF_KWCO2     =0    ,SRF_FCO2      =0    ,SRF_PCO2      =0    ,  &
+       & SRF_XCO2      =0    ,SRF_PCO2_GEX  =0    ,                       &
        & SRF_DMSFLUX   =0    ,SRF_KWCO2SOL  =0    ,SRF_CO2SOL    =0    ,  &
        & SRF_CO2FXD    =0    ,SRF_CO2FXU    =0    ,SRF_CO213FXD  =0    ,  &
        & SRF_CO213FXU  =0    ,SRF_CO214FXD  =0    ,SRF_CO214FXU  =0    ,  &
@@ -106,14 +107,12 @@ module mo_bgcmean
        & SRF_SF6       =0    ,SRF_PHOSPH    =0    ,SRF_OXYGEN    =0    ,  &
        & SRF_IRON      =0    ,SRF_ANO3      =0    ,SRF_ALKALI    =0    ,  &
        & SRF_SILICA    =0    ,SRF_DIC       =0    ,SRF_PHYTO     =0    ,  &
-       & SRF_PH        =0    ,SRF_PCO2_GEX  =0    ,                       &
-       & SRF_NATDIC    =0    ,SRF_NATALKALI =0    ,SRF_NATPCO2   =0    ,  &
-       & SRF_NATCO2FX  =0    ,SRF_NATPH     =0    ,                       &
+       & SRF_PH        =0    ,SRF_NATDIC    =0    ,SRF_NATALKALI =0    ,  &
+       & SRF_NATPCO2   =0    ,SRF_NATCO2FX  =0    ,SRF_NATPH     =0    ,  &
        & SRF_ATMBROMO  =0    ,SRF_BROMO     =0    ,SRF_BROMOFX   =0    ,  &
        & SRF_ANH4      =0    ,SRF_ANO2      =0    ,SRF_ANH3FX    =0    ,  &
        & SRF_PN2OM     =0    ,SRF_PNH3      =0    ,SRF_ATMNH3    =0    ,  &
-       & SRF_ATMN2O    =0    ,                                            &
-       & INT_BROMOPRO  =0    ,INT_BROMOUV   =0    ,                       &
+       & SRF_ATMN2O    =0    ,INT_BROMOPRO  =0    ,INT_BROMOUV   =0    ,  &
        & INT_PHOSY     =0    ,INT_NFIX      =0    ,INT_DNIT      =0    ,  &
        & FLX_NDEPNOY   =0    ,FLX_NDEPNHX   =0    ,FLX_OALK      =0    ,  &
        & FLX_CAR0100   =0    ,FLX_CAR0500   =0    ,FLX_CAR1000   =0    ,  &
@@ -143,8 +142,7 @@ module mo_bgcmean
        & LYR_CFC11     =0    ,LYR_CFC12     =0    ,LYR_SF6       =0    ,  &
        & LYR_NATDIC    =0    ,LYR_NATALKALI =0    ,LYR_NATCALC   =0    ,  &
        & LYR_NATPH     =0    ,LYR_NATOMEGAA =0    ,LYR_NATOMEGAC =0    ,  &
-       & LYR_NATCO3    =0    ,                                            &
-       & LYR_BROMO     =0    ,                                            &
+       & LYR_NATCO3    =0    ,LYR_BROMO     =0    ,                       &
        & LYR_D13C      =0    ,LYR_D14C      =0    ,LYR_BIGD14C   =0    ,  &
        & LYR_POC13     =0    ,LYR_DOC13     =0    ,LYR_CALC13    =0    ,  &
        & LYR_PHYTO13   =0    ,LYR_GRAZER13  =0    ,                       &
@@ -176,8 +174,7 @@ module mo_bgcmean
        & LVL_CFC11     =0    ,LVL_CFC12     =0    ,LVL_SF6       =0    ,  &
        & LVL_NATDIC    =0    ,LVL_NATALKALI =0    ,LVL_NATCALC   =0    ,  &
        & LVL_NATPH     =0    ,LVL_NATOMEGAA =0    ,LVL_NATOMEGAC =0    ,  &
-       & LVL_NATCO3    =0    ,                                            &
-       & LVL_BROMO     =0    ,                                            &
+       & LVL_NATCO3    =0    ,LVL_BROMO     =0    ,                       &
        & LVL_D13C      =0    ,LVL_D14C      =0    ,LVL_BIGD14C   =0    ,  &
        & LVL_POC13     =0    ,LVL_DOC13     =0    ,LVL_CALC13    =0    ,  &
        & LVL_PHYTO13   =0    ,LVL_GRAZER13  =0    ,                       &
@@ -212,6 +209,7 @@ module mo_bgcmean
   character(len=10), dimension(nbgcmax) :: glb_fnametag
   namelist /diabgc/                                                       &
        & SRF_KWCO2         ,SRF_FCO2          ,SRF_PCO2          ,        &
+       & SRF_XCO2          ,SRF_PCO2_GEX      ,                           & 
        & SRF_DMSFLUX       ,SRF_KWCO2SOL      ,SRF_CO2SOL        ,        &
        & SRF_CO2FXD        ,SRF_CO2FXU        ,SRF_CO213FXD      ,        &
        & SRF_CO213FXU      ,SRF_CO214FXD      ,SRF_CO214FXU      ,        &
@@ -224,14 +222,12 @@ module mo_bgcmean
        & SRF_SF6           ,SRF_PHOSPH        ,SRF_OXYGEN        ,        &
        & SRF_IRON          ,SRF_ANO3          ,SRF_ALKALI        ,        &
        & SRF_SILICA        ,SRF_DIC           ,SRF_PHYTO         ,        &
-       & SRF_PH            ,SRF_PCO2_GEX      ,                           &
-       & SRF_NATDIC        ,SRF_NATALKALI     ,SRF_NATPCO2       ,        &
-       & SRF_NATCO2FX      ,SRF_NATPH         ,                           &
+       & SRF_PH            ,SRF_NATDIC        ,SRF_NATALKALI     ,        &
+       & SRF_NATPCO2       ,SRF_NATCO2FX      ,SRF_NATPH         ,        &
        & SRF_ATMBROMO      ,SRF_BROMO         ,SRF_BROMOFX       ,        &
        & SRF_ANH4          ,SRF_ANO2          ,SRF_ANH3FX        ,        &
        & SRF_PN2OM         ,SRF_PNH3          ,SRF_ATMNH3        ,        &
-       & SRF_ATMN2O        ,                                              &
-       & INT_BROMOPRO      ,INT_BROMOUV       ,                           &
+       & SRF_ATMN2O        ,INT_BROMOPRO      ,INT_BROMOUV       ,        &
        & INT_PHOSY         ,INT_NFIX          ,INT_DNIT          ,        &
        & FLX_NDEPNOY       ,FLX_NDEPNHX       ,FLX_OALK          ,        &
        & FLX_CAR0100       ,FLX_CAR0500       ,FLX_CAR1000       ,        &
@@ -261,8 +257,7 @@ module mo_bgcmean
        & LYR_CFC11         ,LYR_CFC12         ,LYR_SF6           ,        &
        & LYR_NATDIC        ,LYR_NATALKALI     ,LYR_NATCALC       ,        &
        & LYR_NATPH         ,LYR_NATOMEGAA     ,LYR_NATOMEGAC     ,        &
-       & LYR_NATCO3        ,                                              &
-       & LYR_BROMO         ,                                              &
+       & LYR_NATCO3        ,LYR_BROMO         ,                           &
        & LYR_D13C          ,LYR_D14C          ,LYR_BIGD14C       ,        &
        & LYR_PHYTO13       ,LYR_GRAZER13      ,LYR_POC13         ,        &
        & LYR_DOC13         ,LYR_CALC13        ,                           &
@@ -286,13 +281,11 @@ module mo_bgcmean
        & LVL_WPHY          ,LVL_WNOS          ,LVL_EPS           ,        &
        & LVL_ASIZE         ,LVL_N2O           ,LVL_PREFO2        ,        &
        & LVL_O2SAT         ,LVL_PREFPO4       ,LVL_PREFALK       ,        &
-       & LVL_PREFDIC       ,LVL_DICSAT        ,                           &
-       & LVL_PREFSILICA    ,                                              &
+       & LVL_PREFDIC       ,LVL_DICSAT        ,LVL_PREFSILICA    ,        &
        & LVL_CFC11         ,LVL_CFC12         ,LVL_SF6           ,        &
        & LVL_NATDIC        ,LVL_NATALKALI     ,LVL_NATCALC       ,        &
        & LVL_NATPH         ,LVL_NATOMEGAA     ,LVL_NATOMEGAC     ,        &
-       & LVL_NATCO3        ,                                              &
-       & LVL_BROMO         ,                                              &
+       & LVL_NATCO3        ,LVL_BROMO         ,                           &
        & LVL_D13C          ,LVL_D14C          ,LVL_BIGD14C       ,        &
        & LVL_PHYTO13       ,LVL_GRAZER13      ,LVL_POC13         ,        &
        & LVL_DOC13         ,LVL_CALC13        ,                           &
@@ -361,6 +354,7 @@ module mo_bgcmean
        &          jco2sol    = 0 ,                                        &
        &          jfco2      = 0 ,                                        &
        &          jpco2      = 0 ,                                        &
+       &          jxco2      = 0 ,                                        &
        &          jpco2_gex  = 0 ,                                        &
        &          jdmsflux   = 0 ,                                        &
        &          jco2fxd    = 0 ,                                        &
@@ -767,10 +761,12 @@ CONTAINS
       jco2sol(n)=i_bsc_m2d*min(1,SRF_CO2SOL(n))
       if (SRF_FCO2(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jfco2(n)=i_bsc_m2d*min(1,SRF_FCO2(n))
-      if (SRF_PCO2_GEX(n) > 0) i_bsc_m2d=i_bsc_m2d+1
-      jpco2_gex(n)=i_bsc_m2d*min(1,SRF_PCO2_GEX(n))
       if (SRF_PCO2(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jpco2(n)=i_bsc_m2d*min(1,SRF_PCO2(n))
+      if (SRF_XCO2(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jxco2(n)=i_bsc_m2d*min(1,SRF_XCO2(n))
+      if (SRF_PCO2_GEX(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jpco2_gex(n)=i_bsc_m2d*min(1,SRF_PCO2_GEX(n))
       if (SRF_DMSFLUX(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jdmsflux(n)=i_bsc_m2d*min(1,SRF_DMSFLUX(n))
       if (SRF_CO2FXD(n) > 0) i_bsc_m2d=i_bsc_m2d+1

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -93,9 +93,8 @@ module mo_bgcmean
 
   ! --- Namelist for diagnostic output
   integer, dimension(nbgcmax) ::                                          &
-       & SRF_KWCO2     =0    ,SRF_PCO2      =0    ,SRF_DMSFLUX   =0    ,  &
-       & SRF_KWCO2KHM  =0    ,SRF_CO2KHM    =0    ,SRF_CO2KH     =0    ,  &
-       & SRF_PCO2M     =0    ,                                            &
+       & SRF_KWCO2     =0    ,SRF_FCO2      =0    ,SRF_PCO2      =0    ,  &
+       & SRF_DMSFLUX   =0    ,SRF_KWCO2SOL  =0    ,SRF_CO2SOL    =0    ,  &
        & SRF_CO2FXD    =0    ,SRF_CO2FXU    =0    ,SRF_CO213FXD  =0    ,  &
        & SRF_CO213FXU  =0    ,SRF_CO214FXD  =0    ,SRF_CO214FXU  =0    ,  &
        & SRF_OXFLUX    =0    ,SRF_NIFLUX    =0    ,SRF_DMS       =0    ,  &
@@ -107,7 +106,7 @@ module mo_bgcmean
        & SRF_SF6       =0    ,SRF_PHOSPH    =0    ,SRF_OXYGEN    =0    ,  &
        & SRF_IRON      =0    ,SRF_ANO3      =0    ,SRF_ALKALI    =0    ,  &
        & SRF_SILICA    =0    ,SRF_DIC       =0    ,SRF_PHYTO     =0    ,  &
-       & SRF_PH        =0    ,                                            &
+       & SRF_PH        =0    ,SRF_PCO2_GEX  =0    ,                       &
        & SRF_NATDIC    =0    ,SRF_NATALKALI =0    ,SRF_NATPCO2   =0    ,  &
        & SRF_NATCO2FX  =0    ,SRF_NATPH     =0    ,                       &
        & SRF_ATMBROMO  =0    ,SRF_BROMO     =0    ,SRF_BROMOFX   =0    ,  &
@@ -212,9 +211,8 @@ module mo_bgcmean
 
   character(len=10), dimension(nbgcmax) :: glb_fnametag
   namelist /diabgc/                                                       &
-       & SRF_KWCO2         ,SRF_PCO2          ,SRF_DMSFLUX       ,        &
-       & SRF_KWCO2KHM      ,SRF_CO2KHM        ,SRF_CO2KH         ,        &
-       & SRF_PCO2M         ,                                              &
+       & SRF_KWCO2         ,SRF_FCO2          ,SRF_PCO2          ,        &
+       & SRF_DMSFLUX       ,SRF_KWCO2SOL      ,SRF_CO2SOL        ,        &
        & SRF_CO2FXD        ,SRF_CO2FXU        ,SRF_CO213FXD      ,        &
        & SRF_CO213FXU      ,SRF_CO214FXD      ,SRF_CO214FXU      ,        &
        & SRF_OXFLUX        ,SRF_NIFLUX        ,SRF_DMS           ,        &
@@ -226,7 +224,7 @@ module mo_bgcmean
        & SRF_SF6           ,SRF_PHOSPH        ,SRF_OXYGEN        ,        &
        & SRF_IRON          ,SRF_ANO3          ,SRF_ALKALI        ,        &
        & SRF_SILICA        ,SRF_DIC           ,SRF_PHYTO         ,        &
-       & SRF_PH            ,                                              &
+       & SRF_PH            ,SRF_PCO2_GEX      ,                           &
        & SRF_NATDIC        ,SRF_NATALKALI     ,SRF_NATPCO2       ,        &
        & SRF_NATCO2FX      ,SRF_NATPH         ,                           &
        & SRF_ATMBROMO      ,SRF_BROMO         ,SRF_BROMOFX       ,        &
@@ -359,11 +357,11 @@ module mo_bgcmean
   integer :: i_bsc_m2d
   integer, dimension(nbgcmax) ::                                          &
        &          jkwco2     = 0 ,                                        &
-       &          jkwco2khm  = 0 ,                                        &
-       &          jco2kh     = 0 ,                                        &
-       &          jco2khm    = 0 ,                                        &
+       &          jkwco2sol  = 0 ,                                        &
+       &          jco2sol    = 0 ,                                        &
+       &          jfco2      = 0 ,                                        &
        &          jpco2      = 0 ,                                        &
-       &          jpco2m     = 0 ,                                        &
+       &          jpco2_gex  = 0 ,                                        &
        &          jdmsflux   = 0 ,                                        &
        &          jco2fxd    = 0 ,                                        &
        &          jco2fxu    = 0 ,                                        &
@@ -763,16 +761,16 @@ CONTAINS
     do n=1,nbgc
       if (SRF_KWCO2(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jkwco2(n)=i_bsc_m2d*min(1,SRF_KWCO2(n))
-      if (SRF_KWCO2KHM(n) > 0) i_bsc_m2d=i_bsc_m2d+1
-      jkwco2khm(n)=i_bsc_m2d*min(1,SRF_KWCO2KHM(n))
-      if (SRF_CO2KH(n) > 0) i_bsc_m2d=i_bsc_m2d+1
-      jco2kh(n)=i_bsc_m2d*min(1,SRF_CO2KH(n))
-      if (SRF_CO2KHM(n) > 0) i_bsc_m2d=i_bsc_m2d+1
-      jco2khm(n)=i_bsc_m2d*min(1,SRF_CO2KHM(n))
+      if (SRF_KWCO2SOL(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jkwco2sol(n)=i_bsc_m2d*min(1,SRF_KWCO2SOL(n))
+      if (SRF_CO2SOL(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jco2sol(n)=i_bsc_m2d*min(1,SRF_CO2SOL(n))
+      if (SRF_FCO2(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jfco2(n)=i_bsc_m2d*min(1,SRF_FCO2(n))
+      if (SRF_PCO2_GEX(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jpco2_gex(n)=i_bsc_m2d*min(1,SRF_PCO2_GEX(n))
       if (SRF_PCO2(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jpco2(n)=i_bsc_m2d*min(1,SRF_PCO2(n))
-      if (SRF_PCO2M(n) > 0) i_bsc_m2d=i_bsc_m2d+1
-      jpco2m(n)=i_bsc_m2d*min(1,SRF_PCO2M(n))
       if (SRF_DMSFLUX(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jdmsflux(n)=i_bsc_m2d*min(1,SRF_DMSFLUX(n))
       if (SRF_CO2FXD(n) > 0) i_bsc_m2d=i_bsc_m2d+1

--- a/hamocc/mo_carbch.F90
+++ b/hamocc/mo_carbch.F90
@@ -71,6 +71,7 @@ module mo_carbch
 
   real, dimension (:,:),     allocatable, public :: fco2
   real, dimension (:,:),     allocatable, public :: pco2
+  real, dimension (:,:),     allocatable, public :: xco2
   real, dimension (:,:),     allocatable, public :: pco2_gex
   real, dimension (:,:),     allocatable, public :: kwco2sol
   real, dimension (:,:),     allocatable, public :: kwco2a
@@ -344,6 +345,15 @@ contains
     allocate (pco2(kpie,kpje),stat=errstat)
     if(errstat.ne.0) stop 'not enough memory pco2'
     pco2(:,:) = 0.0
+
+    if (mnproc.eq.1) then
+      write(io_stdo_bgc,*)'Memory allocation for variable xco2 ...'
+      write(io_stdo_bgc,*)'First dimension    : ',kpie
+      write(io_stdo_bgc,*)'Second dimension   : ',kpje
+    endif
+    allocate (xco2(kpie,kpje),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory xco2'
+    xco2(:,:) = 0.0
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)'Memory allocation for variable pco2_gex ...'

--- a/hamocc/mo_carbch.F90
+++ b/hamocc/mo_carbch.F90
@@ -69,19 +69,19 @@ module mo_carbch
   real, dimension (:,:,:),   allocatable, public :: sedfluxo
   real, dimension (:,:,:),   allocatable, public :: sedfluxb
 
-  real, dimension (:,:),     allocatable, public :: pco2d
-  real, dimension (:,:),     allocatable, public :: pco2m
+  real, dimension (:,:),     allocatable, public :: fco2
+  real, dimension (:,:),     allocatable, public :: pco2
+  real, dimension (:,:),     allocatable, public :: pco2_gex
   real, dimension (:,:),     allocatable, public :: kwco2sol
-  real, dimension (:,:),     allocatable, public :: kwco2d
-  real, dimension (:,:),     allocatable, public :: co2sold
-  real, dimension (:,:),     allocatable, public :: co2solm
+  real, dimension (:,:),     allocatable, public :: kwco2a
+  real, dimension (:,:),     allocatable, public :: co2sol
   real, dimension (:,:),     allocatable, public :: co2fxd
   real, dimension (:,:),     allocatable, public :: co2fxu
   real, dimension (:,:),     allocatable, public :: co213fxd
   real, dimension (:,:),     allocatable, public :: co213fxu
   real, dimension (:,:),     allocatable, public :: co214fxd
   real, dimension (:,:),     allocatable, public :: co214fxu
-  real, dimension (:,:),     allocatable, public :: natpco2d
+  real, dimension (:,:),     allocatable, public :: natpco2
   real, dimension (:,:,:),   allocatable, public :: nathi
   real, dimension (:,:,:),   allocatable, public :: natco3
   real, dimension (:,:,:),   allocatable, public :: natomegaa
@@ -174,13 +174,13 @@ contains
 
     if (use_natDIC) then
       if (mnproc.eq.1) then
-        write(io_stdo_bgc,*)'Memory allocation for variable natpco2d ...'
+        write(io_stdo_bgc,*)'Memory allocation for variable natpco2 ...'
         write(io_stdo_bgc,*)'First dimension    : ',kpie
         write(io_stdo_bgc,*)'Second dimension   : ',kpje
       endif
-      allocate (natpco2d(kpie,kpje),stat=errstat)
-      if(errstat.ne.0) stop 'not enough memory natpco2d'
-      natpco2d(:,:) = 0.0
+      allocate (natpco2(kpie,kpje),stat=errstat)
+      if(errstat.ne.0) stop 'not enough memory natpco2'
+      natpco2(:,:) = 0.0
 
       if (mnproc.eq.1) then
         write(io_stdo_bgc,*)'Memory allocation for variable nathi ...'
@@ -328,31 +328,40 @@ contains
     rivinflx(:,:,:) = 0.0
 
     if (mnproc.eq.1) then
-      write(io_stdo_bgc,*)'Memory allocation for variable pco2d ...'
+      write(io_stdo_bgc,*)'Memory allocation for variable fco2 ...'
       write(io_stdo_bgc,*)'First dimension    : ',kpie
       write(io_stdo_bgc,*)'Second dimension   : ',kpje
     endif
-    allocate (pco2d(kpie,kpje),stat=errstat)
-    if(errstat.ne.0) stop 'not enough memory pco2d'
-    pco2d(:,:) = 0.0
+    allocate (fco2(kpie,kpje),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory fco2'
+    fco2(:,:) = 0.0
 
     if (mnproc.eq.1) then
-      write(io_stdo_bgc,*)'Memory allocation for variable pco2m ...'
+      write(io_stdo_bgc,*)'Memory allocation for variable pco2 ...'
       write(io_stdo_bgc,*)'First dimension    : ',kpie
       write(io_stdo_bgc,*)'Second dimension   : ',kpje
     endif
-    allocate (pco2m(kpie,kpje),stat=errstat)
-    if(errstat.ne.0) stop 'not enough memory pco2m'
-    pco2m(:,:) = 0.0
+    allocate (pco2(kpie,kpje),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory pco2'
+    pco2(:,:) = 0.0
 
     if (mnproc.eq.1) then
-      write(io_stdo_bgc,*)'Memory allocation for variable kwco2d ...'
+      write(io_stdo_bgc,*)'Memory allocation for variable pco2_gex ...'
       write(io_stdo_bgc,*)'First dimension    : ',kpie
       write(io_stdo_bgc,*)'Second dimension   : ',kpje
     endif
-    allocate (kwco2d(kpie,kpje),stat=errstat)
-    if(errstat.ne.0) stop 'not enough memory kwco2d'
-    kwco2d(:,:) = 0.0
+    allocate (pco2_gex(kpie,kpje),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory pco2_gex'
+    pco2_gex(:,:) = 0.0
+
+    if (mnproc.eq.1) then
+      write(io_stdo_bgc,*)'Memory allocation for variable kwco2a ...'
+      write(io_stdo_bgc,*)'First dimension    : ',kpie
+      write(io_stdo_bgc,*)'Second dimension   : ',kpje
+    endif
+    allocate (kwco2a(kpie,kpje),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory kwco2a'
+    kwco2a(:,:) = 0.0
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)'Memory allocation for variable kwco2sol ...'
@@ -364,22 +373,13 @@ contains
     kwco2sol(:,:) = 0.0
 
     if (mnproc.eq.1) then
-      write(io_stdo_bgc,*)'Memory allocation for variable co2sold ...'
+      write(io_stdo_bgc,*)'Memory allocation for variable co2sol ...'
       write(io_stdo_bgc,*)'First dimension    : ',kpie
       write(io_stdo_bgc,*)'Second dimension   : ',kpje
     endif
-    allocate (co2sold(kpie,kpje),stat=errstat)
+    allocate (co2sol(kpie,kpje),stat=errstat)
     if(errstat.ne.0) stop 'not enough memory co2sold'
-    co2sold(:,:) = 0.0
-
-    if (mnproc.eq.1) then
-      write(io_stdo_bgc,*)'Memory allocation for variable co2solm ...'
-      write(io_stdo_bgc,*)'First dimension    : ',kpie
-      write(io_stdo_bgc,*)'Second dimension   : ',kpje
-    endif
-    allocate (co2solm(kpie,kpje),stat=errstat)
-    if(errstat.ne.0) stop 'not enough memory co2solm'
-    co2solm(:,:) = 0.0
+    co2sol(:,:) = 0.0
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)'Memory allocation for variable co2fxd, co2fxu ...'

--- a/hamocc/mo_carchm.F90
+++ b/hamocc/mo_carchm.F90
@@ -586,9 +586,9 @@ contains
               endif
 
               ! Save product of piston velocity and solubility for output
-              kwco2sol(i,j) = kwco2*Kh0*1e-6 !m/s mol/kg/muatm
-              kwco2a(i,j)   = kwco2 ! m/s (incl. ice fraction!)
-              co2sol(i,j)   = Kh0   ! mol/kg/atm
+              kwco2sol(i,j) = kwco2*Kh0*1e-6 ! m/s mol/kg/muatm
+              kwco2a(i,j)   = kwco2          ! m/s (incl. ice fraction!)
+              co2sol(i,j)   = Kh0*1e-6       ! mol/kg/uatm
 
             endif ! k==1
 

--- a/hamocc/mo_carchm.F90
+++ b/hamocc/mo_carchm.F90
@@ -504,16 +504,13 @@ contains
                   atm_sf6=fact*atm_sf6_nh+(1-fact)*atm_sf6_sh
                 endif
 
-                ! Use conversion of 9.86923e-6 [std atm / Pascal]
-                ! Surface flux of cfc11
-                flx11=kw_11*dtbgc*(a_11*atm_cfc11*ppao(i,j)*9.86923*1e-6-ocetra(i,j,1,icfc11))
+                ! Surface flux of cfc11, cfc12, and sf6
+                flx11=kw_11*dtbgc*(a_11*atm_cfc11*rpp0-ocetra(i,j,1,icfc11))
+                flx12=kw_12*dtbgc*(a_12*atm_cfc12*rpp0-ocetra(i,j,1,icfc12))
+                flxsf=kw_sf*dtbgc*(a_sf*atm_sf6  *rpp0-ocetra(i,j,1,isf6))
                 ocetra(i,j,1,icfc11)=ocetra(i,j,1,icfc11)+flx11/pddpo(i,j,1)
-                ! Surface flux of cfc12
-                flx12=kw_12*dtbgc*(a_12*atm_cfc12*ppao(i,j)*9.86923*1e-6-ocetra(i,j,1,icfc12))
                 ocetra(i,j,1,icfc12)=ocetra(i,j,1,icfc12)+flx12/pddpo(i,j,1)
-                ! Surface flux of sf6
-                flxsf=kw_sf*dtbgc*(a_sf*atm_sf6*ppao(i,j)*9.86923*1e-6-ocetra(i,j,1,isf6))
-                ocetra(i,j,1,isf6)=ocetra(i,j,1,isf6)+flxsf/pddpo(i,j,1)
+                ocetra(i,j,1,isf6)  =ocetra(i,j,1,isf6)  +flxsf/pddpo(i,j,1)
               endif
 
               ! Surface flux of dms
@@ -580,12 +577,12 @@ contains
                 co214fxu(i,j)= flux14u
               endif
 
-              ! Save CO2 fugacity and pCO2 [micro atm] in equilibrium with dry air at 1 atm for output
-              fco2(i,j)     = cu * 1.e6 / Kh0 / (1.0-pH2O)
+              ! Save CO2 fugacity and pCO2 [micro atm] in equilibrium with air of x'=atco2 for output
+              fco2(i,j)     = cu * 1.e6 / Kh0 / (rpp0-pH2O)
               pco2(i,j)     = fco2(i,j)/fc
               pco2_gex(i,j) = atco2*(rpp0-pH2O)
               if (use_natDIC) then
-                natpco2(i,j) = natcu * 1.e6 / Kh0 / (1.0-pH2O) / fc
+                natpco2(i,j) = natcu * 1.e6 / Kh0 / (rpp0-pH2O) / fc
               endif
 
               ! Save product of piston velocity and solubility for output

--- a/hamocc/mo_carchm.F90
+++ b/hamocc/mo_carchm.F90
@@ -67,7 +67,7 @@ contains
     !***********************************************************************************************
 
     use mo_carbch,      only: atm,atmflx,co2fxd,co2fxu,co2star,co3,hi,keqb,kwco2sol,               &
-                              ocetra,omegaa,omegac,fco2,pco2,pco2_gex,satn2o,satoxy,               &
+                              ocetra,omegaa,omegac,fco2,pco2,xco2,pco2_gex,satn2o,satoxy,          &
                               kwco2a,co2sol,pn2om
     use mo_chemcon,     only: al1,al2,al3,al4,an0,an1,an2,an3,an4,an5,an6,                         &
                               bl1,bl2,bl3,calcon,ox0,ox1,ox2,ox3,ox4,ox5,ox6,                      &
@@ -148,6 +148,7 @@ contains
     co2fxu   (:,:)=0.
     fco2     (:,:)=0.
     pco2     (:,:)=0.
+    xco2     (:,:)=0.
     pco2_gex (:,:)=0.
     kwco2a   (:,:)=0.
     co2sol   (:,:)=0.
@@ -577,12 +578,13 @@ contains
                 co214fxu(i,j)= flux14u
               endif
 
-              ! Save CO2 fugacity and pCO2 [micro atm] in equilibrium with air of x'=atco2 for output
-              fco2(i,j)     = cu * 1.e6 / Kh0 / (rpp0-pH2O)
-              pco2(i,j)     = fco2(i,j)/fc
-              pco2_gex(i,j) = atco2*(rpp0-pH2O)
+              ! Save pCO2-related diagnostics for output
+              fco2(i,j)     = cu * 1.e6 / Kh0        ! Equilibrium CO2 fugacity at the air sea interface [micro atm]
+              pco2(i,j)     = fco2(i,j)/fc           ! Equilibrium CO2 partial pressure at the air sea interface [micro atm]
+              xco2(i,j)     = pco2(i,j)/(rpp0-pH2O)  ! Equilibrium CO2 dry air mixing raio [ppm]
+              pco2_gex(i,j) = atco2*(rpp0-pH2O)      ! Actual CO2 partial pressure at the air sea interface [micro atm]
               if (use_natDIC) then
-                natpco2(i,j) = natcu * 1.e6 / Kh0 / (rpp0-pH2O) / fc
+                natpco2(i,j) = natcu * 1.e6 / Kh0 / fc
               endif
 
               ! Save product of piston velocity and solubility for output

--- a/hamocc/mo_carchm.F90
+++ b/hamocc/mo_carchm.F90
@@ -67,8 +67,8 @@ contains
     !***********************************************************************************************
 
     use mo_carbch,      only: atm,atmflx,co2fxd,co2fxu,co2star,co3,hi,keqb,kwco2sol,               &
-                              ocetra,omegaa,omegac,pco2d,satn2o,satoxy,                            &
-                              pco2m,kwco2d,co2sold,co2solm,pn2om
+                              ocetra,omegaa,omegac,fco2,pco2,pco2_gex,satn2o,satoxy,               &
+                              kwco2a,co2sol,pn2om
     use mo_chemcon,     only: al1,al2,al3,al4,an0,an1,an2,an3,an4,an5,an6,                         &
                               bl1,bl2,bl3,calcon,ox0,ox1,ox2,ox3,ox4,ox5,ox6,                      &
                               oxyco,tzero,                                                         &
@@ -90,7 +90,7 @@ contains
     use mo_carbch,      only: atm_cfc11_nh,atm_cfc11_sh,atm_cfc12_nh,atm_cfc12_sh,                 &
                               atm_sf6_nh,atm_sf6_sh,                                               &
                               co213fxd,co213fxu,co214fxd,co214fxu,                                 &
-                              nathi,natco3,natpco2d,natomegaa,natomegac,pnh3
+                              nathi,natco3,natpco2,natomegaa,natomegac,pnh3
     use mo_sedmnt,      only: sedlay,powtra,burial
 
     ! Arguments
@@ -119,22 +119,22 @@ contains
     real    :: scco2,sco2,scn2,scdms,scn2o
     real    :: xconvxa
     real    :: oxflux,niflux,dmsflux,n2oflux
-    real    :: ato2,atn2,atco2,pco2,atn2o
+    real    :: ato2,atn2,atco2,atn2o
     real    :: oxy,ani,anisa
     real    :: rrho,t,t2,t3,t4,tk,tk100,prb,s,rs
-    real    :: Kh,Khd,K1,K2,Kb,K1p,K2p,K3p,Ksi,Kw,Ks1,Kf,Kspc,Kspa
-    real    :: tc,ta,sit,pt,ah1,ac,cu,cb,cc,tc_sat
-    real    :: omega
+    real    :: Kh0,K1,K2,Kb,K1p,K2p,K3p,Ksi,Kw,Ks1,Kf,Kspc,Kspa
+    real    :: tc,ta,sit,pt,ah1,ac,cu,cu_sat,cb,cc,tc_sat
+    real    :: Bvir,delta,fc,pH2O,omega
     real    :: atm_cfc11,atm_cfc12,atm_sf6,fact                    ! CFC
     real    :: sch_11,sch_12,sch_sf,kw_11,kw_12,kw_sf              ! CFC
     real    :: flx11,flx12,flxsf,a_11,a_12,a_sf                    ! CFC
-    real    :: natcu,natcb,natcc                                   ! natDIC
-    real    :: natpco2,natfluxd,natfluxu,natomega                  ! natDIC
+    real    :: natcu,natcu_sat,natcb,natcc                         ! natDIC
+    real    :: natfluxd,natfluxu,natomega                          ! natDIC
     real    :: natsupsat,natundsa,natdissol                        ! natDIC
     real    :: rco213,rco214                                       ! cisonew
-    real    :: dissol13,dissol14                                   ! cisonew
+    real    :: dissol13,dissol14,cu13,cu14,cu_sat13,cu_sat14       ! cisonew
     real    :: flux14d,flux14u,flux13d,flux13u                     ! cisonew
-    real    :: atco213,atco214,pco213,pco214                       ! cisonew
+    real    :: atco213,atco214                                     ! cisonew
     real    :: frac_k,frac_aqg,frac_dicg                           ! cisonew
     real    :: flx_bromo,sch_bromo,kw_bromo,a_bromo,atbrf,Kb1,lsub ! BROMO
     ! extNcycle
@@ -146,11 +146,11 @@ contains
     atmflx (:,:,:)=0.
     co2fxd   (:,:)=0.
     co2fxu   (:,:)=0.
-    pco2d    (:,:)=0.
-    pco2m    (:,:)=0.
-    kwco2d   (:,:)=0.
-    co2sold  (:,:)=0.
-    co2solm  (:,:)=0.
+    fco2     (:,:)=0.
+    pco2     (:,:)=0.
+    pco2_gex (:,:)=0.
+    kwco2a   (:,:)=0.
+    co2sol   (:,:)=0.
     kwco2sol (:,:)=0.
     co2star(:,:,:)=0.
     co3    (:,:,:)=0.
@@ -165,7 +165,7 @@ contains
       co214fxu (:,:)=0.
     endif
     if (use_natDIC) then
-      natpco2d   (:,:)=0.
+      natpco2    (:,:)=0.
       natco3   (:,:,:)=0.
       natomegaA(:,:,:)=0.
       natomegaC(:,:,:)=0.
@@ -174,21 +174,24 @@ contains
        pnh3       (:,:)=0.
     endif
 
-    !$OMP PARALLEL DO PRIVATE(t,t2,t3,t4,tk,tk100,s,rs,prb,Kh,Khd,K1,K2   &
-    !$OMP  ,Kb,K1p,K2p,K3p,Ksi,Kw,Ks1,Kf,Kspc,Kspa,tc,ta,sit,pt,ah1,ac    &
-    !$OMP  ,cu,cb,cc,pco2,rpp0,scco2,scdms,sco2,oxy,ani,anisa,Xconvxa     &
-    !$OMP  ,kwco2,kwdms,kwo2,atco2,ato2,atn2,atn2o,fluxd,fluxu,oxflux     &
-    !$OMP  ,tc_sat,niflux,n2oflux,dmsflux,omega,supsat,undsa,dissol       &
-    !$OMP  ,sch_11,sch_12,sch_sf,kw_11,kw_12,kw_sf,a_11,a_12,a_sf,flx11   &
-    !$OMP  ,flx12,flxsf,atm_cfc11,atm_cfc12,atm_sf6,fact                  &
-    !$OMP  ,natcu,natcb,natcc,natpco2,natfluxd,natfluxu,natomega          &
-    !$OMP  ,natsupsat,natundsa,natdissol                                  &
-    !$OMP  ,atco213,atco214,rco213,rco214,pco213,pco214,frac_aqg          &
-    !$OMP  ,frac_dicg,flux13d,flux13u,flux14d,flux14u,dissol13,dissol14   &
-    !$OMP  ,flx_bromo,sch_bromo,kw_bromo,a_bromo,atbrf,Kb1,lsub           &
-    !$OMP ,flx_nh3,sch_nh3_a,sch_nh3_w,kw_nh3,ka_nh3,atnh3                &
-    !$OMP ,diff_nh3_a,diff_nh3_w,mu_air,mu_w,p_dbar,rho_air,h_nh3         &
-    !$OMP ,hstar_nh3,pKa_nh3,eps_safe,Kh_nh3,cD_wind,u_star               &
+    ! -----------------------------------------------------------------
+    ! Solve CO2 system
+    ! -----------------------------------------------------------------
+    !$OMP PARALLEL DO PRIVATE(t,t2,t3,t4,tk,tk100,s,rs,prb,Kh0,K1,K2                &
+    !$OMP  ,Kb,K1p,K2p,K3p,Ksi,Kw,Ks1,Kf,Kspc,Kspa,tc,ta,sit,pt,ah1,ac              &
+    !$OMP  ,cu,cb,cc,cu_sat,Bvir,delta,fc,pH2O,rpp0,scco2,scdms,sco2,oxy,ani,anisa  &
+    !$OMP  ,Xconvxa ,kwco2,kwdms,kwo2,atco2,ato2,atn2,atn2o,fluxd,fluxu,oxflux      &
+    !$OMP  ,tc_sat,niflux,n2oflux,dmsflux,omega,supsat,undsa,dissol                 &
+    !$OMP  ,sch_11,sch_12,sch_sf,kw_11,kw_12,kw_sf,a_11,a_12,a_sf,flx11             &
+    !$OMP  ,flx12,flxsf,atm_cfc11,atm_cfc12,atm_sf6,fact                            &
+    !$OMP  ,natcu,natcu_sat,natcb,natcc,natfluxd,natfluxu,natomega                  &
+    !$OMP  ,natsupsat,natundsa,natdissol                                            &
+    !$OMP  ,atco213,atco214,rco213,rco214,frac_aqg                                  &
+    !$OMP  ,frac_dicg,flux13d,flux13u,flux14d,flux14u,dissol13,dissol14,cu13,cu14   &
+    !$OMP  ,cu_sat13,cu_sat14,flx_bromo,sch_bromo,kw_bromo,a_bromo,atbrf,Kb1,lsub   &
+    !$OMP ,flx_nh3,sch_nh3_a,sch_nh3_w,kw_nh3,ka_nh3,atnh3                          &
+    !$OMP ,diff_nh3_a,diff_nh3_w,mu_air,mu_w,p_dbar,rho_air,h_nh3                   &
+    !$OMP ,hstar_nh3,pKa_nh3,eps_safe,Kh_nh3,cD_wind,u_star                         &
     !$OMP  ,k,j,i,rrho,scn2,scn2o,kwn2,kwn2o)
     do k=1,kpke
       do j=1,kpje
@@ -214,7 +217,7 @@ contains
             pt   = ocetra(i,j,k,iphosph) / rrho
             ah1  = hi(i,j,k)
 
-            call CARCHM_KEQUI(t,s,prb,Kh,Khd,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,Kspc,Kspa)
+            call CARCHM_KEQUI(t,s,prb,Kh0,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,Kspc,Kspa)
 
             call CARCHM_SOLVE(s,tc,ta,sit,pt,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,ah1,ac,niter)
 
@@ -256,13 +259,11 @@ contains
             satoxy(i,j,k)=exp(oxy)*oxyco
 
             if (k.eq.1) then
-              ! Determine CO2 pressure and fugacity (in micoatm)
-              ! NOTE: equation below for pCO2 needs requires CO2 in mol/kg
-              pco2 = cu * 1.e6 / Kh
-              if (use_natDIC) then
-                natpco2 = natcu * 1.e6 / Kh
-              endif
 
+              ! -----------------------------------------------------------------
+              ! Calculatte Schmidt numbers, solubilities, and piston velocities
+              ! -----------------------------------------------------------------
+              
               ! Schmidt numbers according to Wanninkhof (2014), Table 1
               scco2 = 2116.8 - 136.25*t + 4.7353*t2 - 0.092307*t3 + 0.0007555 *t4
               sco2  = 1920.4 - 135.6 *t + 5.2122*t2 - 0.10939 *t3 + 0.00093777*t4
@@ -310,6 +311,7 @@ contains
                 ! Schmidt number water phase
                 sch_nh3_w  = mu_w   /(diff_nh3_w * rrho * 1000.)
               endif
+              
               ! solubility of N2 (Weiss, R.F. 1970, Deep-Sea Res., 17, 721-735) for moist air
               ! at 1 atm; multiplication with oxyco converts to kmol/m^3/atm
               ani=an0+an1/tk100+an2*alog(tk100)+an3*tk100+s*(an4+an5*tk100+an6*tk100**2)
@@ -349,6 +351,7 @@ contains
                 ! effective gas-over-liquid Henry constant (Paulot et al. 2015)
                 hstar_nh3   = h_nh3/(1. + 10.**(log10(hi(i,j,k))+pKa_nh3))
               endif
+              
               ! Transfer (piston) velocity kw according to Wanninkhof (2014), in units of ms-1
               Xconvxa = 6.97e-07   ! Wanninkhof's a=0.251 converted from [cm hr-1]/[m s-1]^2 to [ms-1]/[m s-1]^2
               kwco2 = (1.-psicomo(i,j)) * Xconvxa * pfu10(i,j)**2*(660./scco2)**0.5
@@ -384,6 +387,11 @@ contains
                 Kh_nh3  = (1.-psicomo(i,j)) * Kh_nh3
               endif
 
+
+              ! -----------------------------------------------------------------
+              ! Calculatte and apply surface fluxes
+              ! -----------------------------------------------------------------
+              
               atco2 = atm(i,j,iatmco2)
               ato2  = atm(i,j,iatmo2)
               atn2  = atm(i,j,iatmn2)
@@ -399,25 +407,36 @@ contains
                 atnh3  = atm(i,j,iatmnh3)
               endif
 
-              ! Ratio P/P_0, where P is the local SLP and P_0 is standard pressure (1 atm). This is
-              ! used in all surface flux calculations where atmospheric concentration is given as a
-              ! mixing ratio (i.e. partial presure = mixing ratio*SLP/P_0 [atm])
-              rpp0 = ppao(i,j)/101325.0
+              ! Sea level pressure in atm. This is used in all surface flux calculations where 
+              ! atmospheric concentration is given as a mixing ratio (i.e. partial presure = mixing ratio*SLP/P_0 [atm])
+              rpp0  = ppao(i,j)/101325.0
 
-              fluxd=atco2*rpp0*kwco2*dtbgc*Kh*1e-6*rrho ! Kh is in mol/kg/atm. Multiply by rrho (g/cm^3)
-              fluxu=pco2      *kwco2*dtbgc*Kh*1e-6*rrho ! to get fluxes in kmol/m^2
-              !JT set limit for CO2 outgassing to avoid negative DIC concentration, set minimum DIC concentration to 1e-5 kmol/m3
-              fluxu=min(fluxu,fluxd-(1e-5 - ocetra(i,j,k,isco212))*pddpo(i,j,1))
+              ! calculate correction for non-ideality of CO2 (fugacity coefficient, Weiss and Price 1980)
+              Bvir  = -1636.75 + 12.0408*tk -0.0327957*tk**2 + 0.0000316528*tk**3
+              delta = 57.7-0.118*tk
+              fc    = exp( rpp0*(Bvir + 2.0*delta)/(82.057*tk) )
+
+              ! calculate water vapor pressure [atm] as function of temperature and salinity (Weiss and Price 1980)
+              pH2O  = exp(24.4543 - 67.4509*(100.0/tk) - 4.8489*log(tk/100.0) - 0.000544*s)
+
+              ! Calculate the CO2 concentration in equilibrium with atmospheric x' (atco2=mole fraction of CO2 in dry air [ppm])
+              cu_sat = Kh0*atco2*1e-6*(rpp0-pH2O)*fc
+
+              fluxd = cu_sat*kwco2*dtbgc*rrho ! cu_sat and cu are in mol/kg. Multiply by rrho (g/cm^3) 
+              fluxu = cu    *kwco2*dtbgc*rrho ! to get fluxes in kmol/m^2
+
+              ! Set limit for CO2 outgassing to avoid negative DIC concentration, set minimum DIC concentration to 1e-5 kmol/m3
+              fluxu = min(fluxu,fluxd-(1e-5 - ocetra(i,j,k,isco212))*pddpo(i,j,1))
+
               if (use_natDIC) then
-                natfluxd=atm_co2_nat*rpp0*kwco2*dtbgc*Kh*1e-6*rrho
-                natfluxu=natpco2         *kwco2*dtbgc*Kh*1e-6*rrho
-                natfluxu=min(natfluxu,natfluxd-(1e-5 - ocetra(i,j,k,inatsco212))*pddpo(i,j,1))
+                natcu_sat = Kh0*atm_co2_nat*1e-6*(rpp0-pH2O)*fc
+                natfluxd  = natcu_sat*kwco2*dtbgc*rrho
+                natfluxu  = natcu    *kwco2*dtbgc*rrho
+                natfluxu  = min(natfluxu,natfluxd-(1e-5 - ocetra(i,j,k,inatsco212))*pddpo(i,j,1))
               endif
 
               ! Calculate saturation DIC concentration in mixed layer
-              ta = ocetra(i,j,k,ialkali) / rrho
-              call carchm_solve_DICsat(s,atco2*rpp0,ta,sit,pt,Kh,K1,K2,Kb,Kw,Ks1,Kf, &
-                   &                   Ksi,K1p,K2p,K3p,tc_sat,niter)
+              call carchm_solve_DICsat(s,cu_sat,ta,sit,pt,Kh0,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,tc_sat,niter)
               ocetra(i,j,1:kmle(i,j),idicsat) = tc_sat * rrho ! convert mol/kg to kmlo/m^3
 
               if (use_cisonew ) then
@@ -425,17 +444,19 @@ contains
                 rco213=ocetra(i,j,1,isco213)/(ocetra(i,j,1,isco212)+safediv) ! Fraction DIC13 over total DIC
                 rco214=ocetra(i,j,1,isco214)/(ocetra(i,j,1,isco212)+safediv) ! Fraction DIC14 over total DIC
 
-                pco213 = pco2 * rco213 ! Determine water CO213 pressure and fugacity (microatm)
-                pco214 = pco2 * rco214 ! Determine water CO214 pressure and fugacity (microatm)
+                cu13     = cu * rco213 ! concentration of dissolved CO213
+                cu14     = cu * rco214 ! concentration of dissolved CO214
+                cu_sat13 = Kh0*atco213*1.e-6*(rpp0-pH2O)*fc
+                cu_sat14 = Kh0*atco214*1.e-6*(rpp0-pH2O)*fc
 
                 ! fractionation factors for 13C during air-sea gas exchange (Zhang et al. 1995, Orr et al. 2017)
                 frac_k    = 0.99912                                 !Constant kinetic fractionation
                 frac_aqg  = (0.0049*t - 1.31)/1000. + 1.  !Gas dissolution fractionation
                 frac_dicg = (0.0144*t*(cc/(cc+cu+cb)) - 0.107*t + 10.53)/1000. + 1. !DIC to CO2 frac
-                flux13d=atco213*rpp0*kwco2*dtbgc*Kh*1.e-6*rrho*frac_aqg*frac_k
-                flux13u=pco213      *kwco2*dtbgc*Kh*1.e-6*rrho*frac_aqg*frac_k/frac_dicg
-                flux14d=atco214*rpp0*kwco2*dtbgc*Kh*1.e-6*rrho*(frac_aqg**2)*(frac_k**2)
-                flux14u=pco214      *kwco2*dtbgc*Kh*1.e-6*rrho*(frac_aqg**2)*(frac_k**2)/(frac_dicg**2)
+                flux13d   = cu_sat13*kwco2*dtbgc*rrho*frac_aqg*frac_k
+                flux13u   = cu13    *kwco2*dtbgc*rrho*frac_aqg*frac_k/frac_dicg
+                flux14d   = cu_sat14*kwco2*dtbgc*rrho*(frac_aqg**2)*(frac_k**2)
+                flux14u   = cu14    *kwco2*dtbgc*rrho*(frac_aqg**2)*(frac_k**2)/(frac_dicg**2)
               endif
 
               ! Update DIC
@@ -499,7 +520,6 @@ contains
               ! Note that kwdms already has the open ocean fraction in the term
               dmsflux = kwdms*dtbgc*ocetra(i,j,1,idms)
               ocetra(i,j,1,idms) = ocetra(i,j,1,idms) - dmsflux/pddpo(i,j,1)
-              atmflx(i,j,iatmdms) = dmsflux ! positive to atmosphere [kmol dms m-2 timestep-1]
 
               if (use_BROMO) then
                 ! Quack and Wallace (2003) eq. 1
@@ -511,7 +531,6 @@ contains
 
                 flx_bromo = kw_bromo*dtbgc*(atbrf/a_bromo*1e-12*ppao(i,j)*1e-5/(tk*0.083) - ocetra(i,j,1,ibromo))
                 ocetra(i,j,1,ibromo) = ocetra(i,j,1,ibromo) + flx_bromo/pddpo(i,j,1)
-                atmflx(i,j,iatmbromo) = -flx_bromo
               endif
               if (use_extNcycle) then
                 ! surface flux NH3 - currently assumed atNH3 in pptv
@@ -522,11 +541,16 @@ contains
                 pnh3(i,j) =  hstar_nh3*ocetra(i,j,1,ianh4)  * 8.20573660809596e-5 * (t+273.15) * 1e12
               endif
 
+              ! -----------------------------------------------------------------
+              ! Save variables for output
+              ! -----------------------------------------------------------------
+
               ! Save surface fluxes
               atmflx(i,j,iatmco2)=fluxu-fluxd
               atmflx(i,j,iatmo2)=oxflux
               atmflx(i,j,iatmn2)=niflux
               atmflx(i,j,iatmn2o)=n2oflux   ! positive to atmosphere [kmol N2O m-2 timestep-1]
+              atmflx(i,j,iatmdms)=dmsflux   ! positive to atmosphere [kmol dms m-2 timestep-1]
               if (use_cisonew) then
                 atmflx(i,j,iatmc13)=flux13u-flux13d
                 atmflx(i,j,iatmc14)=flux14u-flux14d
@@ -539,9 +563,13 @@ contains
               if (use_natDIC) then
                 atmflx(i,j,iatmnco2)=natfluxu-natfluxd
               endif
+              if (use_BROMO) then
+                atmflx(i,j,iatmbromo)=-flx_bromo
+              endif
               if (use_extNcycle) then
                 atmflx(i,j,iatmnh3)=-flx_nh3 ! positive to atmosphere [kmol NH3 m-2 timestep-1]
               endif
+              
               ! Save up- and downward components of carbon fluxes for output
               co2fxd(i,j)  = fluxd
               co2fxu(i,j)  = fluxu
@@ -552,21 +580,25 @@ contains
                 co214fxu(i,j)= flux14u
               endif
 
-              ! Save pco2 w.r.t. dry air for output
-              pco2d(i,j) = cu * 1.e6 / Khd
-              ! pCO2 wrt moist air
-              pco2m(i,j) = cu * 1.e6 / Kh
+              ! Save CO2 fugacity and pCO2 [micro atm] in equilibrium with dry air at 1 atm for output
+              fco2(i,j)     = cu * 1.e6 / Kh0 / (1.0-pH2O)
+              pco2(i,j)     = fco2(i,j)/fc
+              pco2_gex(i,j) = atco2*(rpp0-pH2O)
               if (use_natDIC) then
-                natpco2d(i,j) = natcu * 1.e6 / Khd
+                natpco2(i,j) = natcu * 1.e6 / Kh0 / (1.0-pH2O) / fc
               endif
 
               ! Save product of piston velocity and solubility for output
-              kwco2sol(i,j) = kwco2*Kh*1e-6 !m/s mol/kg/muatm
-              kwco2d(i,j)   = kwco2 ! m/s (incl. ice fraction!)
-              co2sold(i,j)  = Khd  ! mol/kg/atm
-              co2solm(i,j)  = Kh   ! mol/kg/atm
+              kwco2sol(i,j) = kwco2*Kh0*1e-6 !m/s mol/kg/muatm
+              kwco2a(i,j)   = kwco2 ! m/s (incl. ice fraction!)
+              co2sol(i,j)   = Kh0   ! mol/kg/atm
 
             endif ! k==1
+
+            
+            ! -----------------------------------------------------------------
+            ! Deep ocean processes
+            ! -----------------------------------------------------------------
 
             if (use_BROMO) then
               ! Degradation to hydrolysis (Eq. 2-4 of Stemmler et al., 2015)
@@ -577,8 +609,6 @@ contains
               lsub=7.33e-10*exp(1.250713e4*(1/298.-1/tk))*dtbgc
               ocetra(i,j,k,ibromo)=ocetra(i,j,k,ibromo)*(1.-lsub)
             endif
-            ! -----------------------------------------------------------------
-            ! Deep ocean processes
 
             ! Determine Omega Calcite/Aragonite and dissolution of caco3 based on OmegaC:
             !   omegaC=([CO3]*[Ca])/([CO3]sat*[Ca]sat)
@@ -680,8 +710,9 @@ contains
     endif ! end of use_cisonew and not use_sedbypass
 
   end subroutine carchm
+  
 
-  subroutine carchm_kequi(temp,saln,prb,Kh,Khd,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,Kspc,Kspa)
+  subroutine carchm_kequi(temp,saln,prb,Kh0,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,Kspc,Kspa)
 
     !***********************************************************************************************
     ! Calculate equilibrium constants for the carbonate system
@@ -699,8 +730,7 @@ contains
     real,    intent(in)    :: temp   ! potential temperature [degr C].
     real,    intent(in)    :: saln   ! salinity [psu].
     real,    intent(in)    :: prb    ! pressure [bar].
-    real,    intent(out)   :: Kh     ! equilibrium constant Kh  =  [CO2]/pCO2, moist air.
-    real,    intent(out)   :: Khd    ! equilibrium constant Khd =  [CO2]/pCO2, dry air.
+    real,    intent(out)   :: Kh0    ! equilibrium constant Kh0 = [CO2]/fCO2, moist air.
     real,    intent(out)   :: K1     ! equilibrium constant K1  = [H][HCO3]/[H2CO3].
     real,    intent(out)   :: K2     ! equilibrium constant K2  = [H][CO3]/[HCO3].
     real,    intent(out)   :: Kb     ! equilibrium constant Kb  = [H][BO2]/[HBO2].
@@ -734,14 +764,11 @@ contains
     sqrts  = sqrt(s)
     scl    = s * salchl
 
-    ! Kh = [CO2]/ p CO2
-    ! Weiss (1974), refitted for moist air Weiss and Price (1980) [mol/kg/atm]
-    nKhwe74 = ac1+ac2/tk100+ac3*log(tk100)+ac4*tk100**2+s*(bc1+bc2*tk100+bc3*tk100**2)
-    Kh      = exp( nKhwe74 )
-    ! Khd = [CO2]/ p CO2
-    ! Weiss (1974) for dry air [mol/kg/atm]
+    ! Kh0 = [CO2]/ fCO2 (fCO2 = fugacity of CO2 in air)
+    ! Weiss (1974), note this does not include a correction for the effect of moist air at 
+    ! air-sea interface [mol/kg/atm]
     nKhwe74 = ad1+ad2/tk100+ad3*log(tk100)+s*(bd1+bd2*tk100+bd3*tk100**2)
-    Khd     = exp( nKhwe74 )
+    Kh0     = exp( nKhwe74 )
     ! K1 = [H][HCO3]/[H2CO3]   ; K2 = [H][CO3]/[HCO3]
     ! Millero p.664 (1995) using Mehrbach et al. data on seawater scale
     K1 = 10**( -1.0 * ( 3670.7 * invtk - 62.008 + 9.7944 * dlogtk - 0.0118 * s + 0.000116 * s2 ) )
@@ -885,35 +912,34 @@ contains
   end subroutine carchm_solve
 
 
-  subroutine carchm_solve_dicsat(saln,pco2,ta,sit,pt,Kh,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,        &
-       &                         tc_sat,niter)
+  subroutine carchm_solve_dicsat(saln,co2_sat,ta,sit,pt,Kh0,K1,K2,Kb,Kw,Ks1,Kf,Ksi,K1p,K2p,K3p,tc_sat,niter)
 
-    !**********************************************************************
-    ! Solve DICsat from TALK and pCO2.
+    !***********************************************************************************************
+    ! Solve DICsat from TALK and h2co3_sat (saturation concentration of dissolved CO2).
     !
     ! J. Tjiputra,    *BCCR, Bergen*    25.01.17
-    !**********************************************************************
+    !***********************************************************************************************
 
     use mo_chemcon, only: bor1,bor2,salchl
 
-    real,    intent(in)  :: saln   ! salinity [psu].
-    real,    intent(in)  :: pco2   ! partial pressure of CO2 [ppm].
-    real,    intent(in)  :: ta     ! total alkalinity [eq/kg].
-    real,    intent(in)  :: sit    ! silicate concentration [mol/kg].
-    real,    intent(in)  :: pt     ! phosphate concentration [mol/kg].
-    real,    intent(in)  :: Kh     ! equilibrium constant Kh  = [H2CO3]/pCO2.
-    real,    intent(in)  :: K1     ! equilibrium constant K1  = [H][HCO3]/[H2CO3].
-    real,    intent(in)  :: K2     ! equilibrium constant K2  = [H][CO3]/[HCO3].
-    real,    intent(in)  :: Kb     ! equilibrium constant Kb  = [H][BO2]/[HBO2].
-    real,    intent(in)  :: Kw     ! equilibrium constant Kw  = [H][OH].
-    real,    intent(in)  :: Ks1    ! equilibrium constant Ks1 = [H][SO4]/[HSO4].
-    real,    intent(in)  :: Kf     ! equilibrium constant Kf  = [H][F]/[HF].
-    real,    intent(in)  :: Ksi    ! equilibrium constant Ksi = [H][SiO(OH)3]/[Si(OH)4].
-    real,    intent(in)  :: K1p    ! equilibrium constant K1p = [H][H2PO4]/[H3PO4].
-    real,    intent(in)  :: K2p    ! equilibrium constant K2p = [H][HPO4]/[H2PO4].
-    real,    intent(in)  :: K3p    ! equilibrium constant K3p = [H][PO4]/[HPO4].
-    real,    intent(out) :: tc_sat ! saturated total DIC concentration [mol/kg].
-    integer, intent(in)  :: niter  ! maximum number of iteration
+    real,    intent(in)  :: saln    ! salinity [psu].
+    real,    intent(in)  :: co2_sat ! saturation concentraion of dissoveld CO2 [mol/kg].
+    real,    intent(in)  :: ta      ! total alkalinity [eq/kg].
+    real,    intent(in)  :: sit     ! silicate concentration [mol/kg].
+    real,    intent(in)  :: pt      ! phosphate concentration [mol/kg].
+    real,    intent(in)  :: Kh0     ! equilibrium constant Kh0 = [H2CO3]/fCO2.
+    real,    intent(in)  :: K1      ! equilibrium constant K1  = [H][HCO3]/[H2CO3].
+    real,    intent(in)  :: K2      ! equilibrium constant K2  = [H][CO3]/[HCO3].
+    real,    intent(in)  :: Kb      ! equilibrium constant Kb  = [H][BO2]/[HBO2].
+    real,    intent(in)  :: Kw      ! equilibrium constant Kw  = [H][OH].
+    real,    intent(in)  :: Ks1     ! equilibrium constant Ks1 = [H][SO4]/[HSO4].
+    real,    intent(in)  :: Kf      ! equilibrium constant Kf  = [H][F]/[HF].
+    real,    intent(in)  :: Ksi     ! equilibrium constant Ksi = [H][SiO(OH)3]/[Si(OH)4].
+    real,    intent(in)  :: K1p     ! equilibrium constant K1p = [H][H2PO4]/[H3PO4].
+    real,    intent(in)  :: K2p     ! equilibrium constant K2p = [H][HPO4]/[H2PO4].
+    real,    intent(in)  :: K3p     ! equilibrium constant K3p = [H][PO4]/[HPO4].
+    real,    intent(out) :: tc_sat  ! saturated total DIC concentration [mol/kg].
+    integer, intent(in)  :: niter   ! maximum number of iteration
 
     ! Parameters to set accuracy of iteration
     real, parameter :: eps=5.e-5
@@ -922,7 +948,7 @@ contains
     integer :: jit
     real    :: s,scl,borat,sti,ft
     real    :: hso4,hf,hsi,hpo4,ab,aw,ah2o,ah2,erel
-    real    :: dic_h2co3,dic_hco3,dic_co3,ah1,ac
+    real    :: hco3_sat,co3_sat,ah1,ac
 
     ! Calculate concentrations for borate, sulfate, and fluoride; see Dickson, A.G.,
     ! Sabine, C.L. and Christian, J.R. (Eds.) 2007. Guide to best practices
@@ -933,7 +959,6 @@ contains
     sti = 0.14 * scl / 96.062      ! Morris & Riley (1966)
     ft = 0.000067 * scl / 18.9984  ! Riley (1965)
     ah1=1.e-8
-    dic_h2co3 = Kh * pco2 * 1e-6
 
     iflag: do jit = 1,niter
       hso4 = sti / ( 1. + Ks1 / ( ah1 / ( 1. + sti / Ks1 ) ) )
@@ -944,8 +969,8 @@ contains
       ab   = borat / ( 1. + ah1 / Kb )
       aw   = Kw / ah1 - ah1 / ( 1. + sti / Ks1 )
       ac   = ta + hso4 - sit * hsi - ab - aw + ft * hf - pt * hpo4
-      ah2o = sqrt((K1*dic_h2co3)**2 + 4.*ac*2.*K1*k2*dic_h2co3)
-      ah2  = (K1*dic_h2co3 + ah2o)/(2.*ac)
+      ah2o = sqrt((K1*co2_sat)**2 + 4.*ac*2.*K1*k2*co2_sat)
+      ah2  = (K1*co2_sat + ah2o)/(2.*ac)
       erel = ( ah2 - ah1 ) / ah2
       if (abs( erel ).ge.eps) then
         ah1 = ah2
@@ -954,9 +979,9 @@ contains
       endif
     enddo iflag
 
-    dic_hco3  = Kh * K1 *      pco2 * 1e-6 / ah1
-    dic_co3   = Kh * K1 * K2 * pco2 * 1e-6 / ah1**2
-    tc_sat    = dic_h2co3 + dic_hco3 + dic_co3
+    hco3_sat  = K1 *      co2_sat / ah1
+    co3_sat   = K1 * K2 * co2_sat / ah1**2
+    tc_sat    = co2_sat + hco3_sat + co3_sat
 
   end subroutine carchm_solve_dicsat
 

--- a/hamocc/mo_carchm.F90
+++ b/hamocc/mo_carchm.F90
@@ -261,7 +261,7 @@ contains
             if (k.eq.1) then
 
               ! -----------------------------------------------------------------
-              ! Calculatte Schmidt numbers, solubilities, and piston velocities
+              ! Calculate Schmidt numbers, solubilities, and piston velocities
               ! -----------------------------------------------------------------
               
               ! Schmidt numbers according to Wanninkhof (2014), Table 1
@@ -389,7 +389,7 @@ contains
 
 
               ! -----------------------------------------------------------------
-              ! Calculatte and apply surface fluxes
+              ! Calculate and apply surface fluxes
               ! -----------------------------------------------------------------
               
               atco2 = atm(i,j,iatmco2)
@@ -408,7 +408,7 @@ contains
               endif
 
               ! Sea level pressure in atm. This is used in all surface flux calculations where 
-              ! atmospheric concentration is given as a mixing ratio (i.e. partial presure = mixing ratio*SLP/P_0 [atm])
+              ! atmospheric concentration is given as a mixing ratio (i.e. partial pressure = mixing ratio*SLP/P_0 [atm])
               rpp0  = ppao(i,j)/101325.0
 
               ! calculate correction for non-ideality of CO2 (fugacity coefficient, Weiss and Price 1980)

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -1377,7 +1377,7 @@ contains
          &   'kwco2sol','CO2 piston velocity times solubility',' ',             &
          &   'm s-1 mol kg-1 muatm-1',0)
     call ncdefvar3d(SRF_CO2SOL(iogrp),cmpflg,'p',                               &
-         &   'co2sol','CO2 solubility',' ','mol kg-1 atm-1',0)
+         &   'co2sol','CO2 solubility',' ','mol kg-1 muatm-1',0)
     call ncdefvar3d(SRF_FCO2(iogrp),cmpflg,'p',                                 &
          &   'fco2','Surface CO2 fugacity at 1 atm total pressure',' ','uatm',0)
     call ncdefvar3d(SRF_PCO2(iogrp),cmpflg,'p',                                 &

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -81,7 +81,7 @@ contains
                               jlvlwnos,jlvlwphy,jn2o,jsrfpn2om,                                    &
                               jn2ofx,jndepnoyfx,jniflux,jnos,joalkfx,                              &
                               jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jfco2,                  &
-                              jpco2,jpco2_gex,jkwco2sol,jco2sol,                                   &
+                              jpco2,jxco2,jpco2_gex,jkwco2sol,jco2sol,                             &
                               jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                             &
                               jprefdic,jprefo2,jprefpo4,jsilica,jprefsilica,                       &
                               jsrfalkali,jsrfano3,jsrfdic,jsrfiron,                                &
@@ -103,7 +103,7 @@ contains
                               lvl_prefalk,lvl_prefdic,lvl_dicsat,                                  &
                               lvl_o2sat,srf_n2ofx,srf_pn2om,srf_atmco2,srf_kwco2,                  &
                               srf_kwco2sol,srf_co2sol,srf_fco2,                                    &
-                              srf_pco2,srf_pco2_gex,srf_dmsflux,srf_co2fxd,                        &
+                              srf_pco2,srf_xco2,srf_pco2_gex,srf_dmsflux,srf_co2fxd,               &
                               srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,                            &
                               srf_dmsprod,srf_dms_bac,srf_dms_uv,                                  &
                               srf_export,srf_exposi,srf_expoca,srf_dic,                            &
@@ -533,6 +533,7 @@ contains
     call wrtsrf(jco2sol(iogrp),      SRF_CO2SOL(iogrp),   rnacc,          0.,cmpflg,'co2sol')
     call wrtsrf(jfco2(iogrp),        SRF_FCO2(iogrp),     rnacc,          0.,cmpflg,'fco2')
     call wrtsrf(jpco2(iogrp),        SRF_PCO2(iogrp),     rnacc,          0.,cmpflg,'pco2')
+    call wrtsrf(jxco2(iogrp),        SRF_XCO2(iogrp),     rnacc,          0.,cmpflg,'xco2')
     call wrtsrf(jpco2_gex(iogrp),    SRF_PCO2_GEX(iogrp), rnacc,          0.,cmpflg,'pco2_gex')
     call wrtsrf(jdmsflux(iogrp),     SRF_DMSFLUX(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dmsflux')
     call wrtsrf(jco2fxd(iogrp),      SRF_CO2FXD(iogrp),   rnacc*12./dtbgc,0.,cmpflg,'co2fxd')
@@ -887,6 +888,7 @@ contains
     call inisrf(jco2sol(iogrp),0.)
     call inisrf(jfco2(iogrp),0.)
     call inisrf(jpco2(iogrp),0.)
+    call inisrf(jxco2(iogrp),0.)
     call inisrf(jpco2_gex(iogrp),0.)
     call inisrf(jdmsflux(iogrp),0.)
     call inisrf(jco2fxd(iogrp),0.)
@@ -1240,9 +1242,9 @@ contains
     use mod_nctools,    only: ncdefvar,ncattr,ncfopn,ncdimc,ncdims,                                &
                               nctime,ncfcls,ncedef,ncdefvar3d,ndouble
     use mo_control_bgc, only: use_M4AGO
-    use mo_bgcmean,     only: srf_kwco2,srf_fco2,srf_pco2,srf_pco2_gex,srf_dmsflux,srf_co2fxd,     &
-                              srf_kwco2sol,srf_co2sol,                                             &
-                              srf_co2fxu,srf_oxflux,srf_niflux,srf_pn2om,srf_dms,srf_dmsprod,      &
+    use mo_bgcmean,     only: srf_kwco2,srf_fco2,srf_pco2,srf_xco2,srf_pco2_gex,srf_dmsflux,       &
+                              srf_co2fxd,srf_co2fxu,srf_kwco2sol,srf_co2sol,                       &
+                              srf_oxflux,srf_niflux,srf_pn2om,srf_dms,srf_dmsprod,                 &
                               srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
                               srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
                               srf_iron,srf_phyto,srf_ph,int_phosy,int_nfix,int_dnit,               &
@@ -1379,9 +1381,13 @@ contains
     call ncdefvar3d(SRF_CO2SOL(iogrp),cmpflg,'p',                               &
          &   'co2sol','CO2 solubility',' ','mol kg-1 muatm-1',0)
     call ncdefvar3d(SRF_FCO2(iogrp),cmpflg,'p',                                 &
-         &   'fco2','Surface CO2 fugacity at 1 atm total pressure',' ','uatm',0)
+         &   'fco2','Surface equilibrium CO2 fugacity at the air-sea interface',&
+         &   ' ','uatm',0)
     call ncdefvar3d(SRF_PCO2(iogrp),cmpflg,'p',                                 &
-         &   'pco2','Surface pCO2 at 1 atm total pressure',' ','uatm',0)
+         &   'pco2','Surface equilibrium pCO2 at the air-sea interface',        &
+         &   ' ','uatm',0)
+    call ncdefvar3d(SRF_XCO2(iogrp),cmpflg,'p',                                 &
+         &   'xco2','Equilibrium CO2 dry air mixing ratio',' ','ppm',0)
     call ncdefvar3d(SRF_PCO2_GEX(iogrp),cmpflg,'p',                             &
          &   'pco2_gex','Atmospheric pCO2 at the air-sea interface',' ','uatm',0)
     call ncdefvar3d(SRF_DMSFLUX(iogrp),                                         &

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -80,8 +80,8 @@ contains
                               jlvlprefo2,jlvlprefpo4,jlvlsf6,jlvlsilica,                           &
                               jlvlwnos,jlvlwphy,jn2o,jsrfpn2om,                                    &
                               jn2ofx,jndepnoyfx,jniflux,jnos,joalkfx,                              &
-                              jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jpco2,                  &
-                              jpco2m,jkwco2khm,jco2kh,jco2khm,                                     &
+                              jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jfco2,                  &
+                              jpco2,jpco2_gex,jkwco2sol,jco2sol,                                   &
                               jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                             &
                               jprefdic,jprefo2,jprefpo4,jsilica,jprefsilica,                       &
                               jsrfalkali,jsrfano3,jsrfdic,jsrfiron,                                &
@@ -102,8 +102,8 @@ contains
                               lvl_n2o,lvl_prefo2,lvl_o2sat,lvl_prefpo4,lvl_prefsilica,             &
                               lvl_prefalk,lvl_prefdic,lvl_dicsat,                                  &
                               lvl_o2sat,srf_n2ofx,srf_pn2om,srf_atmco2,srf_kwco2,                  &
-                              srf_kwco2khm,srf_co2kh,srf_co2khm,srf_pco2m,                         &
-                              srf_pco2,srf_dmsflux,srf_co2fxd,                                     &
+                              srf_kwco2sol,srf_co2sol,srf_fco2,                                    &
+                              srf_pco2,srf_pco2_gex,srf_dmsflux,srf_co2fxd,                        &
                               srf_co2fxu,srf_oxflux,srf_niflux,srf_dms,                            &
                               srf_dmsprod,srf_dms_bac,srf_dms_uv,                                  &
                               srf_export,srf_exposi,srf_expoca,srf_dic,                            &
@@ -529,11 +529,11 @@ contains
 
     ! --- Store 2d fields
     call wrtsrf(jkwco2(iogrp),       SRF_KWCO2(iogrp),    rnacc,          0.,cmpflg,'kwco2')
-    call wrtsrf(jkwco2khm(iogrp),    SRF_KWCO2KHM(iogrp), rnacc,          0.,cmpflg,'kwco2khm')
-    call wrtsrf(jco2kh(iogrp),       SRF_CO2KH(iogrp),    rnacc,          0.,cmpflg,'co2kh')
-    call wrtsrf(jco2khm(iogrp),      SRF_CO2KHM(iogrp),   rnacc,          0.,cmpflg,'co2khm')
+    call wrtsrf(jkwco2sol(iogrp),    SRF_KWCO2SOL(iogrp), rnacc,          0.,cmpflg,'kwco2sol')
+    call wrtsrf(jco2sol(iogrp),      SRF_CO2SOL(iogrp),   rnacc,          0.,cmpflg,'co2sol')
+    call wrtsrf(jfco2(iogrp),        SRF_FCO2(iogrp),     rnacc,          0.,cmpflg,'fco2')
     call wrtsrf(jpco2(iogrp),        SRF_PCO2(iogrp),     rnacc,          0.,cmpflg,'pco2')
-    call wrtsrf(jpco2m(iogrp),       SRF_PCO2M(iogrp),    rnacc,          0.,cmpflg,'pco2m')
+    call wrtsrf(jpco2_gex(iogrp),    SRF_PCO2_GEX(iogrp), rnacc,          0.,cmpflg,'pco2_gex')
     call wrtsrf(jdmsflux(iogrp),     SRF_DMSFLUX(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dmsflux')
     call wrtsrf(jco2fxd(iogrp),      SRF_CO2FXD(iogrp),   rnacc*12./dtbgc,0.,cmpflg,'co2fxd')
     call wrtsrf(jco2fxu(iogrp),      SRF_CO2FXU(iogrp),   rnacc*12./dtbgc,0.,cmpflg,'co2fxu')
@@ -883,11 +883,11 @@ contains
 
     ! --- Initialise fields
     call inisrf(jkwco2(iogrp),0.)
-    call inisrf(jkwco2khm(iogrp),0.)
-    call inisrf(jco2kh(iogrp),0.)
-    call inisrf(jco2khm(iogrp),0.)
+    call inisrf(jkwco2sol(iogrp),0.)
+    call inisrf(jco2sol(iogrp),0.)
+    call inisrf(jfco2(iogrp),0.)
     call inisrf(jpco2(iogrp),0.)
-    call inisrf(jpco2m(iogrp),0.)
+    call inisrf(jpco2_gex(iogrp),0.)
     call inisrf(jdmsflux(iogrp),0.)
     call inisrf(jco2fxd(iogrp),0.)
     call inisrf(jco2fxu(iogrp),0.)
@@ -1240,8 +1240,8 @@ contains
     use mod_nctools,    only: ncdefvar,ncattr,ncfopn,ncdimc,ncdims,                                &
                               nctime,ncfcls,ncedef,ncdefvar3d,ndouble
     use mo_control_bgc, only: use_M4AGO
-    use mo_bgcmean,     only: srf_kwco2,srf_pco2,srf_dmsflux,srf_co2fxd,                           &
-                              srf_kwco2khm,srf_co2kh,srf_co2khm,srf_pco2m,                         &
+    use mo_bgcmean,     only: srf_kwco2,srf_fco2,srf_pco2,srf_pco2_gex,srf_dmsflux,srf_co2fxd,     &
+                              srf_kwco2sol,srf_co2sol,                                             &
                               srf_co2fxu,srf_oxflux,srf_niflux,srf_pn2om,srf_dms,srf_dmsprod,      &
                               srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
                               srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
@@ -1373,17 +1373,17 @@ contains
 
     call ncdefvar3d(SRF_KWCO2(iogrp),cmpflg,'p',                                &
          &   'kwco2','CO2 piston velocity',' ','m s-1',0)
-    call ncdefvar3d(SRF_KWCO2KHM(iogrp),cmpflg,'p',                             &
-         &   'kwco2khm','CO2 piston velocity times solubility (moist air)',' ', &
+    call ncdefvar3d(SRF_KWCO2SOL(iogrp),cmpflg,'p',                             &
+         &   'kwco2sol','CO2 piston velocity times solubility',' ',             &
          &   'm s-1 mol kg-1 muatm-1',0)
-    call ncdefvar3d(SRF_CO2KH(iogrp),cmpflg,'p',                                &
-         &   'co2kh','CO2 solubility (dry air)',' ','mol kg-1 atm-1',0)
-    call ncdefvar3d(SRF_CO2KHM(iogrp),cmpflg,'p',                               &
-         &   'co2khm','CO2 solubility (moist air)',' ','mol kg-1 atm-1',0)
+    call ncdefvar3d(SRF_CO2SOL(iogrp),cmpflg,'p',                               &
+         &   'co2sol','CO2 solubility',' ','mol kg-1 atm-1',0)
+    call ncdefvar3d(SRF_FCO2(iogrp),cmpflg,'p',                                 &
+         &   'fco2','Surface CO2 fugacity at 1 atm total pressure',' ','uatm',0)
     call ncdefvar3d(SRF_PCO2(iogrp),cmpflg,'p',                                 &
-         &   'pco2','Surface PCO2',' ','uatm',0)
-    call ncdefvar3d(SRF_PCO2M(iogrp),cmpflg,'p',                                &
-         &   'pco2m','Surface PCO2 (moist air)',' ','uatm',0)
+         &   'pco2','Surface pCO2 at 1 atm total pressure',' ','uatm',0)
+    call ncdefvar3d(SRF_PCO2_GEX(iogrp),cmpflg,'p',                             &
+         &   'pco2_gex','Atmospheric pCO2 at the air-sea interface',' ','uatm',0)
     call ncdefvar3d(SRF_DMSFLUX(iogrp),                                         &
          &   cmpflg,'p','dmsflux','DMS flux',' ','mol DMS m-2 s-1',0)
     call ncdefvar3d(SRF_CO2FXD(iogrp),                                          &


### PR DESCRIPTION
This PR abandons the use of a fit for CO2 solubility that already includes corrections for non-ideality and water vapor (Weiss and Price 1980). Instead these corrections are now calculated separately (also following Weiss and Price 1980). This is slightly more accurate (the correction for non-ideality was fixed at 1 atm pressure before). However, the main reason for introducing this is that diagnostic quantities can be calculated in a more easy and transparent way (e.g. the actual CO2 partial pressure at the air-sea interface, fugacity of CO2).

Results are not bit-for-bit, but very close (visually indistinguishable in time-series of a 100 year test-simulation). Note, however, that the output variable `pCO2` previously actually was the fugacity of CO2, not the partial pressure. This is now fixed and an extra output variable `fCO2` is introduced (the difference is a small offset of about 1 muatm)