### PR TITLE
Making preformed tracers optional to enable HR runs without them

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -31,7 +31,7 @@
     <default_value>FALSE</default_value>
     <group>build_component_blom</group>
     <file>env_build.xml</file>
-    <desc>Set preprocessor option to activate age tracer code. Requires module iage or ecosys</desc>
+    <desc>Set namelist option to activate age tracer code. Requires module iage or ecosys</desc>
   </entry>
 
   <entry id="BLOM_TURBULENT_CLOSURE">
@@ -151,7 +151,7 @@
     </values>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set preprocessor option to activate the extended nitrogen cycle code. Requires module ecosys</desc>
+    <desc>Set namelist option to activate the extended nitrogen cycle code. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_ATMNDEPC">
@@ -184,7 +184,7 @@
     <default_value>FALSE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set preprocessor option to activate the M4AGO sinking scheme. Requires module ecosys</desc>
+    <desc>Set namelist option to activate the M4AGO sinking scheme. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_PREF_TRACERS">
@@ -193,7 +193,7 @@
     <default_value>TRUE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set preprocessor option to activate the preformed tracer code. Requires module ecosys</desc>
+    <desc>Set namelist option to activate the preformed tracer code. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_CISO">
@@ -202,7 +202,7 @@
     <default_value>FALSE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set preprocessor option to activate the carbon isotope code. Requires module ecosys</desc>
+    <desc>Set namelist option to activate the carbon isotope code. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_SEDBYPASS">
@@ -211,7 +211,7 @@
     <default_value>FALSE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set preprocessor option to bypass the sediment code. Requires module ecosys</desc>
+    <desc>Set namelist option to bypass the sediment code. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_SEDSPINUP">

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -148,12 +148,12 @@
        <value compset="_BGC.*%N2OC">TRUE</value>
        <value compset="_BGC.*%NH3C">TRUE</value>
        <value compset="_BGC.*%ATMNDEPC">TRUE</value>
-    </values>	    
+    </values>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set preprocessor option to activate the extended nitrogen cycle code. Requires module ecosys</desc>
   </entry>
-  
+
   <entry id="HAMOCC_ATMNDEPC">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -165,7 +165,7 @@
     <file>env_run.xml</file>
     <desc>Nitrogen deposition coupled from atmosphere. Requires module ecosys and extncycle</desc>
   </entry>
-  
+
   <entry id="HAMOCC_N2OC">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -185,6 +185,15 @@
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set preprocessor option to activate the M4AGO sinking scheme. Requires module ecosys</desc>
+  </entry>
+
+  <entry id="HAMOCC_PREF_TRACERS">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>TRUE</default_value>
+    <group>run_component_blom</group>
+    <file>env_run.xml</file>
+    <desc>Set preprocessor option to activate the preformed tracer code. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_CISO">
@@ -211,7 +220,7 @@
     <default_value>TRUE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Activate sediment spinup. HAMOCC_SEDSPINUP_YR_START and HAMOCC_SEDSPINUP_YR_END 
+    <desc>Activate sediment spinup. HAMOCC_SEDSPINUP_YR_START and HAMOCC_SEDSPINUP_YR_END
       need to be set to valid values for this option to take effect. Requires module ecosys</desc>
   </entry>
 
@@ -221,7 +230,7 @@
     <default_value>1</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set start year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE. 
+    <desc>Set start year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE.
       Requires module ecosys</desc>
   </entry>
 
@@ -231,17 +240,17 @@
     <default_value>800</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set end year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE. 
+    <desc>Set end year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE.
       Requires module ecosys</desc>
   </entry>
- 
+
   <entry id="HAMOCC_SEDSPINUP_NCYCLE">
     <type>integer</type>
     <valid_values/>
     <default_value>20</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set the number of sub-cycles for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE. 
+    <desc>Set the number of sub-cycles for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE.
       Requires module ecosys</desc>
   </entry>
 

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4145,6 +4145,17 @@
     <desc>add desc</desc>
   </entry>
 
+  <entry id="use_pref_tracers" modify_via_xml="HAMOCC_PREF_TRACERS">
+    <type>logical</type>
+    <category>config_bgc</category>
+    <group>config_bgc</group>
+    <values>
+      <value>.true.</value>
+      <value hamocc_pref_tracers="false">.false.</value>
+    </values>
+    <desc>activate the HAMOCC preformed tracers code</desc>
+  </entry>
+
   <!-- ========================= -->
   <!-- namelist group: bgcoafx -->
   <!-- These options can be activated by expert users via user namelist. -->

--- a/hamocc/mo_accfields.F90
+++ b/hamocc/mo_accfields.F90
@@ -128,7 +128,8 @@ contains
                                 jsdm_remin_sulf,jsediffnh4,jsediffn2o,jsediffno2,jatmn2o,jatmnh3,  &
                                 jndepnhxfx
     use mo_control_bgc,   only: io_stdo_bgc,dtb,use_BROMO,use_AGG,use_WLIN,use_natDIC,             &
-                                use_CFC,use_sedbypass,use_cisonew,use_BOXATM,use_M4AGO,use_extNcycle
+                                use_CFC,use_sedbypass,use_cisonew,use_BOXATM,use_M4AGO,            &
+                                use_extNcycle,use_pref_tracers
     use mo_param1_bgc,    only: ialkali,ian2o,iano3,iatmco2,iatmdms,iatmn2,iatmn2o,iatmo2,         &
                                 icalc,idet,idms,idicsat,idoc,iiron,iopal,                          &
                                 ioxygen,iphosph,iphy,iprefalk,iprefdic,                            &
@@ -394,12 +395,14 @@ contains
     call acclyr(jomegac,OmegaC,pddpo,1)
     call acclyr(jphosy,phosy3d,pddpo,1)
     call acclyr(jo2sat,satoxy,pddpo,1)
-    call acclyr(jprefo2,ocetra(1,1,1,iprefo2),pddpo,1)
-    call acclyr(jprefpo4,ocetra(1,1,1,iprefpo4),pddpo,1)
-    call acclyr(jprefsilica,ocetra(1,1,1,iprefsilica),pddpo,1)
-    call acclyr(jprefalk,ocetra(1,1,1,iprefalk),pddpo,1)
-    call acclyr(jprefdic,ocetra(1,1,1,iprefdic),pddpo,1)
     call acclyr(jdicsat,ocetra(1,1,1,idicsat),pddpo,1)
