### PR TITLE
always obtain ndep from datm or cam using cmeps/cdeps

### DIFF
--- a/cesm/mod_cesm.F90
+++ b/cesm/mod_cesm.F90
@@ -242,7 +242,7 @@ contains
         call ncdefvar('atmbrf_da', 'x y', ndouble, 8)
         call ncdefvar('atmn2o_da', 'x y', ndouble, 8)
         call ncdefvar('atmnh3_da', 'x y', ndouble, 8)
-        call ncdefvar('atmnoydep_da', 'x y', ndouble, 8)
+        call ncdefvar('atmnhxdep_da', 'x y', ndouble, 8)
         call ncdefvar('atmnoydep_da', 'x y', ndouble, 8)
         call ncdefvar('ztx_da', 'x y', ndouble, 8)
         call ncdefvar('mty_da', 'x y', ndouble, 8)
@@ -301,8 +301,6 @@ contains
         call ncwrtr('mty_da', 'x y', mty_da(1 - nbdy, 1 - nbdy, l2ci), &
              iv, 1, 1._r8, 0._r8, 8)
         call ncfcls
-        call xcstop('(getfrc_cesm)')
-        stop '(getfrc_cesm)'
       end if
 
       if (csdiag) then

--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -89,9 +89,6 @@ def buildcpp(case):
     if pio_typename == "pnetcdf":
         blom_cppdefs = blom_cppdefs + " -DPNETCDF"
 
-    if ocn_grid in ["tnx2v1", "tnx1.5v1", "tnx1v1", "tnx1v3", "tnx1v4", "tnx0.5v1", "tnx0.25v1", "tnx0.25v3", "tnx0.25v4", "tnx0.125v4"]:
-        blom_cppdefs = blom_cppdefs + " -DARCTIC"
-
     if ocn_grid in ["gx1v5", "gx1v6", "tnx1v1", "tnx1v3", "tnx1v4", "tnx0.5v1", "tnx0.25v1", "tnx0.25v3", "tnx0.25v4", "tnx0.125v4"]:
         blom_cppdefs = blom_cppdefs + " -DLEVITUS2X"
 

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -121,23 +121,24 @@
     <valid_values>UNSET,1850,2000,hist,ssp119,ssp126,ssp245,ssp370,ssp434,ssp460,ssp534os,ssp585</valid_values>
     <default_value>1850</default_value>
     <values>
-      <value compset="HIST_CAM60%NORESM.*_BLOM%ECO"    >hist</value>
-      <value compset="20TR_DATM.*_BLOM%ECO"            >hist</value>
-      <value compset="2000_CAM60%NORESM.*_BLOM%ECO"    >2000</value>
-      <value compset="SSP119_CAM60%NORESM.*_BLOM%ECO"  >ssp119</value>
-      <value compset="SSP126_CAM60%NORESM.*_BLOM%ECO"  >ssp126</value>
-      <value compset="SSP245_CAM60%NORESM.*_BLOM%ECO"  >ssp245</value>
-      <value compset="SSP370_CAM60%NORESM.*_BLOM%ECO"  >ssp370</value>
-      <value compset="SSP370LOWNTCF_CAM60%NORESM.*_BLOM%ECO"      >ssp370</value>
-      <value compset="SSP370REFGHGLOWNTCF_CAM60%NORESM.*_BLOM%ECO">ssp370</value>
-      <value compset="SSP434_CAM60%NORESM.*_BLOM%ECO"  >ssp434</value>
-      <value compset="SSP460_CAM60%NORESM.*_BLOM%ECO"  >ssp460</value>
-      <value compset="SSP534_CAM60%NORESM.*_BLOM%ECO"  >ssp534os</value>
-      <value compset="SSP585_CAM60%NORESM.*_BLOM%ECO"  >ssp585</value>
+      <value compset="1850_.*_BLOM%ECO"   >1850</value>
+      <value compset="2000_.*_BLOM%ECO"   >2000</value>
+      <value compset="HIST_.*_BLOM%ECO"   >hist</value>
+      <value compset="20TR_.*_BLOM%ECO"   >hist</value>
+      <value compset="SSP119_.*_BLOM%ECO" >ssp119</value>
+      <value compset="SSP126_.*_BLOM%ECO" >ssp126</value>
+      <value compset="SSP245_.*_BLOM%ECO" >ssp245</value>
+      <value compset="SSP370_.*_BLOM%ECO" >ssp370</value>
+      <value compset="SSP434_.*_BLOM%ECO" >ssp434</value>
+      <value compset="SSP460_.*_BLOM%ECO" >ssp460</value>
+      <value compset="SSP534_.*_BLOM%ECO" >ssp534os</value>
+      <value compset="SSP585_.*_BLOM%ECO" >ssp585</value>
+      <value compset="SSP370.*_BLOM%ECO"  >ssp370</value>
      </values>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Scenario for nitrogen deposition data. Requires module ecosys</desc>
+    <desc>Scenario for nitrogen deposition data. Requires module ecosys.
+    Not used when coupling with nuopc-cmeps</desc>
   </entry>
 
   <entry id="HAMOCC_EXTNCYCLE">
@@ -163,7 +164,8 @@
     </values>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Nitrogen deposition coupled from atmosphere. Requires module ecosys and extncycle</desc>
