### PR TITLE
Corrected some bugs when using MCT

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -326,15 +326,16 @@ def buildnml(case, caseroot, compname):
     # Note - this does not change the blom namelist - it changes xml variables that are then
     # used by cmeps to change attributes that are sent to the atm
     # TODO: add n2o_emis and nh3_emis logic
-    if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
-        dms_emis = case.get_value("DMS_EMIS_OCN")
-        if dms_emis is not None:
-            case.set_value('DMS_EMIS_OCN','TRUE')
-            print ("   ***Setting DMS_EMIS_OCN to TRUE***")
-        brf_emis = pg_blom.get_value('use_bromo')
-        if brf_emis == ".true.":
-            case.set_value('BRF_EMIS_OCN','TRUE')
-            print ("   ***Setting BRF_EMIS_OCN to TRUE***")
+    if comp_interface == "nuopc":
+        if "ecosys" in case.get_value("BLOM_TRACER_MODULES"):
+            dms_emis = case.get_value("DMS_EMIS_OCN")
+            if dms_emis is not None:
+                case.set_value('DMS_EMIS_OCN','TRUE')
+                print ("   ***Setting DMS_EMIS_OCN to TRUE***")
+            brf_emis = pg_blom.get_value('use_bromo')
+            if brf_emis == ".true.":
+                case.set_value('BRF_EMIS_OCN','TRUE')
+                print ("   ***Setting BRF_EMIS_OCN to TRUE***")
 
 ###############################################################################
 def _main_func():

--- a/drivers/mct/setlogunit.F90
+++ b/drivers/mct/setlogunit.F90
@@ -1,0 +1,43 @@
+! ------------------------------------------------------------------------------
+! Copyright (C) 2015-2024 Mats Bentsen, Ping-Gin Chiu
+!
+! This file is part of BLOM.
+!
+! BLOM is free software: you can redistribute it and/or modify it under the
+! terms of the GNU Lesser General Public License as published by the Free
+! Software Foundation, either version 3 of the License, or (at your option)
+! any later version.
+!
+! BLOM is distributed in the hope that it will be useful, but WITHOUT ANY
+! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+! FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+! more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with BLOM. If not, see <https://www.gnu.org/licenses/>.
+! ------------------------------------------------------------------------------
+
+subroutine setlogunit
+
+   use mod_config,   only: inst_suffix
+   use mod_xc,       only: mnproc, lp
+   use shr_file_mod, only: shr_file_getUnit, shr_file_setIO
+
+   implicit none
+
+   character(len = 256) :: nlfnm
+   logical :: exists
+
+   ! ---------------------------------------------------------------------------
+   ! Redirect standard out to a log file if requested
+   ! ---------------------------------------------------------------------------
+   if (mnproc.eq.1) then
+      nlfnm = 'ocn_modelio.nml'//trim(inst_suffix)
+      inquire(file = nlfnm, exist = exists)
+      if (exists) then
+         lp = shr_file_getUnit()
+         call shr_file_setIO(nlfnm, lp)
+      endif
+   endif
+
+end subroutine setlogunit

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -1,7 +1,7 @@
 ! ------------------------------------------------------------------------------
 ! Copyright (C) 2005 HYCOM Consortium and contributors
-! Copyright (C) 2006-2020 Lars Inge Enstad, Mats Bentsen, Alok Kumar Gupta
-! Copyright (C) 2024 Mariana Vertenstein
+! Copyright (C) 2006-2024 Lars Inge Enstad, Mats Bentsen, Alok Kumar Gupta,
+!                         Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !
@@ -1388,6 +1388,8 @@ contains
     call mpi_comm_size(mpicomm, npesi, mpierr)
 
     mnproc = mypei + 1  ! mnproc counts from 1
+
+    call setlogunit
 
     if (use_DEBUG_ALL) then
        write(lp,'(a,i5)') 'mnproc =',mnproc


### PR DESCRIPTION
This PR fixes an issue that correct log file was not used when running NorESM simulations using MCT. It also omits the new logic for sending DMS and BROMO to CMEPS if NUOPC is not used, since this caused an configuration error with MCT. 