### PR TITLE
Bodner et al. (2023) parameterization for mixed layer restratification

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -381,6 +381,130 @@
     <desc>Method of applying eddy-induced transport in the remap</desc>
   </entry>
 
+  <entry id="mlrmth">
+    <type>char</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>fox08</value>
+    </values>
+    <desc>Mixed layer restratification method</desc>
+  </entry>
+
+  <entry id="ce">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.06</value>
+      <value ocn_grid="tnx1v4"    blom_vcoord="isopyc_bulkml" ocn_ncpl="24">.5</value>
+      <value ocn_grid="tnx0.25v4" blom_vcoord="isopyc_bulkml">1.0</value>
+    </values>
+    <desc>Efficiency factor for the restratification by mixed layer</desc>
+  </entry>
+
+  <entry id="cl">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.25</value>
+    </values>
+    <desc>Scaling of the efficiency factor for the restratification by mixed layer eddies (Bodner et al., 2023)</desc>
+  </entry>
+
+  <entry id="tau_mlr">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>86400.</value>
+    </values>
+    <desc>Timescale for momentum mixing across mixed layer</desc>
+  </entry>
+
+  <entry id="tau_growing_hbl">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>0.</value>
+    </values>
+    <desc>Time-scale for running mean filter when signal is greater than filtered value (used for boundary layer thickness and vertical momentum flux)</desc>
+  </entry>
+
+  <entry id="tau_decaying_hbl">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>0.</value>
+    </values>
+    <desc>Time-scale for running mean filter when signal is less than filtered value (used for boundary layer thickness and vertical momentum flux)</desc>
+  </entry>
+
+  <entry id="tau_growing_hml">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>0.</value>
+    </values>
+    <desc>Time-scale for running mean filter when signal is greater than filtered value (used for mixed layer thickness)</desc>
+  </entry>
+
+  <entry id="tau_decaying_hml">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>0.</value>
+    </values>
+    <desc>Time-scale for running mean filter when signal is less than filtered value (used for mixed layer thickness)</desc>
+  </entry>
+
+  <entry id="lfmin">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>5000.</value>
+      <value blom_unit="cgs">5000.e2</value>
+    </values>
+    <desc>Minimum length scale of mixed layer fronts</desc>
+  </entry>
+
+  <entry id="mstar">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.5</value>
+    </values>
+    <desc>Scaling of boundary layer turbulence due to friction velocity (Bodner et al., 2023)</desc>
+  </entry>
+
+  <entry id="nstar">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.066</value>
+    </values>
+    <desc>Scaling of boundary layer turbulence due to convective velocity (Bodner et al., 2023)</desc>
+  </entry>
+
+  <entry id="wpup_min">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>1.e-7</value>
+      <value blom_unit="cgs">1.e-3</value>
+    </values>
+    <desc>Minimum vertical momentum flux (Bodner et al., 2023)</desc>
+  </entry>
+
   <entry id="mlrttp">
     <type>char</type>
     <category>limits</category>
@@ -409,18 +533,6 @@
       <value>0.</value>
     </values>
     <desc>Efficiency factor of TKE generation by momentum</desc>
-  </entry>
-
-  <entry id="ce">
-    <type>real</type>
-    <category>limits</category>
-    <group>limits</group>
-    <values>
-      <value>.06</value>
-      <value ocn_grid="tnx1v4"    blom_vcoord="isopyc_bulkml" ocn_ncpl="24">.5</value>
-      <value ocn_grid="tnx0.25v4" blom_vcoord="isopyc_bulkml">1.0</value>
-    </values>
-    <desc>Efficiency factor for the restratification by mixed layer</desc>
   </entry>
 
   <entry id="tdfile" is_inputdata="yes">

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -40,14 +40,38 @@
 !            column) (a)
 ! RMPMTH   : Method of applying eddy-induced transport in the remap
 !            transport algorithm. Valid methods: 'eitvel', 'eitflx' (a)