+    <desc>Nitrogen deposition coupled from atmosphere. Requires module ecosys and extncycle.
+    Not used when coupling with nuopc-cmeps</desc>
   </entry>
 
   <entry id="HAMOCC_N2OC">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3839,6 +3839,18 @@
    <desc>File name (incl. full path) for atmopheric N-deposition data</desc>
   </entry>
 
+  <entry id="use_nuopc_ndep">
+    <type>logical</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>.false.</value>
+      <value comp_interface="nuopc">.true.</value>
+    </values>
+    <desc>if .true., use NUOPC to obtain NDEP (always imported to model) and ignore the
+    settings of do_ndep_coupled and ndepfile, whereas the setting of do_ndep is still used</desc>
+  </entry>
+
   <entry id="do_ndep_coupled" modify_via_xml="HAMOCC_ATMNDEPC">
     <type>logical</type>
     <category>bgcnml</category>
@@ -8760,17 +8772,6 @@
       <value comp_interface="nuopc">.true.</value>
     </values>
     <desc>if .true., use NUOPC stream relaxation capability</desc>
-  </entry>
-
-  <entry id="use_nuopc_ndep">
-    <type>logical</type>
-    <category>limits</category>
-    <group>limits</group>
-    <values>
-      <value>.false.</value>
-      <value comp_interface="nuopc">.true.</value>
-    </values>
-    <desc>if .true., use NUOPC to obtain NDEP (always imported to model) </desc>
   </entry>
 
   <!-- =========================  -->

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -892,6 +892,26 @@
     <desc>0 = netcdf, 1 = pnetcdf</desc>
   </entry>
 
+  <entry id="use_diag">
+    <type>logical</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.false.</value>
+    </values>
+    <desc>optionally turn on additional diagnostics</desc>
+  </entry>
+
+  <entry id="use_arctic">
+    <type>logical</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.true.</value>
+    </values>
+    <desc>if region includes arctic ocean</desc>
+  </entry>
+
   <!-- ========================= -->
   <!-- namelist group: vcoord -->
   <!-- ========================= -->
@@ -6040,7 +6060,7 @@
       <value is_test="yes">0,0,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>AMELIST FOR DIAGNOSTIC iHAMOCC OUTPUT</desc>
+    <desc>namelist for diagnostic iHAMOCC output</desc>
   </entry>
 
   <entry id="flx_car0100">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3841,8 +3841,8 @@
 
   <entry id="use_nuopc_ndep">
     <type>logical</type>
-    <category>bgcnml</category>
-    <group>bgcnml</group>
+    <category>config_bgc</category>
+    <group>config_bgc</group>
     <values>
       <value>.false.</value>
       <value comp_interface="nuopc">.true.</value>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -636,17 +636,6 @@
     </desc>
   </entry>
 
-  <entry id="use_stream_relaxation">
-    <type>logical</type>
-    <category>limits</category>
-    <group>limits</group>
-    <values>
-      <value>.false.</value>
-      <value comp_interface="nuopc">.true.</value>
-    </values>
-    <desc>if .true., use NUOPC stream relaxation capability</desc>
-  </entry>
-
   <entry id="trxday">
     <type>real</type>
     <category>limits</category>
@@ -8736,6 +8725,32 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
     <desc>(ssster) [mol m-3]</desc>
+  </entry>
+
+  <!-- =========================  -->
+  <!-- namelist group: forcing fields using nuopc -->
+  <!-- =========================  -->
+
+  <entry id="use_stream_relaxation">
+    <type>logical</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.false.</value>
+      <value comp_interface="nuopc">.true.</value>
+    </values>
+    <desc>if .true., use NUOPC stream relaxation capability</desc>
+  </entry>
+
+  <entry id="use_nuopc_ndep">
+    <type>logical</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>.false.</value>
+      <value comp_interface="nuopc">.true.</value>
+    </values>
+    <desc>if .true., use NUOPC to obtain NDEP (always imported to model) </desc>
   </entry>
 
   <!-- =========================  -->

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3847,19 +3847,7 @@
       <value>.false.</value>
       <value comp_interface="nuopc">.true.</value>
     </values>
-    <desc>if .true., use NUOPC to obtain NDEP (always imported to model) and ignore the
-    settings of do_ndep_coupled and ndepfile, whereas the setting of do_ndep is still used</desc>
-  </entry>
-
-  <entry id="do_ndep_coupled" modify_via_xml="HAMOCC_ATMNDEPC">
-    <type>logical</type>
-    <category>bgcnml</category>
-    <group>bgcnml</group>
-    <values>
-      <value>.false.</value>
-      <value blom_n_deposition="yes" hamocc_atmndepc="yes" hamocc_extncycle="yes">.true.</value>
-    </values>
-    <desc>Switch to couple nitrogen deposition. Requires do_ndep.</desc>
+    <desc>if .true., use NUOPC to obtain NDEP (always imported to model).</desc>
   </entry>
 
   <entry id="do_n2onh3_coupled" modify_via_xml="HAMOCC_N2OC">

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -173,7 +173,7 @@
 ! CWMI     : Array of grid cell i-indices (i)
 ! CWMJ     : Array of grid cell j-indices (i)
 ! CWMWTH   : Array of modified grid cell widths (m) (f)
-! 
+!
 !===========================================================================
 ! NAMELIST FOR MERIDIONAL OVERTURNING AND FLUX DIAGNOSTICS
 !
@@ -188,7 +188,7 @@
 !              for each region (i)
 ! MER_MINLAT : Minimum latitude to be considered for each region (f)
 ! MER_MAXLAT : Maximum latitude to be considered for each region (f)