+    if (use_pref_tracers) then
+      call acclyr(jprefo2,ocetra(1,1,1,iprefo2),pddpo,1)
+      call acclyr(jprefpo4,ocetra(1,1,1,iprefpo4),pddpo,1)
+      call acclyr(jprefsilica,ocetra(1,1,1,iprefsilica),pddpo,1)
+      call acclyr(jprefalk,ocetra(1,1,1,iprefalk),pddpo,1)
+      call acclyr(jprefdic,ocetra(1,1,1,iprefdic),pddpo,1)
+    endif
     if (use_natDIC) then
       call acclyr(jnatalkali,ocetra(1,1,1,inatalkali),pddpo,1)
       call acclyr(jnatdic,ocetra(1,1,1,inatsco212),pddpo,1)
@@ -511,12 +514,14 @@ contains
         call acclvl(jlvlomegac,OmegaC,k,ind1,ind2,wghts)
         call acclvl(jlvlphosy,phosy3d,k,ind1,ind2,wghts)
         call acclvl(jlvlo2sat,satoxy,k,ind1,ind2,wghts)
-        call acclvl(jlvlprefo2,ocetra(1,1,1,iprefo2),k,ind1,ind2,wghts)
-        call acclvl(jlvlprefpo4,ocetra(1,1,1,iprefpo4),k,ind1,ind2,wghts)
-        call acclvl(jlvlprefsilica,ocetra(1,1,1,iprefsilica),k,ind1,ind2,wghts)
-        call acclvl(jlvlprefalk,ocetra(1,1,1,iprefalk),k,ind1,ind2,wghts)
-        call acclvl(jlvlprefdic,ocetra(1,1,1,iprefdic),k,ind1,ind2,wghts)
         call acclvl(jlvldicsat,ocetra(1,1,1,idicsat),k,ind1,ind2,wghts)
+        if (use_pref_tracers) then
+          call acclvl(jlvlprefo2,ocetra(1,1,1,iprefo2),k,ind1,ind2,wghts)
+          call acclvl(jlvlprefpo4,ocetra(1,1,1,iprefpo4),k,ind1,ind2,wghts)
+          call acclvl(jlvlprefsilica,ocetra(1,1,1,iprefsilica),k,ind1,ind2,wghts)
+          call acclvl(jlvlprefalk,ocetra(1,1,1,iprefalk),k,ind1,ind2,wghts)
+          call acclvl(jlvlprefdic,ocetra(1,1,1,iprefdic),k,ind1,ind2,wghts)
+        endif
         if (use_natDIC) then
           call acclvl(jlvlnatdic,ocetra(1,1,1,inatsco212),k,ind1,ind2,wghts)
           call acclvl(jlvlnatalkali,ocetra(1,1,1,inatalkali),k,ind1,ind2,wghts)

--- a/hamocc/mo_aufr_bgc.F90
+++ b/hamocc/mo_aufr_bgc.F90
@@ -82,7 +82,7 @@ CONTAINS
     use mo_carbch,          only: co2star,co3,hi,satoxy,ocetra,atm,nathi
     use mo_control_bgc,     only: io_stdo_bgc,ldtbgc,use_cisonew,use_AGG,                          &
                                   use_BOXATM,use_BROMO,use_CFC,use_natDIC,use_sedbypass,           &
-                                  use_extNcycle
+                                  use_extNcycle,use_pref_tracers
     use mo_param1_bgc,      only: ialkali,ian2o,iano3,icalc,idet,idicsat,                          &
                                   idms,idoc,ifdust,igasnit,iiron,iopal,ioxygen,iphosph,iphy,       &
                                   iprefalk,iprefdic,iprefo2,iprefpo4,iprefsilica,                  &
@@ -400,13 +400,15 @@ CONTAINS
     call read_netcdf_var(ncid,'dms',locetra(1,1,1,idms),2*kpke,0,iotype)
     call read_netcdf_var(ncid,'fdust',locetra(1,1,1,ifdust),2*kpke,0,iotype)
     call read_netcdf_var(ncid,'iron',locetra(1,1,1,iiron),2*kpke,0,iotype)
-    call read_netcdf_var(ncid,'prefo2',locetra(1,1,1,iprefo2),2*kpke,0,iotype)
-    call read_netcdf_var(ncid,'prefpo4',locetra(1,1,1,iprefpo4),2*kpke,0,iotype)
-    call read_netcdf_var(ncid,'prefalk',locetra(1,1,1,iprefalk),2*kpke,0,iotype)
-    call read_netcdf_var(ncid,'prefdic',locetra(1,1,1,iprefdic),2*kpke,0,iotype)
     call read_netcdf_var(ncid,'dicsat',locetra(1,1,1,idicsat),2*kpke,0,iotype)
-    if(lread_prefsi) then
-      call read_netcdf_var(ncid,'prefsilica',locetra(1,1,1,iprefsilica),2*kpke,0,iotype)
+    if (use_pref_tracers) then
+      call read_netcdf_var(ncid,'prefo2',locetra(1,1,1,iprefo2),2*kpke,0,iotype)
+      call read_netcdf_var(ncid,'prefpo4',locetra(1,1,1,iprefpo4),2*kpke,0,iotype)
+      call read_netcdf_var(ncid,'prefalk',locetra(1,1,1,iprefalk),2*kpke,0,iotype)
+      call read_netcdf_var(ncid,'prefdic',locetra(1,1,1,iprefdic),2*kpke,0,iotype)
+      if(lread_prefsi) then
+        call read_netcdf_var(ncid,'prefsilica',locetra(1,1,1,iprefsilica),2*kpke,0,iotype)
+      endif
     endif
 
     if (use_cisonew .and. lread_iso) then

--- a/hamocc/mo_aufw_bgc.F90
+++ b/hamocc/mo_aufw_bgc.F90
@@ -75,7 +75,8 @@ contains
     use mod_dia,        only: iotype
     use mo_carbch,      only: co2star,co3,hi,satoxy,nathi
     use mo_control_bgc, only: io_stdo_bgc,ldtbgc,rmasks,rmasko,use_cisonew,use_AGG,use_BOXATM,     &
-                              use_BROMO,use_CFC,use_natDIC,use_sedbypass,use_extNcycle
+                              use_BROMO,use_CFC,use_natDIC,use_sedbypass,use_extNcycle,            &
+                              use_pref_tracers
     use mo_sedmnt,      only: sedhpl
     use mo_intfcblom,   only: sedlay2,powtra2,burial2,atm2
     use mo_param1_bgc,  only: ialkali, ian2o,iano3,icalc,idet,idicsat,idms,idoc,ifdust,igasnit,    &
@@ -762,12 +763,14 @@ contains
     call write_netcdf_var(ncid,'dms',locetra(1,1,1,idms),2*kpke,0)
     call write_netcdf_var(ncid,'fdust',locetra(1,1,1,ifdust),2*kpke,0)
     call write_netcdf_var(ncid,'iron',locetra(1,1,1,iiron),2*kpke,0)