+! MLRMTH   : Mixed layer restratification method. Valid methods: 'none',
+!            'fox08','bod23' (a)
+! CE       : Efficiency factor for the restratification by mixed layer
+!            eddies (Fox-Kemper et al., 2008) () (f)
+! CL       : Scaling of the efficiency factor for the restratification
+!            by mixed layer eddies (Bodner et al., 2023) () (f)
+! TAU_MLR  : Timescale for momentum mixing across mixed layer (s) (f).
+! TAU_GROWING_HBL  : Time-scale for running mean filter when signal is
+!                    greater than filtered value (used for boundary
+!                    layer thickness and vertical momentum flux) (s) (f)
+! TAU_DECAYING_HBL : Time-scale for running mean filter when signal is
+!                    less than filtered value (used for boundary layer
+!                    thickness and vertical momentum flux) (s) (f)
+! TAU_GROWING_HML  : Time-scale for running mean filter when signal is
+!                    greater than filtered value (used for mixed layer
+!                    thickness) (s) (f)
+! TAU_DECAYING_HML : Time-scale for running mean filter when signal is
+!                    less than filtered value (used for mixed layer
+!                    thickness) (s) (f)
+! LFMIN    : Minimum length scale of mixed layer fronts (cm) (f)
+! MSTAR    : Scaling of boundary layer turbulence due to friction
+!            velocity (Bodner et al., 2023) () (f)
+! NSTAR    : Scaling of boundary layer turbulence due to convective
+!            velocity (Bodner et al., 2023) () (f)
+! WPUP_MIN : Minimum vertical momentum flux (Bodner et al., 2023)
+!            (cm**2/s**2) (f)
 ! MLRTTP   : Type of mixed layer restratification time scale. Valid
 !            types: 'variable', 'constant', 'limited' (a)
 ! RM0      : Efficiency factor of wind TKE generation in the Oberhuber
 !            (1993) TKE closure () (f)
 ! RM5      : Efficiency factor of TKE generation by momentum
 !            entrainment in the Oberhuber (1993) TKE closure () (f)
-! CE       : Efficiency factor for the restratification by mixed layer
-!            eddies (Fox-Kemper et al., 2008) () (f)
 ! TDFILE   : Name of file containing tidal wave energy dissipation
 !            divided by by bottom buoyancy frequency (a)
 ! NIWGF    : Global factor applied to the energy input by near-intertial
@@ -101,8 +125,6 @@
 ! EDWMTH   : Method to estimate eddy diffusivity weight as a function of
 !            the ration of Rossby radius of deformation to the
 !            horizontal grid spacing. Valid methods: 'smooth', 'step' (a)
-! MLRTTP   : Type of mixed layer restratification time scale. Valid
-!            types: 'variable', 'constant', 'limited' (a)
 ! EDDF2D   : If true, eddy diffusivity has a 2d structure (l)
 ! EDSPRS   : Apply eddy mixing suppression away from steering level (l)
 ! EGC      : Parameter c in Eden and Greatbatch (2008) parameterization (f)

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -46,7 +46,7 @@ module mod_difest
   use mod_cmnfld,            only: bfsqi, nnslpx, nnslpy, mlts
   use mod_forcing,           only: wavsrc_opt, wavsrc_param, &
                                    abswnd, lamult, lasl, &
-                                   ustar, ustarb, ustar3, &
+                                   ustar, ustarb, ustar3, wstar3, &
                                    buoyfl, t_sw_nonloc, surflx, sswflx, salflx
   use mod_tidaldissip,       only: twedon
   use mod_niw,               only: niwgf, niwbf, niwlf, idkedt, niw_ke_tendency
@@ -112,7 +112,8 @@ module mod_difest
        iL_mks2cgs = 1./L_mks2cgs, &
        iM_mks2cgs = 1./M_mks2cgs, &
        A_mks2cgs  = L_mks2cgs**2, &
-       A_cgs2mks  = 1./(L_mks2cgs*L_mks2cgs)
+       A_cgs2mks  = 1./(L_mks2cgs*L_mks2cgs), &
+       V_mks2cgs  = L_mks2cgs**3
 
   ! parameters:
   !   iidtyp - type of interface and isopycnal diffusivities. If
@@ -1384,6 +1385,9 @@ contains
             t_sw_nonloc(i,j,k) = max(t_sw_nonloc(i,j,k), &
                  nonLocalTrans(k,1))
           end do