-! 
+!
 !===========================================================================
 ! NAMELIST FOR SECTION TRANSPORT DIAGNOSTICS
 !
@@ -196,7 +196,7 @@
 !
 ! SEC_SIFILE : Name of file containing section specification for section
 !              transport computation (a)
-! 
+!
 !===========================================================================
 ! IO-NAMELIST FOR DIAGNOSTIC OUTPUT
 !
@@ -230,10 +230,10 @@
 !   MSC_     - miscellanous, non-gridded fields
 !
 ! Global parameters:
-!   FNAMETAG - tag used in file name (c10) 
-!   AVEPERIO - average period in days (i) 
-!   FILEFREQ - how often to start a new file in days (i) 
-!   COMPFLAG - switch for compressed/uncompressed output (i) 
+!   FNAMETAG - tag used in file name (c10)
+!   AVEPERIO - average period in days (i)
+!   FILEFREQ - how often to start a new file in days (i)
+!   COMPFLAG - switch for compressed/uncompressed output (i)
 !   NCFORMAT - netcdf format (valid arguments are 0 for classic,
 !              1 for 64-bit offset and 2 for netcdf4/hdf5 format)
 !
@@ -380,13 +380,12 @@
 !
 ! ATM_CO2     : Atmospheric CO2 concentration [ppmv]
 ! FEDEPFILE   : File name (incl. full path) for iron (dust) deposition data