-    call write_netcdf_var(ncid,'prefo2',locetra(1,1,1,iprefo2),2*kpke,0)
-    call write_netcdf_var(ncid,'prefpo4',locetra(1,1,1,iprefpo4),2*kpke,0)
-    call write_netcdf_var(ncid,'prefsilica',locetra(1,1,1,iprefsilica),2*kpke,0)
-    call write_netcdf_var(ncid,'prefalk',locetra(1,1,1,iprefalk),2*kpke,0)
-    call write_netcdf_var(ncid,'prefdic',locetra(1,1,1,iprefdic),2*kpke,0)
     call write_netcdf_var(ncid,'dicsat',locetra(1,1,1,idicsat),2*kpke,0)
+    if (use_pref_tracers) then
+      call write_netcdf_var(ncid,'prefo2',locetra(1,1,1,iprefo2),2*kpke,0)
+      call write_netcdf_var(ncid,'prefpo4',locetra(1,1,1,iprefpo4),2*kpke,0)
+      call write_netcdf_var(ncid,'prefsilica',locetra(1,1,1,iprefsilica),2*kpke,0)
+      call write_netcdf_var(ncid,'prefalk',locetra(1,1,1,iprefalk),2*kpke,0)
+      call write_netcdf_var(ncid,'prefdic',locetra(1,1,1,iprefdic),2*kpke,0)
+    endif
     if (use_cisonew) then
       call write_netcdf_var(ncid,'sco213'   ,locetra(1,1,1,isco213) ,2*kpke,0)
       call write_netcdf_var(ncid,'sco214'   ,locetra(1,1,1,isco214) ,2*kpke,0)

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -83,6 +83,7 @@ module mo_control_bgc
   logical           :: use_BOXATM             = .false.
   logical           :: use_sedbypass          = .false.
   logical           :: use_extNcycle          = .false.
+  logical           :: use_pref_tracers       = .true.
 
 contains
 

--- a/hamocc/mo_hamocc4bcm.F90
+++ b/hamocc/mo_hamocc4bcm.F90
@@ -55,7 +55,7 @@ contains
                                 do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,               &
                                 use_BROMO, use_CFC, use_PBGC_CK_TIMESTEP,                          &
                                 use_BOXATM, use_sedbypass,ocn_co2_type,                            &
-                                do_n2onh3_coupled,use_extNcycle
+                                do_n2onh3_coupled,use_extNcycle,use_pref_tracers
     use mo_param1_bgc,    only: iatmco2,iatmdms,nocetra,nriv,iatmbromo,nndep,iatmn2o,iatmnh3
     use mo_vgrid,         only: set_vgrid
     use mo_apply_fedep,   only: apply_fedep
@@ -309,8 +309,10 @@ contains
       call inventory_bgc(kpie,kpje,kpke,pdlxp,pdlyp,pddpo,omask,0)
     endif
 
-    ! update preformed tracers
-    call preftrc(kpie,kpje,omask)
+    if (use_pref_tracers) then
+      ! update preformed tracers
+      call preftrc(kpie,kpje,omask)
+    endif
 
     !--------------------------------------------------------------------
     !     Sediment module

--- a/hamocc/mo_ini_fields.F90
+++ b/hamocc/mo_ini_fields.F90
@@ -94,7 +94,7 @@ contains
     use mo_param_bgc,   only: fesoly,cellmass,fractdim,bifr13_ini,bifr14_ini,c14fac,re1312,re14to
     use mo_biomod,      only: abs_oce
     use mo_control_bgc, only: rmasks,use_FB_BGC_OCE,use_cisonew,use_AGG,use_CFC,use_natDIC,        &
-                              use_BROMO, use_sedbypass,use_extNcycle
+                              use_BROMO, use_sedbypass,use_extNcycle,use_pref_tracers
     use mo_param1_bgc,  only: ialkali,ian2o,iano3,icalc,idet,idicsat,idms,idoc,ifdust,igasnit,     &
                               iiron,iopal,ioxygen,iphosph,iphy,iprefalk,iprefdic,iprefo2,iprefpo4, &
                               isco212,isilica,izoo,iadust,inos,ibromo,icfc11,icfc12,isf6,          &
@@ -190,15 +190,17 @@ contains
             ocetra(i,j,k,idms)   =0.
             ocetra(i,j,k,ifdust) =0.
             ocetra(i,j,k,iiron)  =fesoly
-            ocetra(i,j,k,iprefo2)=0.
-            ocetra(i,j,k,iprefpo4)=0.
-            ocetra(i,j,k,iprefsilica)=0.
-            ocetra(i,j,k,iprefalk)=0.
-            ocetra(i,j,k,iprefdic)=0.
             ocetra(i,j,k,idicsat)=1.e-8
             hi(i,j,k)            =1.e-8
             co3(i,j,k)           =0.
             co2star(i,j,k)       =20.e-6
+            if (use_pref_tracers) then
+              ocetra(i,j,k,iprefo2)     = 0.
+              ocetra(i,j,k,iprefpo4)    = 0.
+              ocetra(i,j,k,iprefsilica) = 0.
+              ocetra(i,j,k,iprefalk)    = 0.
+              ocetra(i,j,k,iprefdic)    = 0.
+            endif
             if (use_AGG) then
               ! calculate initial numbers from mass, to start with appropriate size distribution
               snow = (ocetra(i,j,k,iphy)+ocetra(i,j,k,idet))*1.e+6
@@ -243,19 +245,21 @@ contains
       enddo
     enddo
 
-    ! Initialise preformed tracers in the mixed layer; note that the
-    ! whole field has been initialised to zero above
-    do j=1,kpje
-      do i=1,kpie
-        if (omask(i,j) > 0.5) then
-          ocetra(i,j,1:kmle(i,j),iprefo2)  = ocetra(i,j,1:kmle(i,j),ioxygen)
-          ocetra(i,j,1:kmle(i,j),iprefpo4) = ocetra(i,j,1:kmle(i,j),iphosph)
-          ocetra(i,j,1:kmle(i,j),iprefsilica)= ocetra(i,j,1:kmle(i,j),isilica)
-          ocetra(i,j,1:kmle(i,j),iprefalk) = ocetra(i,j,1:kmle(i,j),ialkali)
-          ocetra(i,j,1:kmle(i,j),iprefdic) = ocetra(i,j,1:kmle(i,j),isco212)
-        endif
+    if (use_pref_tracers) then
+      ! Initialise preformed tracers in the mixed layer; note that the
+      ! whole field has been initialised to zero above
+      do j=1,kpje
+        do i=1,kpie
+          if (omask(i,j) > 0.5) then
+            ocetra(i,j,1:kmle(i,j),iprefo2)  = ocetra(i,j,1:kmle(i,j),ioxygen)
+            ocetra(i,j,1:kmle(i,j),iprefpo4) = ocetra(i,j,1:kmle(i,j),iphosph)
+            ocetra(i,j,1:kmle(i,j),iprefsilica)= ocetra(i,j,1:kmle(i,j),isilica)
+            ocetra(i,j,1:kmle(i,j),iprefalk) = ocetra(i,j,1:kmle(i,j),ialkali)
+            ocetra(i,j,1:kmle(i,j),iprefdic) = ocetra(i,j,1:kmle(i,j),isco212)
+          endif
+        enddo
       enddo