+
+          ! Compute convective velocity cubed [cm3 s-3].
+          wstar3(i,j) = max(0.,-surfBuoyFlux)*OBLdepth(i,j)*V_mks2cgs
 
         end do
       end do

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -1,5 +1,6 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2002-2023 Mats Bentsen, Jerry Tjiputra, Jörg Schwinger
+! Copyright (C) 2002-2024 Mats Bentsen, Jerry Tjiputra, Jörg Schwinger,
+!                         Mariana Vertenstein, Joeran Maerz
 !
 ! This file is part of BLOM.
 !
@@ -153,7 +154,8 @@ module mod_forcing
       tauy, &         ! v-component of surface stress [g cm-1 s-2].
       ustar, &        ! Surface friction velocity [cm s-1].
       ustarb, &       ! Bottom friction velocity [cm s-1].
-      ustar3          ! Friction velocity cubed [cm3 s-3].
+      ustar3, &       ! Friction velocity cubed [cm3 s-3].
+      wstar3          ! Convective velocity cubed [cm3 s-3].
 
    ! Flux fields at model interfaces.
 
@@ -178,7 +180,7 @@ module mod_forcing
              atmco2, flxco2, flxdms, flxbrf, atmbrf, &
              atmn2o,flxn2o,atmnh3,flxnh3, atmnhxdep,atmnoydep, &
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
-             ustar, ustarb, ustar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
+             ustar, ustarb, ustar3, wstar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
              s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
              sss_stream, sst_stream, ice_stream, use_stream_relaxation
 
@@ -237,6 +239,7 @@ contains
             ustar(i, j) = spval
             ustarb(i, j) = spval
             ustar3(i, j) = spval
+            wstar3(i, j) = spval
          enddo
       enddo
    !$omp end parallel do
@@ -286,6 +289,7 @@ contains
             atmnoydep(i, j) = 0._r8
             ustar (i, j) = 0._r8
             ustarb(i, j) = 0._r8
+            wstar3(i, j) = 0._r8
          enddo
          enddo
       enddo

--- a/phy/mod_iniphy.F90
+++ b/phy/mod_iniphy.F90
@@ -25,6 +25,7 @@ module mod_iniphy
   use mod_vcoord,      only: vcoord_type_tag, cntiso_hybrid
   use mod_tidaldissip, only: read_tidaldissip
   use mod_difest,      only: init_difest
+  use mod_eddtra,      only: init_eddtra
 
   implicit none
   private
@@ -57,6 +58,8 @@ contains
     if (vcoord_type_tag == cntiso_hybrid) then
       call init_difest
     end if
+
+    call init_eddtra
 
   end subroutine iniphy
 

--- a/phy/mod_inivar.F90
+++ b/phy/mod_inivar.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2015-2021 Mats Bentsen, Jerry Tjiputra
+! Copyright (C) 2015-2024 Mats Bentsen, Jerry Tjiputra, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !
@@ -27,6 +27,7 @@ module mod_inivar
   use mod_tmsmt,       only: inivar_tmsmt
   use mod_diffusion,   only: inivar_diffusion
   use mod_difest,      only: inivar_difest
+  use mod_eddtra,      only: inivar_eddtra
   use mod_utility,     only: inivar_utility
   use mod_mxlayr,      only: inivar_mxlayr
   use mod_seaice,      only: inivar_seaice
@@ -58,6 +59,7 @@ contains
     call inivar_tmsmt
     call inivar_diffusion
     call inivar_difest
+    call inivar_eddtra
     call inivar_utility
     call inivar_mxlayr
     call inivar_seaice

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -48,7 +48,11 @@ module mod_rdlim
                              srxlim, srxbal, sprfac, use_stream_relaxation
   use mod_swabs,       only: swamth, jwtype, chlopt, ccfile
   use mod_diffusion,   only: readnml_diffusion
-  use mod_mxlayr,      only: rm0, rm5, ce, mlrttp
+  use mod_eddtra,      only: mlrmth, ce, cl, tau_mlr, tau_growing_hbl, &
+                             tau_decaying_hbl, tau_growing_hml, &
+                             tau_decaying_hml, lfmin, mstar, nstar, &
+                             wpup_min
+  use mod_mxlayr,      only: rm0, rm5, mlrttp
   use mod_niw,         only: niwgf, niwbf, niwlf
   use mod_tidaldissip, only: tdfile
   use mod_dia,         only: nphymax, glb_fnametag, rstfrq, rstfmt, rstcmp, &