-! SWACLIMFILE : File name (incl. full path) for swa climatology field (needed 
+! SWACLIMFILE : File name (incl. full path) for swa climatology field (needed
 !                if bromoform scheme is activated)
 ! DO_RIVINPT  : Logical switch to activate riverine input
 ! RIVINFILE   : File name (incl. full path) for riverine input data
 ! DO_NDEP     : Logical switch to activate N-deposition
-! DO_NDEP_COUPLED: Logical to apply N-deposition fluxes received from the atmosphere (true=atm, false=clim), requires DO_NDEP=TRUE
-! NDEPFILE    : File name (incl. full path) for atmopheric N-deposition data
+! NDEPFILE    : File name (incl. full path) for atmopheric N-deposition data (not used for coupling to cmeps)
 ! DO_N2ONH3_COUPLED: Logical switch for interactive coupling of N2O and NH3 fluxes (true=atm, false=fix atmospheric value)
 ! DO_SEDSPINUP: Logical switch to activate sediment spin-up
 ! SEDSPIN_YR_S: Start year for sediment spinup
@@ -398,21 +397,21 @@
 ! PI_PH_FILE  : File name (incl. full path) for surface PI pH input data.
 ! use_M4AGO     : Switch for M4AGO settling scheme
 ! LEUPHOTIC_CYA : Switch to perform bluefix (cyanobacteria) only in the euphotic zone
-! L_3DVARSEDPOR : Logical switch to enable lon-lat-depth variable sediment porosity (as opposed to default: only depth) 
+! L_3DVARSEDPOR : Logical switch to enable lon-lat-depth variable sediment porosity (as opposed to default: only depth)
 ! SEDPORFILE  : File name (incl. full path) for sediment porosity
 !
 !===========================================================================
 ! NAMELIST BGCPARAMS FOR iHAMOCC-BGC PARAMETERS (DEVELOPERS ONLY)
-! 
+!
 ! CONTENTS: EMPTY BY DEFAULT
 !           FOR ADJUSTABLE PARAMETERS, SEE CODE
-! 
+!
 !===========================================================================
 ! NAMELIST BGCOAFX FOR ALKALINIZATION SCENARIO
 !
 ! CONTENTS:
 !
-! OALKSCEN      : Name of alkalinization scenario ('const', 'ramp', or 'file') 
+! OALKSCEN      : Name of alkalinization scenario ('const', 'ramp', or 'file')
 ! OALKFILE      : Full path of the input file for the alkalinization scenario 'file'
 ! ADDALK        : Pmol alkalinity/yr added in 'const' or 'ramp' scenarios
 ! CDRMIP_LATMAX : Max latitude where alkalinity is added in 'const' or 'ramp' scenarios
@@ -434,10 +433,10 @@
 !   BUR_     - 2d fields of sediment burial
 !
 ! Global parameters:
-!   FNAMETAG - tag used in file name (c10) 
-!   AVEPERIO - average period in days (i) 
-!   FILEFREQ - how often to start a new file in days (i) 
-!   COMPFLAG - switch for compressed/uncompressed output (i) 
+!   FNAMETAG - tag used in file name (c10)
+!   AVEPERIO - average period in days (i)
+!   FILEFREQ - how often to start a new file in days (i)
+!   COMPFLAG - switch for compressed/uncompressed output (i)
 !   NCFORMAT - netcdf format (valid arguments are 0 for classic,
 !              1 for 64-bit offset and 2 for netcdf4/hdf5 format)
 !   INVENTORY- how often to write an inventory of tracers to ocean
@@ -487,7 +486,7 @@
 !   PHOSY          - Primary production (pp) [mol C m-3 s-1]
 !   CO3            - Carbonate ions (co3) [mol C m-3]
 !   N2O            - Nitrous oxide concentration [mol N2O m-3]
-!   NITR_NH4       - nitrification rate on NH4 [mol NH4 m-3 s-1] - extended N cycle only   
+!   NITR_NH4       - nitrification rate on NH4 [mol NH4 m-3 s-1] - extended N cycle only
 !   NITR_NO2       - nitrification rate on NO2 [mol NO2 m-3 s-1] - extended N cycle only
 !   NITR_N2O_PROD  - N2O production rate during nitrification on NH4 [mol N2O m-3 s-1] - ext. N cycle only
 !   NITR_NH4_OM    - detritus production during nitrification on NH4 [mol P m-3 s-1] - ext. N cycle only
@@ -498,9 +497,9 @@
 !   DNRA_NO2       - DNRA on NO2 [mol NO2 m-3 s-1] - ext. N cycle only
 !   ANMX_N2_PROD   - anammox N2 production [mol N2 m-3 s-1] - ext. N cycle only
 !   ANMX_OM_PROD   - anammox detritus production [mol P m-3 s-1] - ext. N cycle only
-!   PHOSY_NH4      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only 
-!   PHOSY_NO3      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only 
-!   REMIN_AEROB    - aerob remineralization rate (sev. sources) [mol NH4 m-3 s-1] - ext. N cycle only 
+!   PHOSY_NH4      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only
+!   PHOSY_NO3      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only
+!   REMIN_AEROB    - aerob remineralization rate (sev. sources) [mol NH4 m-3 s-1] - ext. N cycle only
 !   REMIN_SULF     - sulfate-based remin rate on det [mol P m-3 s-1] - ext. N cycle only
 !   AGG_WS         - M4AGO aggregate mean settling velocity [m/d]
 !   DYNVIS         - molecular dynamic viscosity of sea water [kg m-1 s-1]
@@ -549,8 +548,8 @@
 !   PCO2M          - Surface PCO2 under moist air assumption [uatm]
 !   KWCO2          - Piston velocity (kwco2)  [m s-1]
 !   KWCO2KHM       - Piston velocity times solubility (kwco2*kh; moist air) [m s-1 mol kg-1 uatm-1]
-!   CO2KH          - CO2 solubility under dry air assumption (khd) [mol kg-1 atm-1] 
-!   CO2KHM         - CO2 solubility under moist air assumption (kh) [mol kg-1 atm-1] 
+!   CO2KH          - CO2 solubility under dry air assumption (khd) [mol kg-1 atm-1]
+!   CO2KHM         - CO2 solubility under moist air assumption (kh) [mol kg-1 atm-1]
 !   CO2FXD         - Downward CO2 flux (co2fxd) [kg C m-2 s-1]
 !   CO2FXU         - Upward CO2 flux (co2fxu) [kg C m-2 s-1]
 !   NIFLUX         - Nitrogen flux (fgn2) [mol N2 m-2 s-1]
@@ -608,7 +607,7 @@
 !   BURSSSC12      - burial fluxes of calcium carbonate [mol Ca m-2 s-1]
 !   BURSSSSIL      - burial fluxes of silicate [mol Si m-2 s-1]
 !   BURSSSTER      - burial fluxes of clay [g m-2 s-1]
-!   
+!
 ! Sediment fields (SDM)
 !   POWAIC         - (powdic) [mol C m-3]
 !   POWAAL         - (powalk) [eq m-3]
@@ -620,7 +619,7 @@
 !   POWNH4         - (pownh4) [mol NH4 m-3] - extended N cycle only
 !   POWN2O         - (pown2o) [mol N2O m-3] - extended N cycle only
 !   POWNO2         - (powno2) [mol NO2 m-3] - extended N cycle only
-!   NITR_NH4       - nitrification rate on NH4 [mol NH4 m-3 s-1] - extended N cycle only   
+!   NITR_NH4       - nitrification rate on NH4 [mol NH4 m-3 s-1] - extended N cycle only
 !   NITR_NO2       - nitrification rate on NO2 [mol NO2 m-3 s-1] - extended N cycle only
 !   NITR_N2O_PROD  - N2O production rate during nitrification on NH4 [mol N2O m-3 s-1] - ext. N cycle only
 !   NITR_NH4_OM    - detritus production during nitrification on NH4 [mol P m-3 s-1] - ext. N cycle only
@@ -631,9 +630,9 @@
 !   DNRA_NO2       - DNRA on NO2 [mol NO2 m-3 s-1] - ext. N cycle only
 !   ANMX_N2_PROD   - anammox N2 production [mol N2 m-3 s-1] - ext. N cycle only
 !   ANMX_OM_PROD   - anammox detritus production [mol P m-3 s-1] - ext. N cycle only
-!   PHOSY_NH4      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only 
-!   PHOSY_NO3      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only 
-!   REMIN_AEROB    - aerob remineralization rate (sev. sources) [mol NH4 m-3 s-1] - ext. N cycle only 
+!   PHOSY_NH4      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only
+!   PHOSY_NO3      - PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only
+!   REMIN_AEROB    - aerob remineralization rate (sev. sources) [mol NH4 m-3 s-1] - ext. N cycle only
 !   REMIN_SULF     - sulfate-based remin rate on det [mol P m-3 s-1] - ext. N cycle only
 !   SSSO12         - (ssso12) [mol m-3]
 !   SSSSIL         - (ssssil) [mol Si m-3]

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -889,8 +889,8 @@ contains
                ficem_da(i,j,l2ci) = fldlist(index_Si_ifrac)%dataptr(n)
 
                ! Nitrogen deposition [kg m-2 s-1].
-               atmnhxdep_da(i,j,l2ci) = fldlist(index_Faxa_ndep)%dataptr2d(n,1)*afac
-               atmnoydep_da(i,j,l2ci) = fldlist(index_Faxa_ndep)%dataptr2d(n,2)*afac
+               atmnhxdep_da(i,j,l2ci) = fldlist(index_Faxa_ndep)%dataptr2d(1,n)*afac
+               atmnoydep_da(i,j,l2ci) = fldlist(index_Faxa_ndep)%dataptr2d(2,n)*afac
             endif
 
          enddo

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -43,6 +43,7 @@ module ocn_import_export
                              rnf_da, rfi_da, fmltfz_da, sfl_da, ztx_da, mty_da, &
                              ustarw_da, slp_da, abswnd_da, ficem_da, lamult_da, &
                              lasl_da, ustokes_da, vstokes_da, atmco2_da, &
+                             atmnhxdep_da, atmnoydep_da, &
                              l1ci, l2ci
    use mod_utility,    only: util1, util2
    use mod_checksum,   only: csdiag, chksummsk
@@ -142,6 +143,7 @@ module ocn_import_export
         index_Faxa_lwdn   = -1, &
         index_Faxa_snow   = -1, &
         index_Faxa_rain   = -1, &
+        index_Faxa_ndep   = -1, &
         index_Sa_pslv     = -1, &
         index_Sa_co2diag  = -1, &
         index_Sa_co2prog  = -1, &
@@ -269,6 +271,8 @@ contains
      call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_lwdn' , index_Faxa_lwdn)
      call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_snow' , index_Faxa_snow)
      call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_rain' , index_Faxa_rain)
+     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_ndep' , index_Faxa_ndep, &
+          ungridded_lbound=1, ungridded_ubound=2)
      if (flds_co2a .or. flds_co2c) then
         call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_co2diag' ,index_Sa_co2diag)
         call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_co2prog', index_Sa_co2prog)