-    enddo
+    endif
 
 
     ! Initial values for sediment

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -682,7 +682,7 @@ contains
                                idet14,idoc13,idoc14,iphy13,iphy14,isco213,isco214,izoo13,izoo14,   &
                                inatalkali,inatcalc,inatsco212,ianh4,iano2,iprefsilica
       use mo_control_bgc,only: use_PBGC_CK_TIMESTEP,use_BOXATM,use_sedbypass,use_cisonew,use_AGG,  &
-                               use_CFC,use_natDIC,use_BROMO
+                               use_CFC,use_natDIC,use_BROMO,use_pref_tracers
 
       implicit none
 
@@ -1098,66 +1098,6 @@ contains
              &    'Mean dissolved iron concentration') )
         call nccheck( NF90_PUT_ATT(ncid, zc_iron_varid, 'units', 'kmol/m^3') )
 
-        call nccheck( NF90_DEF_VAR(ncid, 'zt_prefo2', NF90_DOUBLE,                &
-             &    time_dimid, zt_prefo2_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefo2_varid, 'long_name',            &
-             &    'Total preformed oxygen tracer') )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefo2_varid, 'units', 'kmol') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zc_prefo2', NF90_DOUBLE,                &
-             &    time_dimid, zc_prefo2_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefo2_varid, 'long_name',            &
-             &    'Mean preformed oxygen concentration') )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefo2_varid, 'units', 'kmol/m^3') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zt_prefpo4', NF90_DOUBLE,               &
-             &    time_dimid, zt_prefpo4_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefpo4_varid, 'long_name',           &
-             &    'Total preformed phosphate tracer') )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefpo4_varid, 'units', 'kmol') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zc_prefpo4', NF90_DOUBLE,               &
-             &    time_dimid, zc_prefpo4_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefpo4_varid, 'long_name',           &
-             &    'Mean preformed phosphate concentration') )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefpo4_varid, 'units', 'kmol/m^3') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zt_prefsilica', NF90_DOUBLE,            &
-             &    time_dimid, zt_prefsilica_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefsilica_varid, 'long_name',        &
-             &    'Total preformed silica tracer') )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefsilica_varid, 'units', 'kmol') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zc_prefsilica', NF90_DOUBLE,            &
-             &    time_dimid, zc_prefsilica_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefsilica_varid, 'long_name',        &
-             &    'Mean preformed silica concentration') )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefsilica_varid, 'units', 'kmol/m^3') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zt_prefalk', NF90_DOUBLE,               &
-             &    time_dimid, zt_prefalk_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefalk_varid, 'long_name',           &
-             &    'Total preformed alkalinity tracer') )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefalk_varid, 'units', 'kmol') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zc_prefalk', NF90_DOUBLE,               &
-             &    time_dimid, zc_prefalk_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefalk_varid, 'long_name',           &
-             &    'Mean preformed alkalinity concentration') )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefalk_varid, 'units', 'kmol/m^3') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zt_prefdic', NF90_DOUBLE,               &
-             &    time_dimid, zt_prefdic_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefdic_varid, 'long_name',           &
-             &    'Total preformed DIC tracer') )
-        call nccheck( NF90_PUT_ATT(ncid, zt_prefdic_varid, 'units', 'kmol') )
-
-        call nccheck( NF90_DEF_VAR(ncid, 'zc_prefdic', NF90_DOUBLE,               &
-             &    time_dimid, zc_prefdic_varid) )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefdic_varid, 'long_name',           &
-             &    'Mean preformed DIC concentration') )
-        call nccheck( NF90_PUT_ATT(ncid, zc_prefdic_varid, 'units', 'kmol/m^3') )
-
         call nccheck( NF90_DEF_VAR(ncid, 'zt_dicsat', NF90_DOUBLE,                &
              &    time_dimid, zt_dicsat_varid) )
         call nccheck( NF90_PUT_ATT(ncid, zt_dicsat_varid, 'long_name',            &
@@ -1170,6 +1110,67 @@ contains
              &    'Mean saturated DIC concentration') )
         call nccheck( NF90_PUT_ATT(ncid, zc_dicsat_varid, 'units', 'kmol/m^3') )
 
+        if (use_pref_tracers) then
+          call nccheck( NF90_DEF_VAR(ncid, 'zt_prefo2', NF90_DOUBLE,                &
+               &    time_dimid, zt_prefo2_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefo2_varid, 'long_name',            &
+               &    'Total preformed oxygen tracer') )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefo2_varid, 'units', 'kmol') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zc_prefo2', NF90_DOUBLE,                &
+               &    time_dimid, zc_prefo2_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefo2_varid, 'long_name',            &
+               &    'Mean preformed oxygen concentration') )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefo2_varid, 'units', 'kmol/m^3') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zt_prefpo4', NF90_DOUBLE,               &
+               &    time_dimid, zt_prefpo4_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefpo4_varid, 'long_name',           &
+               &    'Total preformed phosphate tracer') )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefpo4_varid, 'units', 'kmol') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zc_prefpo4', NF90_DOUBLE,               &
+               &    time_dimid, zc_prefpo4_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefpo4_varid, 'long_name',           &
+               &    'Mean preformed phosphate concentration') )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefpo4_varid, 'units', 'kmol/m^3') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zt_prefsilica', NF90_DOUBLE,            &
+               &    time_dimid, zt_prefsilica_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefsilica_varid, 'long_name',        &
+               &    'Total preformed silica tracer') )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefsilica_varid, 'units', 'kmol') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zc_prefsilica', NF90_DOUBLE,            &
+               &    time_dimid, zc_prefsilica_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefsilica_varid, 'long_name',        &
+               &    'Mean preformed silica concentration') )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefsilica_varid, 'units', 'kmol/m^3') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zt_prefalk', NF90_DOUBLE,               &
+               &    time_dimid, zt_prefalk_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefalk_varid, 'long_name',           &
+               &    'Total preformed alkalinity tracer') )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefalk_varid, 'units', 'kmol') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zc_prefalk', NF90_DOUBLE,               &
+               &    time_dimid, zc_prefalk_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefalk_varid, 'long_name',           &
+               &    'Mean preformed alkalinity concentration') )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefalk_varid, 'units', 'kmol/m^3') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zt_prefdic', NF90_DOUBLE,               &
+               &    time_dimid, zt_prefdic_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefdic_varid, 'long_name',           &
+               &    'Total preformed DIC tracer') )
+          call nccheck( NF90_PUT_ATT(ncid, zt_prefdic_varid, 'units', 'kmol') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'zc_prefdic', NF90_DOUBLE,               &
+               &    time_dimid, zc_prefdic_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefdic_varid, 'long_name',           &
+               &    'Mean preformed DIC concentration') )
+          call nccheck( NF90_PUT_ATT(ncid, zc_prefdic_varid, 'units', 'kmol/m^3') )
+        endif
         if (use_cisonew) then
           call nccheck( NF90_DEF_VAR(ncid, 'zt_sco213', NF90_DOUBLE,                &
                &    time_dimid, zt_sco213_varid) )