@@ -127,8 +131,10 @@ contains
          grfile,icfile,pref,baclin,batrop, &
          mdv2hi,mdv2lo,mdv4hi,mdv4lo,mdc2hi,mdc2lo, &
          vsc2hi,vsc2lo,vsc4hi,vsc4lo,cbar,cb,cwbdts,cwbdls, &
-         mommth,bmcmth,rmpmth,mlrttp, &
-         rm0,rm5,ce,tdfile,niwgf,niwbf,niwlf, &
+         mommth,bmcmth,rmpmth, &
+         mlrmth,ce,cl,tau_mlr,tau_growing_hbl,tau_decaying_hbl, &
+         tau_growing_hml,tau_decaying_hml,lfmin,mstar,nstar,wpup_min, &
+         mlrttp,rm0,rm5,tdfile,niwgf,niwbf,niwlf, &
          swamth,jwtype,chlopt,ccfile, &
          trxday,srxday,trxdpt,srxdpt,trxlim,srxlim, &
          aptflx,apsflx,ditflx,disflx,srxbal,scfile, &
@@ -194,9 +200,21 @@ contains
       write (lp,*) 'MOMMTH ',trim(MOMMTH)
       write (lp,*) 'BMCMTH ',trim(BMCMTH)
       write (lp,*) 'RMPMTH ',trim(RMPMTH)
+      write (lp,*) 'MLRMTH ',trim(MLRMTH)
+      write (lp,*) 'CE',CE
+      write (lp,*) 'CL',CL
+      write (lp,*) 'TAU_MLR',TAU_MLR
+      write (lp,*) 'TAU_GROWING_HBL',TAU_GROWING_HBL
+      write (lp,*) 'TAU_DECAYING_HBL',TAU_DECAYING_HBL
+      write (lp,*) 'TAU_GROWING_HML',TAU_GROWING_HML
+      write (lp,*) 'TAU_DECAYING_HML',TAU_DECAYING_HML
+      write (lp,*) 'LFMIN',LFMIN
+      write (lp,*) 'MSTAR',MSTAR
+      write (lp,*) 'NSTAR',NSTAR
+      write (lp,*) 'WPUP_MIN',WPUP_MIN
+      write (lp,*) 'MLRTTP ',trim(MLRTTP)
       write (lp,*) 'RM0',RM0
       write (lp,*) 'RM5',RM5
-      write (lp,*) 'CE',CE
       write (lp,*) 'TDFILE',trim(TDFILE)
       write (lp,*) 'NIWGF',NIWGF
       write (lp,*) 'NIWBF',NIWBF
@@ -265,10 +283,21 @@ contains
     call xcbcst(mommth)
     call xcbcst(bmcmth)
     call xcbcst(rmpmth)
+    call xcbcst(mlrmth)
+    call xcbcst(ce)
+    call xcbcst(cl)
+    call xcbcst(tau_mlr)
+    call xcbcst(tau_growing_hbl)
+    call xcbcst(tau_decaying_hbl)
+    call xcbcst(tau_growing_hml)
+    call xcbcst(tau_decaying_hml)
+    call xcbcst(lfmin)
+    call xcbcst(mstar)
+    call xcbcst(nstar)
+    call xcbcst(wpup_min)
     call xcbcst(mlrttp)
     call xcbcst(rm0)
     call xcbcst(rm5)
-    call xcbcst(ce)
     call xcbcst(tdfile)
     call xcbcst(niwgf)
     call xcbcst(niwbf)

--- a/phy/mod_restart.F90
+++ b/phy/mod_restart.F90
@@ -1,7 +1,7 @@
 ! ------------------------------------------------------------------------------
 ! Copyright (C) 2006-2024 Mats Bentsen, Mehmet Ilicak, Alok Kumar Gupta,
 !                         Ingo Bethke, Jerry Tjiputra, Ping-Gin Chiu,
-!                         Aleksi Nummelin, Jörg Schwinger
+!                         Aleksi Nummelin, Jörg Schwinger, Mariana Vertenstein, !                         Joeran Maerz
 !
 ! This file is part of BLOM.
 !