@@ -884,6 +888,9 @@ contains
                ! Ice fraction [].
                ficem_da(i,j,l2ci) = fldlist(index_Si_ifrac)%dataptr(n)
 
+               ! Nitrogen deposition [kg m-2 s-1].
+               atmnhxdep_da(i,j,l2ci) = fldlist(index_Faxa_ndep)%dataptr2d(n,1)*afac
+               atmnoydep_da(i,j,l2ci) = fldlist(index_Faxa_ndep)%dataptr2d(n,2)*afac
             endif
 
          enddo
@@ -901,6 +908,8 @@ contains
          call xctilr(swa_da(1-nbdy,1-nbdy,l2ci), 1,1, 0,0, halo_ps)
          call xctilr(nsf_da(1-nbdy,1-nbdy,l2ci), 1,1, 0,0, halo_ps)
          call xctilr(hmlt_da(1-nbdy,1-nbdy,l2ci), 1,1, 0,0, halo_ps)
+         call xctilr(atmnhxdep_da(1-nbdy,1-nbdy,l2ci), 1,1, 0,0, halo_ps)
+         call xctilr(atmnoydep_da(1-nbdy,1-nbdy,l2ci), 1,1, 0,0, halo_ps)
       endif
 
       call fill_global(mval, fval, halo_ps, slp_da(1-nbdy,1-nbdy,l2ci))
@@ -1034,6 +1043,8 @@ contains
          call chksummsk(abswnd_da(1-nbdy,1-nbdy,l2ci),ip,1,'abswnd')
          call chksummsk( ficem_da(1-nbdy,1-nbdy,l2ci),ip,1,'ficem')
          call chksummsk(atmco2_da(1-nbdy,1-nbdy,l2ci),ip,1,'atmco2')
+         call chksummsk(atmnhxdep_da(1-nbdy,1-nbdy,l2ci),ip,1,'atmnhxdep')
+         call chksummsk(atmnoydep_da(1-nbdy,1-nbdy,l2ci),ip,1,'atmnoydep')
       endif
 
       if (first_call) then

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -54,7 +54,6 @@ module mo_control_bgc
   ! Variables set via namelist bgcnml
   logical           :: l_3Dvarsedpor          = .false. ! apply spatially variable sediment porosity
   logical           :: do_ndep                = .true.  ! apply n-deposition
-  logical           :: do_ndep_coupled        = .false. ! for coupled simulations, use field provided by atmosphere
   logical           :: do_n2onh3_coupled      = .false. ! for coupled simulations, use field provided by atmosphere
   logical           :: do_rivinpt             = .true.  ! apply riverine input
   logical           :: do_sedspinup           = .false. ! apply sediment spin-up

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -82,6 +82,7 @@ module mo_control_bgc
   logical           :: use_BOXATM             = .false.
   logical           :: use_sedbypass          = .false.
   logical           :: use_extNcycle          = .false.
+  logical           :: use_nuopc_ndep         = .false.
   logical           :: use_pref_tracers       = .true.
 
 contains

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -38,6 +38,7 @@ contains
     use mod_time,       only: date,baclin
     use mod_xc,         only: ii,jj,kk,idm,jdm,kdm,nbdy,isp,ifp,ilp,mnproc,lp,xchalt
     use mod_grid,       only: plon,plat
+    use mod_forcing,    only: use_nuopc_ndep
     use mod_tracers,    only: ntrbgc,ntr,itrbgc,trc
     use mo_control_bgc, only: bgc_namelist,get_bgc_namelist,do_ndep,do_rivinpt,do_oalk,            &
                               do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                 &