@@ -1593,18 +1594,20 @@ contains
         call nccheck( NF90_INQ_VARID(ncid, "zc_fdust", zc_fdust_varid) )
         call nccheck( NF90_INQ_VARID(ncid, "zt_iron", zt_iron_varid) )
         call nccheck( NF90_INQ_VARID(ncid, "zc_iron", zc_iron_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zt_prefo2", zt_prefo2_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zc_prefo2", zc_prefo2_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zt_prefpo4", zt_prefpo4_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zc_prefpo4", zc_prefpo4_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zt_prefsilica", zt_prefsilica_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zc_prefsilica", zc_prefsilica_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zt_prefalk", zt_prefalk_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zc_prefalk", zc_prefalk_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zt_prefdic", zt_prefdic_varid) )
-        call nccheck( NF90_INQ_VARID(ncid, "zc_prefdic", zc_prefdic_varid) )
         call nccheck( NF90_INQ_VARID(ncid, "zt_dicsat", zt_dicsat_varid) )
         call nccheck( NF90_INQ_VARID(ncid, "zc_dicsat", zc_dicsat_varid) )
+        if (use_pref_tracers) then
+          call nccheck( NF90_INQ_VARID(ncid, "zt_prefo2", zt_prefo2_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zc_prefo2", zc_prefo2_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zt_prefpo4", zt_prefpo4_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zc_prefpo4", zc_prefpo4_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zt_prefsilica", zt_prefsilica_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zc_prefsilica", zc_prefsilica_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zt_prefalk", zt_prefalk_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zc_prefalk", zc_prefalk_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zt_prefdic", zt_prefdic_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "zc_prefdic", zc_prefdic_varid) )
+        endif
         if (use_cisonew) then
           call nccheck( NF90_INQ_VARID(ncid, "zt_sco213", zt_sco213_varid) )
           call nccheck( NF90_INQ_VARID(ncid, "zc_sco213", zc_sco213_varid) )
@@ -1778,30 +1781,32 @@ contains
            &    zocetratot(iiron), start = wrstart) )
       call nccheck( NF90_PUT_VAR(ncid, zc_iron_varid,                              &
            &    zocetratoc(iiron), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zt_prefo2_varid,                            &
-           &    zocetratot(iprefo2), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zc_prefo2_varid,                            &
-           &    zocetratoc(iprefo2), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zt_prefpo4_varid,                           &
-           &    zocetratot(iprefpo4), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zc_prefpo4_varid,                           &
-           &    zocetratoc(iprefpo4), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zt_prefsilica_varid,                        &
-           &    zocetratot(iprefsilica), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zc_prefsilica_varid,                        &
-           &    zocetratoc(iprefsilica), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zt_prefalk_varid,                           &
-           &    zocetratot(iprefalk), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zc_prefalk_varid,                           &
-           &    zocetratoc(iprefalk), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zt_prefdic_varid,                           &
-           &    zocetratot(iprefdic), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zc_prefdic_varid,                           &
-           &    zocetratoc(iprefdic), start = wrstart) )
       call nccheck( NF90_PUT_VAR(ncid, zt_dicsat_varid,                            &
            &    zocetratot(idicsat), start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, zc_dicsat_varid,                            &
-           &    zocetratoc(idicsat), start = wrstart) )
+      if (use_pref_tracers) then
+        call nccheck( NF90_PUT_VAR(ncid, zc_dicsat_varid,                            &
+             &    zocetratoc(idicsat), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zt_prefo2_varid,                            &
+             &    zocetratot(iprefo2), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zc_prefo2_varid,                            &
+             &    zocetratoc(iprefo2), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zt_prefpo4_varid,                           &
+             &    zocetratot(iprefpo4), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zc_prefpo4_varid,                           &
+             &    zocetratoc(iprefpo4), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zt_prefsilica_varid,                        &
+             &    zocetratot(iprefsilica), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zc_prefsilica_varid,                        &
+             &    zocetratoc(iprefsilica), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zt_prefalk_varid,                           &
+             &    zocetratot(iprefalk), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zc_prefalk_varid,                           &
+             &    zocetratoc(iprefalk), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zt_prefdic_varid,                           &
+             &    zocetratot(iprefdic), start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, zc_prefdic_varid,                           &
+             &    zocetratoc(iprefdic), start = wrstart) )
+      endif
       if (use_cisonew) then
         call nccheck( NF90_PUT_VAR(ncid, zt_sco213_varid,                            &
              &    zocetratot(isco213), start = wrstart) )

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -35,7 +35,7 @@ contains
     use mod_grid,       only: depths,plat,plon
     use mod_dia,        only: diafnm,sigmar1,iotype,ddm,depthslev,depthslev_bnds
     use mo_control_bgc, only: dtbgc,use_cisonew,use_AGG,use_CFC,use_natDIC,use_BROMO,              &
-                              use_sedbypass,use_BOXATM,use_M4AGO,use_extNcycle
+                              use_sedbypass,use_BOXATM,use_M4AGO,use_extNcycle,use_pref_tracers
     use mo_vgrid,       only: k0100,k0500,k1000,k2000,k4000
     use mo_param1_bgc,  only: ks
     use mod_nctools,    only: ncwrt1,ncdims,nctime,ncfcls,ncfopn,ncdimc,ncputr,ncputi,ncwrtr
@@ -324,13 +324,15 @@ contains
     call finlyr(jomegaa(iogrp),jdp(iogrp))
     call finlyr(jomegac(iogrp),jdp(iogrp))
     call finlyr(jn2o(iogrp),jdp(iogrp))
-    call finlyr(jprefo2(iogrp),jdp(iogrp))
     call finlyr(jo2sat(iogrp),jdp(iogrp))