@@ -83,7 +83,7 @@ module mod_restart
    use mod_forcing,        only: ditflx, disflx, sprfac, tflxdi, sflxdi, nflxdi, &
                                  prfac, eiacc, pracc, flxco2, flxdms, flxbrf, &
                                  flxn2o,flxnh3, &
-                                 ustarb, buoyfl, ustar
+                                 ustarb, wstar3, buoyfl, ustar
    use mod_niw,            only: uml, vml, umlres, vmlres
    use mod_difest,         only: OBLdepth
    use mod_diffusion,      only: difiso, Kvisc_m, Kdiff_t, Kdiff_s, &
@@ -92,6 +92,7 @@ module mod_restart
                                  usflld, utflsm, usflld, utflld, umfltd, usflld, &
                                  vmflsm, vsfltd, vtflld, vsflsm, vtfltd, &
                                  vsflld, vtflsm, vsflld, vtflld, vmfltd, vsflld
+   use mod_eddtra,         only: hbl_tf, wpup_tf, hml_tf1, hml_tf
    use mod_cesm,           only: frzpot, mltpot, swa_da, nsf_da, hmlt_da, lip_da, &
                                  sop_da, eva_da, rnf_da, rfi_da, fmltfz_da, sfl_da, &
                                  ztx_da, mty_da, ustarw_da, slp_da, abswnd_da, &
@@ -351,9 +352,9 @@ contains
       endif
 
       if (vcoord_type_tag == cntiso_hybrid) then
-         call defwrtfld('dpu', trim(c5p)//' kk2 time', &
+         call defwrtfld('dpu', trim(c5u)//' kk2 time', &
                          dpu, iu, defmode)
-         call defwrtfld('dpv', trim(c5p)//' kk2 time', &
+         call defwrtfld('dpv', trim(c5v)//' kk2 time', &
                          dpv, iv, defmode)
          call defwrtfld('difiso', trim(c5p)//' kk time', &
                          difiso, ip, defmode)
@@ -379,6 +380,16 @@ contains
                          vtflsm, ivv, defmode)
          call defwrtfld('vsflsm', trim(c5v)//' kk2 time', &
                          vsflsm, ivv, defmode)
+         call defwrtfld('wstar3', trim(c5p)//' time', &
+                         wstar3, ip, defmode)
+         call defwrtfld('hbl_tf', trim(c5p)//' time', &
+                         hbl_tf, ip, defmode)
+         call defwrtfld('wpup_tf', trim(c5p)//' time', &
+                         wpup_tf, ip, defmode)
+         call defwrtfld('hml_tf1', trim(c5p)//' time', &
+                         hml_tf1, ip, defmode)
+         call defwrtfld('hml_tf', trim(c5p)//' time', &
+                         hml_tf, ip, defmode)
       endif
 
       if (sprfac) then
@@ -1549,6 +1560,11 @@ contains
          call readfld('vmflsm', lm_unitconv, vmflsm, ivv)
          call readfld('vtflsm', lm_unitconv, vtflsm, ivv)
          call readfld('vsflsm', lm_unitconv, vsflsm, ivv)
+         call readfld('wstar3', l3_unitconv, wstar3, ip)
+         call readfld('hbl_tf', l_unitconv, hbl_tf, ip)
+         call readfld('wpup_tf', l2_unitconv, wpup_tf, ip)
+         call readfld('hml_tf1', l_unitconv, hml_tf1, ip)
+         call readfld('hml_tf', l_unitconv, hml_tf, ip)
       endif
 
       if (sprfac) then


### PR DESCRIPTION
Added the parameterization by Bodner et al. (2023) for mixed layer restratification by submesoscale eddies as an additional method to the existing Fox Kemper et al. (2008) parameterization.

The mixed layer restratification method is selected by the new namelist variable "mlrmth" that can have values "none", "fox08" or "bod23".  Time-filtering to reduce the diurnal variability of mixed layer variables used in the "fox08" and "bod23" methods have been implemented and can be controlled by the namelist variables "tau_growing_hbl", "tau_decaying_hbl", "tau_growing_hml" and "tau_decaying_hml". A namelist variable "cl" has been introduced for the "bod23" method to scale the efficiency factor for the restratification.

Default is to use the existing "fox08" method with no time-filtering and this reproduces results of current master. Correct restart with the "bod23" method and time-filtering enabled has been confirmed in an OMIP simulation.