@@ -198,7 +199,9 @@ contains
     ! --- Initialise reading of input data (dust, n-deposition, river, etc.)
     !
     call ini_read_fedep(idm,jdm,omask)
-    call ini_read_ndep(idm,jdm)
+    if (.not. use_nuopc_ndep) then
+       call ini_read_ndep(idm,jdm)
+    end if
     call ini_read_rivin(idm,jdm,omask)
     call ini_read_oafx(idm,jdm,bgc_dx,bgc_dy,plat,omask)
     if (use_BROMO) then

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -43,7 +43,7 @@ contains
                               do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                 &
                               dtb,dtbgc,io_stdo_bgc,ldtbgc,                                        &
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
-                              do_ndep_coupled,lkwrbioz_off,do_n2onh3_coupled,                      &
+                              lkwrbioz_off,do_n2onh3_coupled,                                      &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
                               use_nuopc_ndep
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
@@ -82,7 +82,7 @@ contains
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,swaclimfile,       &
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
-         &            do_ndep_coupled,do_n2onh3_coupled,lkwrbioz_off
+         &            do_n2onh3_coupled,lkwrbioz_off
     !
     ! --- Set io units and some control parameters
     !

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -38,14 +38,14 @@ contains
     use mod_time,       only: date,baclin
     use mod_xc,         only: ii,jj,kk,idm,jdm,kdm,nbdy,isp,ifp,ilp,mnproc,lp,xchalt
     use mod_grid,       only: plon,plat
-    use mod_forcing,    only: use_nuopc_ndep
     use mod_tracers,    only: ntrbgc,ntr,itrbgc,trc
     use mo_control_bgc, only: bgc_namelist,get_bgc_namelist,do_ndep,do_rivinpt,do_oalk,            &
                               do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                 &
                               dtb,dtbgc,io_stdo_bgc,ldtbgc,                                        &
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
                               do_ndep_coupled,lkwrbioz_off,do_n2onh3_coupled,                      &
-                              ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle
+                              ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
+                              use_nuopc_ndep
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
     use mo_param_bgc,   only: ini_parambgc
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -242,7 +242,8 @@ contains
     use mo_control_bgc, only: bgc_namelist,get_bgc_namelist, io_stdo_bgc
     use mo_control_bgc, only: use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,           &
                               use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,           &
-                              use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers,use_nuopc_ndep
+                              use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers,           &
+                              use_nuopc_ndep
     integer :: iounit
 
     namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -30,7 +30,7 @@ module mo_param1_bgc
   use mo_control_bgc, only: use_BROMO, use_AGG, use_WLIN, use_natDIC, use_CFC,                     &
                             use_cisonew, use_PBGC_OCNP_TIMESTEP, use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE, use_BOXATM, use_sedbypass, use_extNcycle,              &
-                            use_pref_tracers, use_nuopc_ndep
+                            use_pref_tracers
   implicit none
   public
 
@@ -242,12 +242,12 @@ contains
     use mo_control_bgc, only: bgc_namelist,get_bgc_namelist, io_stdo_bgc
     use mo_control_bgc, only: use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,           &
                               use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,           &
-                              use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers
+                              use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers,use_nuopc_ndep
     integer :: iounit
 
     namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &
                             use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,             &
-                            use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers
+                            use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers,use_nuopc_ndep
 
     io_stdo_bgc = lp              !  standard out.
 

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -30,7 +30,7 @@ module mo_param1_bgc
   use mo_control_bgc, only: use_BROMO, use_AGG, use_WLIN, use_natDIC, use_CFC,                     &
                             use_cisonew, use_PBGC_OCNP_TIMESTEP, use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE, use_BOXATM, use_sedbypass, use_extNcycle,              &
-                            use_pref_tracers
+                            use_pref_tracers, use_nuopc_ndep
   implicit none
   public
 

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -37,7 +37,7 @@ module mo_param_bgc
                             do_ndep,do_oalk,do_rivinpt,do_sedspinup,l_3Dvarsedpor,                 &
                             use_BOXATM,use_CFC,use_PBGC_CK_TIMESTEP,                               &
                             use_sedbypass,with_dmsph,use_PBGC_OCNP_TIMESTEP,ocn_co2_type,use_M4AGO,&
-                            do_ndep_coupled,do_n2onh3_coupled,use_extNcycle,                       &
+                            do_n2onh3_coupled,use_extNcycle,                                       &
                             lkwrbioz_off
   use mod_xc,         only: mnproc
 
@@ -837,7 +837,6 @@ contains
       call cinfo_add_entry('lkwrbioz_off',           lkwrbioz_off)
       call cinfo_add_entry('use_M4AGO',              use_M4AGO)
       if (use_extNcycle) then
-        call cinfo_add_entry('do_ndep_coupled',        do_ndep_coupled)
         call cinfo_add_entry('do_n2onh3_coupled',       do_n2onh3_coupled)
       endif
       write(io_stdo_bgc,*) '* '

--- a/hamocc/mo_read_ndep.F90
+++ b/hamocc/mo_read_ndep.F90
@@ -181,6 +181,7 @@ contains
     !***********************************************************************************************
 
     use mod_xc,             only: mnproc
+    use mod_forcing,        only: use_nuopc_ndep
     use netcdf,             only: nf90_open,nf90_close,nf90_nowrite
     use mo_control_bgc,     only: io_stdo_bgc,do_ndep,use_extNcycle, do_ndep_coupled
     use mo_netcdf_bgcrw,    only: read_netcdf_var