-    call finlyr(jprefpo4(iogrp),jdp(iogrp))
-    call finlyr(jprefsilica(iogrp),jdp(iogrp))
-    call finlyr(jprefalk(iogrp),jdp(iogrp))
-    call finlyr(jprefdic(iogrp),jdp(iogrp))
     call finlyr(jdicsat(iogrp),jdp(iogrp))
+    if (use_pref_tracers) then
+      call finlyr(jprefo2(iogrp),jdp(iogrp))
+      call finlyr(jprefpo4(iogrp),jdp(iogrp))
+      call finlyr(jprefsilica(iogrp),jdp(iogrp))
+      call finlyr(jprefalk(iogrp),jdp(iogrp))
+      call finlyr(jprefdic(iogrp),jdp(iogrp))
+    endif
     if (use_cisonew) then
       call finlyr(jdic13(iogrp),jdp(iogrp))
       call finlyr(jdic14(iogrp),jdp(iogrp))
@@ -439,13 +441,15 @@ contains
     call msklvl(jlvlomegaa(iogrp),depths)
     call msklvl(jlvlomegac(iogrp),depths)
     call msklvl(jlvln2o(iogrp),depths)
-    call msklvl(jlvlprefo2(iogrp),depths)
     call msklvl(jlvlo2sat(iogrp),depths)
-    call msklvl(jlvlprefpo4(iogrp),depths)
-    call msklvl(jlvlprefsilica(iogrp),depths)
-    call msklvl(jlvlprefalk(iogrp),depths)
-    call msklvl(jlvlprefdic(iogrp),depths)
     call msklvl(jlvldicsat(iogrp),depths)
+    if (use_pref_tracers) then
+      call msklvl(jlvlprefo2(iogrp),depths)
+      call msklvl(jlvlprefpo4(iogrp),depths)
+      call msklvl(jlvlprefsilica(iogrp),depths)
+      call msklvl(jlvlprefalk(iogrp),depths)
+      call msklvl(jlvlprefdic(iogrp),depths)
+    endif
     if (use_cisonew) then
       call msklvl(jlvldic13(iogrp),depths)
       call msklvl(jlvldic14(iogrp),depths)
@@ -664,13 +668,15 @@ contains
     call wrtlyr(jomegaa(iogrp),      LYR_OMEGAA(iogrp),   1.,             0.,cmpflg,'omegaa')
     call wrtlyr(jomegac(iogrp),      LYR_OMEGAC(iogrp),   1.,             0.,cmpflg,'omegac')
     call wrtlyr(jn2o(iogrp),         LYR_N2O(iogrp),      1e3,            0.,cmpflg,'n2o')
-    call wrtlyr(jprefo2(iogrp),      LYR_PREFO2(iogrp),   1e3,            0.,cmpflg,'p_o2')
     call wrtlyr(jo2sat(iogrp),       LYR_O2SAT(iogrp),    1e3,            0.,cmpflg,'satoxy')
-    call wrtlyr(jprefpo4(iogrp),     LYR_PREFPO4(iogrp),  1e3,            0.,cmpflg,'p_po4')
-    call wrtlyr(jprefsilica(iogrp),  LYR_PREFSILICA(iogrp), 1e3,          0.,cmpflg,'p_silica')
-    call wrtlyr(jprefalk(iogrp),     LYR_PREFALK(iogrp),  1e3,            0.,cmpflg,'p_talk')
-    call wrtlyr(jprefdic(iogrp),     LYR_PREFDIC(iogrp),  1e3,            0.,cmpflg,'p_dic')
     call wrtlyr(jdicsat(iogrp),      LYR_DICSAT(iogrp),   1e3,            0.,cmpflg,'sat_dic')
+    if (use_pref_tracers) then
+      call wrtlyr(jprefo2(iogrp),      LYR_PREFO2(iogrp),   1e3,            0.,cmpflg,'p_o2')
+      call wrtlyr(jprefpo4(iogrp),     LYR_PREFPO4(iogrp),  1e3,            0.,cmpflg,'p_po4')
+      call wrtlyr(jprefsilica(iogrp),  LYR_PREFSILICA(iogrp), 1e3,          0.,cmpflg,'p_silica')
+      call wrtlyr(jprefalk(iogrp),     LYR_PREFALK(iogrp),  1e3,            0.,cmpflg,'p_talk')
+      call wrtlyr(jprefdic(iogrp),     LYR_PREFDIC(iogrp),  1e3,            0.,cmpflg,'p_dic')
+    endif
     if (use_cisonew) then
       call wrtlyr(jdic13(iogrp),       LYR_DIC13(iogrp),    1.e3,           0.,cmpflg,'dissic13')
       call wrtlyr(jdic14(iogrp),       LYR_DIC14(iogrp),    1.e3*c14fac,    0.,cmpflg,'dissic14')
@@ -762,13 +768,15 @@ contains
     call wrtlvl(jlvlomegaa(iogrp),   LVL_OMEGAA(iogrp),   rnacc,          0.,cmpflg,'omegaalvl')
     call wrtlvl(jlvlomegac(iogrp),   LVL_OMEGAC(iogrp),   rnacc,          0.,cmpflg,'omegaclvl')
     call wrtlvl(jlvln2o(iogrp),      LVL_N2O(iogrp),      rnacc*1e3,      0.,cmpflg,'n2olvl')
-    call wrtlvl(jlvlprefo2(iogrp),   LVL_PREFO2(iogrp),   rnacc*1e3,      0.,cmpflg,'p_o2lvl')
     call wrtlvl(jlvlo2sat(iogrp),    LVL_O2SAT(iogrp),    rnacc*1e3,      0.,cmpflg,'satoxylvl')
-    call wrtlvl(jlvlprefpo4(iogrp),  LVL_PREFPO4(iogrp),  rnacc*1e3,      0.,cmpflg,'p_po4lvl')
-    call wrtlvl(jlvlprefsilica(iogrp),LVL_PREFSILICA(iogrp), rnacc*1e3,   0.,cmpflg,'p_silicalvl')
-    call wrtlvl(jlvlprefalk(iogrp),  LVL_PREFALK(iogrp),  rnacc*1e3,      0.,cmpflg,'p_talklvl')
-    call wrtlvl(jlvlprefdic(iogrp),  LVL_PREFDIC(iogrp),  rnacc*1e3,      0.,cmpflg,'p_diclvl')
     call wrtlvl(jlvldicsat(iogrp),   LVL_DICSAT(iogrp),   rnacc*1e3,      0.,cmpflg,'sat_diclvl')
