### PR TITLE
Fix namelist creating for multiple instances

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -38,6 +38,8 @@ def create_dimmod(case):
     blom_vcoord = case.get_value("BLOM_VCOORD")
     ntasks_ocn = case.get_value("NTASKS_OCN")
     objroot = case.get_value("OBJROOT")
+    if case.get_value("NINST_OCN") > 1:
+        ntasks_ocn = case.get_value("NTASKS_PER_INST_OCN")
 
     gridconf_dir = os.path.join(comp_root_dir_ocn, "bld", ocn_grid)
     kdm_file = os.path.join(gridconf_dir, "kdm." + blom_vcoord)

--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -36,10 +36,8 @@ def create_dimmod(case):
     comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
     ocn_grid = case.get_value("OCN_GRID")
     blom_vcoord = case.get_value("BLOM_VCOORD")
-    ntasks_ocn = case.get_value("NTASKS_OCN")
+    ntasks_ocn = case.get_value("NTASKS_PER_INST_OCN")
     objroot = case.get_value("OBJROOT")
-    if case.get_value("NINST_OCN") > 1:
-        ntasks_ocn = case.get_value("NTASKS_PER_INST_OCN")
 
     gridconf_dir = os.path.join(comp_root_dir_ocn, "bld", ocn_grid)
     kdm_file = os.path.join(gridconf_dir, "kdm." + blom_vcoord)

--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -36,7 +36,10 @@ def create_dimmod(case):
     comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
     ocn_grid = case.get_value("OCN_GRID")
     blom_vcoord = case.get_value("BLOM_VCOORD")
-    ntasks_ocn = case.get_value("NTASKS_PER_INST_OCN")
+    if case.get_value("NINST_OCN") > 1:
+        ntasks_ocn = case.get_value("NTASKS_OCN")
+    else:
+        ntasks_ocn = case.get_value("NTASKS_PER_INST_OCN")
     objroot = case.get_value("OBJROOT")
 
     gridconf_dir = os.path.join(comp_root_dir_ocn, "bld", ocn_grid)

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -97,7 +97,6 @@ def buildnml(case, caseroot, compname):
     #--------------------------
 
     xml_fil = os.path.join(srcroot,"components","blom","cime_config","namelist_definition_blom.xml")
-    pg_blom = OcnInParamGen.from_namelist_xml(xml_fil)
 
     #------------------------
     # Loop over all instances:
@@ -115,6 +114,7 @@ def buildnml(case, caseroot, compname):
         # Remove old input data:
         #----------------------
 
+        pg_blom = OcnInParamGen.from_namelist_xml(xml_fil)
         if os.path.isfile(input_data_list):
             os.remove(input_data_list)
 


### PR DESCRIPTION
Get correct NTASK_OCN in buildcpp, which will be NINST_OCN times when run in multiple instance.
Move pg_blom into instance loop to reset it in every instance.