@@ -209,7 +210,9 @@ contains
       return
     endif
 
-    if (use_extNcycle .and. do_ndep_coupled) then
+    ! Note - if use_nuopc_ndep - then nitrogen deposition is ALWAYS obtained from the
+    ! nuopc mediator
+    if (use_nuopc_ndep .or. (use_extNcycle .and. do_ndep_coupled)) then
 
         ! get N-deposition from atmosphere
         fatmndep = 365.*86400./mw_nitrogen

--- a/hamocc/mo_read_ndep.F90
+++ b/hamocc/mo_read_ndep.F90
@@ -181,9 +181,8 @@ contains
     !***********************************************************************************************
 
     use mod_xc,             only: mnproc
-    use mod_forcing,        only: use_nuopc_ndep
     use netcdf,             only: nf90_open,nf90_close,nf90_nowrite
-    use mo_control_bgc,     only: io_stdo_bgc, do_ndep, use_extNcycle, do_ndep_coupled
+    use mo_control_bgc,     only: io_stdo_bgc, do_ndep, use_extNcycle, do_ndep_coupled, use_nuopc_ndep
     use mo_netcdf_bgcrw,    only: read_netcdf_var
     use mo_param1_bgc,      only: nndep,idepnoy,idepnhx
     use mo_chemcon,         only: mw_nitrogen

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -96,6 +96,7 @@ module mod_forcing
       sst_stream, &    ! Sea-surface temperature [deg C] from stream data.
       ice_stream, &    ! Sea-ice concentration [] from stream data.
       sss_stream       ! Sea-surface salinity [g kg-1] from stream data.
+
    logical :: use_stream_relaxation ! If true, use nuopc stream relaxation capability
 
    ! Variables related to balancing the freshwater forcing budget.

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -96,8 +96,9 @@ module mod_forcing
       sst_stream, &    ! Sea-surface temperature [deg C] from stream data.
       ice_stream, &    ! Sea-ice concentration [] from stream data.
       sss_stream       ! Sea-surface salinity [g kg-1] from stream data.
-
    logical :: use_stream_relaxation ! If true, use nuopc stream relaxation capability
+
+   logical :: use_nuopc_ndep    ! If true, use nuopc input for rivin fluxes
 
    ! Variables related to balancing the freshwater forcing budget.
    real(r8) :: &
@@ -182,7 +183,8 @@ module mod_forcing
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
              ustar, ustarb, ustar3, wstar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
              s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
-             sss_stream, sst_stream, ice_stream, use_stream_relaxation
+             sss_stream, sst_stream, ice_stream, use_stream_relaxation, &
+             use_nuopc_ndep
 
 contains
 

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -98,8 +98,6 @@ module mod_forcing
       sss_stream       ! Sea-surface salinity [g kg-1] from stream data.
    logical :: use_stream_relaxation ! If true, use nuopc stream relaxation capability
 
-   logical :: use_nuopc_ndep    ! If true, use nuopc input for rivin fluxes
-
    ! Variables related to balancing the freshwater forcing budget.
    real(r8) :: &
       prfac           ! Correction factor for precipitation and runoff [].
@@ -183,8 +181,7 @@ module mod_forcing
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
              ustar, ustarb, ustar3, wstar3, buoyfl, t_sw_nonloc, t_rs_nonloc, &
              s_br_nonloc, s_rs_nonloc, inivar_forcing, fwbbal, &
-             sss_stream, sst_stream, ice_stream, use_stream_relaxation, &
-             use_nuopc_ndep
+             sss_stream, sst_stream, ice_stream, use_stream_relaxation
 
 contains
 

--- a/phy/mod_ifdefs.F90
+++ b/phy/mod_ifdefs.F90
@@ -38,41 +38,13 @@ module mod_ifdefs
 #else
   logical :: use_IDLAGE = .false.
 #endif
-#ifdef TIMER
-  logical :: use_TIMER = .true.
-#else
-  logical :: use_TIMER = .false.
-#endif
-#ifdef DEBUG_TIMER
-  logical :: use_DEBUG_TIMER = .true.
-#else
-  logical :: use_DEBUG_TIMER = .false.
-#endif
-#ifdef DEBUG_TIMER_ALL
-  logical :: use_DEBUG_TIMER_ALL = .true.
-#else
-  logical :: use_DEBUG_TIMER_ALL = .false.
-#endif
-#ifdef DEBUG_ALL
-  logical :: use_DEBUG_ALL = .true.
-#else
-  logical :: use_DEBUG_ALL = .false.
-#endif
-#ifdef ARCTIC
-  logical :: use_ARCTIC = .true.
-#else
-  logical :: use_ARCTIC = .false.
-#endif
 #ifdef MKS
   logical :: use_MKS = .true.
 #else
   logical :: use_MKS = .false.
 #endif
-#ifdef DIAG
-  logical :: use_DIAG = .true.
-#else
-  logical :: use_DIAG = .false.
-#endif
 
+  ! Namelist input
+  logical :: use_diag = .false.
 
 end module mod_ifdefs

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -28,7 +28,7 @@ module mod_rdlim
                              nstep2, nstep, lstep, nstep_in_day, time0, &
                              time, baclin, batrop, init_timevars, &
                              set_day_of_year, step_time