+    if (use_pref_tracers) then
+      call wrtlvl(jlvlprefo2(iogrp),   LVL_PREFO2(iogrp),   rnacc*1e3,      0.,cmpflg,'p_o2lvl')
+      call wrtlvl(jlvlprefpo4(iogrp),  LVL_PREFPO4(iogrp),  rnacc*1e3,      0.,cmpflg,'p_po4lvl')
+      call wrtlvl(jlvlprefsilica(iogrp),LVL_PREFSILICA(iogrp), rnacc*1e3,   0.,cmpflg,'p_silicalvl')
+      call wrtlvl(jlvlprefalk(iogrp),  LVL_PREFALK(iogrp),  rnacc*1e3,      0.,cmpflg,'p_talklvl')
+      call wrtlvl(jlvlprefdic(iogrp),  LVL_PREFDIC(iogrp),  rnacc*1e3,      0.,cmpflg,'p_diclvl')
+    endif
     if (use_cisonew) then
       call wrtlvl(jlvldic13(iogrp),    LVL_DIC13(iogrp),    rnacc*1.e3,     0.,cmpflg,'dissic13lvl')
       call wrtlvl(jlvldic14(iogrp),    LVL_DIC14(iogrp),    rnacc*1.e3*c14fac,0.,cmpflg,'dissic14lvl')
@@ -1019,13 +1027,15 @@ contains
     call inilyr(jomegaa(iogrp),0.)
     call inilyr(jomegac(iogrp),0.)
     call inilyr(jn2o(iogrp),0.)
-    call inilyr(jprefo2(iogrp),0.)
     call inilyr(jo2sat(iogrp),0.)
-    call inilyr(jprefpo4(iogrp),0.)
-    call inilyr(jprefsilica(iogrp),0.)
-    call inilyr(jprefalk(iogrp),0.)
-    call inilyr(jprefdic(iogrp),0.)
     call inilyr(jdicsat(iogrp),0.)
+    if (use_pref_tracers) then
+      call inilyr(jprefo2(iogrp),0.)
+      call inilyr(jprefpo4(iogrp),0.)
+      call inilyr(jprefsilica(iogrp),0.)
+      call inilyr(jprefalk(iogrp),0.)
+      call inilyr(jprefdic(iogrp),0.)
+    endif
     if (use_cisonew) then
       call inilyr(jdic13(iogrp),0.)
       call inilyr(jdic14(iogrp),0.)
@@ -1115,13 +1125,15 @@ contains
     call inilvl(jlvlomegaa(iogrp),0.)
     call inilvl(jlvlomegac(iogrp),0.)
     call inilvl(jlvln2o(iogrp),0.)
-    call inilvl(jlvlprefo2(iogrp),0.)
     call inilvl(jlvlo2sat(iogrp),0.)
-    call inilvl(jlvlprefpo4(iogrp),0.)
-    call inilvl(jlvlprefsilica(iogrp),0.)
-    call inilvl(jlvlprefalk(iogrp),0.)
-    call inilvl(jlvlprefdic(iogrp),0.)
     call inilvl(jlvldicsat(iogrp),0.)
+    if (use_pref_tracers) then
+      call inilvl(jlvlprefo2(iogrp),0.)
+      call inilvl(jlvlprefpo4(iogrp),0.)
+      call inilvl(jlvlprefsilica(iogrp),0.)
+      call inilvl(jlvlprefalk(iogrp),0.)
+      call inilvl(jlvlprefdic(iogrp),0.)
+    endif
     if (use_cisonew) then
       call inilvl(jlvldic13(iogrp),0.)
       call inilvl(jlvldic14(iogrp),0.)
@@ -1336,7 +1348,7 @@ contains
                               SDM_remin_sulf,jsediffnh4,jsediffn2o,jsediffno2,                     &
                               FLX_SEDIFFNH4,FLX_SEDIFFN2O,FLX_SEDIFFNO2
     use mo_control_bgc, only: use_cisonew,use_AGG,use_CFC,use_natDIC,use_BROMO,                    &
-                              use_sedbypass,use_BOXATM,use_extNcycle
+                              use_sedbypass,use_BOXATM,use_extNcycle,use_pref_tracers
 
     ! Arguments
     integer   :: iogrp,cmpflg
@@ -1645,20 +1657,22 @@ contains
          &   'omegac','OmegaC',' ','1',1)
     call ncdefvar3d(LYR_N2O(iogrp),cmpflg,'p',                                  &
          &   'n2o','N2O',' ','mol N2O m-3',1)
-    call ncdefvar3d(LYR_PREFO2(iogrp),cmpflg,'p',                               &
-         &   'p_o2','Preformed oxygen',' ','mol O2 m-3',1)
     call ncdefvar3d(LYR_O2SAT(iogrp),cmpflg,'p',                                &
          &   'satoxy','Saturated oxygen',' ','mol O2 m-3',1)
-    call ncdefvar3d(LYR_PREFPO4(iogrp),cmpflg,'p',                              &
-         &   'p_po4','Preformed phosphorus',' ','mol P m-3',1)
-    call ncdefvar3d(LYR_PREFSILICA(iogrp),cmpflg,'p',                           &
-       &   'p_silica','Preformed silica',' ','mol N m-3',1)
-    call ncdefvar3d(LYR_PREFALK(iogrp),cmpflg,'p',                              &
-         &   'p_talk','Preformed alkalinity',' ','eq m-3',1)
-    call ncdefvar3d(LYR_PREFDIC(iogrp),cmpflg,'p',                              &
-         &   'p_dic','Preformed DIC',' ','mol C m-3',1)
     call ncdefvar3d(LYR_DICSAT(iogrp),cmpflg,'p',                               &
          &   'sat_dic','Saturated DIC',' ','mol C m-3',1)
+    if (use_pref_tracers) then
+      call ncdefvar3d(LYR_PREFO2(iogrp),cmpflg,'p',                             &
+           &   'p_o2','Preformed oxygen',' ','mol O2 m-3',1)
+      call ncdefvar3d(LYR_PREFPO4(iogrp),cmpflg,'p',                            &
+           &   'p_po4','Preformed phosphorus',' ','mol P m-3',1)
+      call ncdefvar3d(LYR_PREFSILICA(iogrp),cmpflg,'p',                         &
+         &   'p_silica','Preformed silica',' ','mol N m-3',1)
+      call ncdefvar3d(LYR_PREFALK(iogrp),cmpflg,'p',                            &
+           &   'p_talk','Preformed alkalinity',' ','eq m-3',1)
+      call ncdefvar3d(LYR_PREFDIC(iogrp),cmpflg,'p',                            &
+           &   'p_dic','Preformed DIC',' ','mol C m-3',1)
+    endif
     if (use_cisonew) then
       call ncdefvar3d(LYR_DIC13(iogrp),cmpflg,'p',                              &
            &   'dissic13','Dissolved C13',' ','mol 13C m-3',1)
@@ -1826,20 +1840,22 @@ contains
          &   'omegaclvl','OmegaC',' ','1',2)
     call ncdefvar3d(LVL_N2O(iogrp),cmpflg,'p',                                  &
          &   'n2olvl','N2O',' ','mol N2O m-3',2)
