### PR TITLE
replaced imp.load_source with importlib.machinery.SourceFileLoader

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -3,7 +3,7 @@
 """
 build blom library
 """
-import os, shutil, sys, glob, imp
+import os, sys
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:

--- a/cime_config/buildlib_2.1
+++ b/cime_config/buildlib_2.1
@@ -3,7 +3,8 @@
 """
 build blom library
 """
-import os, shutil, sys, glob, imp
+import os, shutil, sys, glob
+from importlib.machinery import SourceFileLoader
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -32,7 +33,7 @@ def _main_func():
         cmd = os.path.join(os.path.join(comp_root_dir_ocn, "cime_config", "buildcpp"))
         logger.info("     ...calling blom buildcpp to set build time options")
         try:
-            mod = imp.load_source("buildcpp", cmd)
+            mod = SourceFileLoader("buildcpp", cmd).load_module()
             blom_cppdefs = mod.buildcpp(case)
         except:
             raise

--- a/cime_config/buildlib_2.2
+++ b/cime_config/buildlib_2.2
@@ -3,7 +3,8 @@
 """
 build blom library
 """
-import os, shutil, sys, glob, imp
+import os, shutil, sys, glob
+from importlib.machinery import SourceFileLoader
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -33,7 +34,7 @@ def _main_func():
         cmd = os.path.join(os.path.join(comp_root_dir_ocn, "cime_config", "buildcpp"))
         logger.info("     ...calling blom buildcpp to set build time options")
         try:
-            mod = imp.load_source("buildcpp", cmd)
+            mod = SourceFileLoader("buildcpp", cmd).load_module()
             blom_cppdefs = mod.buildcpp(case)
         except:
             raise


### PR DESCRIPTION
the module imp no will longer be supported in python3.12 and later. 
Currently we are using python3.11 in noresm to deal with this limitation. But the desire is to move to python 3.12 in the near future.
The suggested recommendation is to replace 
`imp.load_source` with  `importlib.machinery.SourceFileLoader`
Testing: verified that ERR_Ld3.TL319_tn14.NOIIAJRAOC.betzy_intel.blom-hybrid built successfully (when the same change was made in cice)