-  use mod_xc,          only: xcbcst, xchalt, xcstop, mnproc, lp
+  use mod_xc,          only: xcbcst, xchalt, xcstop, mnproc, lp, use_arctic
   use mod_grid,        only: grfile
   use mod_eos,         only: pref
   use mod_inicon,      only: icfile
@@ -107,6 +107,7 @@ module mod_rdlim
   use mod_budget,      only: cnsvdi
   use mod_checksum,    only: csdiag
   use mod_nctools,     only: ncfopn, ncgeti, ncgetr, ncfcls
+  use mod_ifdefs,      only: use_diag
 
   implicit none
   private
@@ -142,7 +143,8 @@ contains
          itest,jtest, &
          cnsvdi, &
          csdiag, &
-         rstfrq,rstfmt,rstcmp,iotype,use_stream_relaxation
+         rstfrq,rstfmt,rstcmp,iotype,use_stream_relaxation, &
+         use_diag, use_arctic
 
     ! read limits namelist
 
@@ -247,6 +249,8 @@ contains
       write (lp,*) 'RSTCMP',RSTCMP
       write (lp,*) 'IOTYPE',IOTYPE
       write (lp,*) 'USE_STREAM_RELAXATION',use_stream_relaxation
+      write (lp,*) 'USE_DIAG',use_diag
+      write (lp,*) 'USE_ARCTIC',use_arctic
       write (lp,*)
 
     end if
@@ -330,6 +334,8 @@ contains
     call xcbcst(rstcmp)
     call xcbcst(iotype)
     call xcbcst(use_stream_relaxation)
+    call xcbcst(use_diag)
+    call xcbcst(use_arctic)
 
     ! resolve options
     select case (trim(wavsrc))

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -161,7 +161,7 @@ contains
           open (newunit=nfu,file=nlfnm,status='old',action = 'read', &
                recl = 80)
         else
-          write (lp,*) 'rdlim: could not find namelist file!'
+          write (lp,*) 'rdlim: could not find namelist file! '//trim(nlfnm)
           call xchalt('(rdlim)')
           stop '(rdlim)'
         end if

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -25,8 +25,6 @@ module mod_xc
   use dimensions, only: idm,jdm,kdm,itdm,jtdm,iqr,jqr,ijqr,&
                         ii_pe,jj_pe,i0_pe,j0_pe,nreg
   use mod_wtime,  only: wtime
-  use mod_ifdefs, only: use_TIMER, use_DEBUG_TIMER, use_DEBUG_TIMER_ALL, &
-                        use_DEBUG_ALL, use_ARCTIC
 
   implicit none
   public
@@ -170,6 +168,15 @@ module mod_xc
 
   real, private :: al(itdm,jdm),ala(itdm,jdm,jqr),at(idm*jdm),ata(idm*jdm,iqr)
 #endif
+
+  ! debug flags
+  logical :: use_DEBUG_TIMER     = .false.
+  logical :: use_DEBUG_TIMER_ALL = .false.
+  logical :: use_DEBUG_ALL       = .false.
+  logical :: use_TIMER           = .false.
+
+  ! other namelist flags
+  logical :: use_ARCTIC = .true.
 
 contains
 


### PR DESCRIPTION
In noresm2_5, ndep is always sent to blom by either cam or datm - so there is no need to read a file.
This PR implements the functionality in blom to use this import data rather than reading a file.
- a new namelist variable (`use_nuopc_ndep`) has been added to the namelist group `config_bgc`
- by default use_nuopc_ndep will always be true if the coupling framework is using nuopc
- if use_nuopc_ndep is true, then hamocc will bypass reading in ndep from a file and instead use import values.

----

**Test 1:  ERS_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio**
The left hand screen is the dev1.6.1.8 output for ndep whereas the right hand screen is the new output for ndep
The two have different behavior. The difference is due to the differerent ndep forcing files:

- use_nuopc_ndep = .false.  blom reads
/cluster/shared/noresm/inputdata/ocn/blom/bndcon/ndep_1850_CMIP6_tnx1v4_20171106.nc
- use_nuopc_ndep = .true.  blom receives from cam
/cluster/shared/noresm/inputdata/lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc
- note that /cluster/shared/noresm/inputdata/ocn/blom/bndcon/ndep_1850_CMIP6_tnx1v4_20171106.nc
was obtained from an original fv1.9x2.5 dataset whereas cam is read in an fv09.x1.25 dataset.

![Screenshot 2024-10-07 at 4 05 57 PM](https://github.com/user-attachments/assets/0706ace9-194b-4d2f-802b-4dcaf983d617)
 
----

**Test 2: ERS_Ld3.TL319_tn14.NOIIAJRAOC.betzy_intel.blom-hybrid**
- in the new case - datm is reading the following file **_and then interpolating it to the model grid_** (TL319) and then the **_mediator in turn interpolations this to the blom grid (tnx1v4)_**
`/cluster/shared/noresm/inputdata/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc`
- in the original case - blom is reading in the file 
`/cluster/shared/noresm/inputdata/ocn/blom/bndcon/ndep_1850_CMIP6_tnx1v4_20171106.nc`
But this is incorrect since the compset is for 2000 (see #411) 
- in the new case, using `xmlchange DATM_PRESNDEP=clim_1850` now results in the following two comparisons
<img width="1146" alt="Screenshot 2024-10-02 at 10 42 54 PM" src="https://github.com/user-attachments/assets/cace1482-9c5c-4135-896d-6802f9b21cae">