-    call ncdefvar3d(LVL_PREFO2(iogrp),cmpflg,'p',                               &
-         &   'p_o2lvl','Preformed oxygen',' ','mol O2 m-3',2)
     call ncdefvar3d(LVL_O2SAT(iogrp),cmpflg,'p',                                &
          &   'satoxylvl','Saturated oxygen',' ','mol O2 m-3',2)
-    call ncdefvar3d(LVL_PREFPO4(iogrp),cmpflg,'p',                              &
-         &   'p_po4lvl','Preformed phosphorus',' ','mol P m-3',2)
-    call ncdefvar3d(LVL_PREFSILICA(iogrp),cmpflg,'p',                           &
-         &   'p_silicalvl','Preformed silica',' ','mol N m-3',2)
-    call ncdefvar3d(LVL_PREFALK(iogrp),cmpflg,'p',                              &
-         &   'p_talklvl','Preformed alkalinity',' ','eq m-3',2)
-    call ncdefvar3d(LVL_PREFDIC(iogrp),cmpflg,'p',                              &
-         &   'p_diclvl','Preformed DIC',' ','mol C m-3',2)
     call ncdefvar3d(LVL_DICSAT(iogrp),cmpflg,'p',                               &
          &   'sat_diclvl','Saturated DIC',' ','mol C m-3',2)
+    if (use_pref_tracers) then
+      call ncdefvar3d(LVL_PREFO2(iogrp),cmpflg,'p',                               &
+           &   'p_o2lvl','Preformed oxygen',' ','mol O2 m-3',2)
+      call ncdefvar3d(LVL_PREFPO4(iogrp),cmpflg,'p',                              &
+           &   'p_po4lvl','Preformed phosphorus',' ','mol P m-3',2)
+      call ncdefvar3d(LVL_PREFSILICA(iogrp),cmpflg,'p',                           &
+           &   'p_silicalvl','Preformed silica',' ','mol N m-3',2)
+      call ncdefvar3d(LVL_PREFALK(iogrp),cmpflg,'p',                              &
+           &   'p_talklvl','Preformed alkalinity',' ','eq m-3',2)
+      call ncdefvar3d(LVL_PREFDIC(iogrp),cmpflg,'p',                              &
+           &   'p_diclvl','Preformed DIC',' ','mol C m-3',2)
+    endif
     if (use_cisonew) then
       call ncdefvar3d(LVL_DIC13(iogrp),cmpflg,'p',                              &
            &   'dissic13lvl','Dissolved C13',' ','mol 13C m-3',2)

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -29,7 +29,8 @@ module mo_param1_bgc
 
   use mo_control_bgc, only: use_BROMO, use_AGG, use_WLIN, use_natDIC, use_CFC,                     &
                             use_cisonew, use_PBGC_OCNP_TIMESTEP, use_PBGC_CK_TIMESTEP,             &
-                            use_FB_BGC_OCE, use_BOXATM, use_sedbypass, use_extNcycle
+                            use_FB_BGC_OCE, use_BOXATM, use_sedbypass, use_extNcycle,              &
+                            use_pref_tracers
   implicit none
   public
 
@@ -58,11 +59,14 @@ module mo_param1_bgc
   integer, protected :: idms
   integer, protected :: iiron
   integer, protected :: ifdust
+  integer, protected :: idicsat
+
+  ! Indices for preformed tracers
+  integer, protected :: i_pref
   integer, protected :: iprefo2
   integer, protected :: iprefpo4
   integer, protected :: iprefalk
   integer, protected :: iprefdic
-  integer, protected :: idicsat
   integer, protected :: iprefsilica
 
   ! Indices for C-isotope tracers
@@ -238,12 +242,12 @@ contains
     use mo_control_bgc, only: bgc_namelist,get_bgc_namelist, io_stdo_bgc
     use mo_control_bgc, only: use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,           &
                               use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,           &
-                              use_FB_BGC_OCE, use_BOXATM,use_extNcycle
+                              use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers
     integer :: iounit
 
     namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &
                             use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,             &
-                            use_FB_BGC_OCE,use_BOXATM,use_extNcycle
+                            use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers
 
     io_stdo_bgc = lp              !  standard out.
 
@@ -259,7 +263,7 @@ contains
     endif
 
     ! Tracer indices
-    i_base   = 23
+    i_base   = 18
     isco212  = 1
     ialkali  = 2
     iphosph  = 3
@@ -277,12 +281,7 @@ contains
     idms     = 15
     iiron    = 16
     ifdust   = 17
-    iprefo2  = 18
-    iprefpo4 = 19
-    iprefalk = 20
-    iprefdic = 21
-    idicsat  = 22
-    iprefsilica = 23
+    idicsat  = 18
     if (use_cisonew) then
       i_iso    = 12
       isco213  = i_base+1
@@ -359,9 +358,24 @@ contains
       iano2  = -1
       ianh4  = -1
     endif
+    if (use_pref_tracers) then
+      i_pref      = 5
+      iprefo2     = i_base+i_iso+i_cfc+i_agg+i_nat_dic+i_bromo+i_extn+1
+      iprefpo4    = i_base+i_iso+i_cfc+i_agg+i_nat_dic+i_bromo+i_extn+2
+      iprefalk    = i_base+i_iso+i_cfc+i_agg+i_nat_dic+i_bromo+i_extn+3
+      iprefdic    = i_base+i_iso+i_cfc+i_agg+i_nat_dic+i_bromo+i_extn+4
+      iprefsilica = i_base+i_iso+i_cfc+i_agg+i_nat_dic+i_bromo+i_extn+5
+    else
+      i_pref      = 0
+      iprefo2     = -1
+      iprefpo4    = -1
+      iprefalk    = -1
+      iprefdic    = -1
+      iprefsilica = -1
+    endif
 
     ! total number of advected tracers
-    nocetra=i_base+i_iso+i_cfc+i_agg+i_nat_dic +i_bromo+i_extn
+    nocetra=i_base+i_iso+i_cfc+i_agg+i_nat_dic +i_bromo+i_extn+i_pref
 
     ! ATMOSPHERE
     i_base_atm=5


### PR DESCRIPTION
@JorgSchwinger and @TomasTorsvik , as suggested in #340 , preformed tracers could be made optional to enable HR runs without them. With this PR, this is achieved, while the default is still to run iHAMOCC with preformed tracers.

@matsbn , the new introduced switch `use_pref_tracers` via `xmlchange HAMOCC_PREF_TRACERS=FALSE` might be of interest for you, in the case that you want to run HR simulations including iHAMOCC, while wanting to reduce the BGC costs.