### PR TITLE
Bugfix DNRA and introduce max_limiter

### DIFF
--- a/hamocc/mo_extNsediment.F90
+++ b/hamocc/mo_extNsediment.F90
@@ -91,7 +91,7 @@ module mo_extNsediment
              ised_remin_sulf    = 13, &
              n_seddiag          = 13
 
-  real :: eps    = 1.e-25
+  real :: eps    = epsilon(1.)
   real :: minlim = 1.e-9
 
 contains

--- a/hamocc/mo_extNwatercol.F90
+++ b/hamocc/mo_extNwatercol.F90
@@ -72,7 +72,7 @@ module mo_extNwatercol
   ! public functions
   public :: nitrification,denit_NO3_to_NO2,anammox,denit_dnra,extN_inv_check
 
-  real :: eps    = 1.e-25
+  real :: eps    = epsilon(1.)
 
 contains
 

--- a/hamocc/mo_extNwatercol.F90
+++ b/hamocc/mo_extNwatercol.F90
@@ -48,7 +48,6 @@ module mo_extNwatercol
   !****************************************************************
   use mo_vgrid,       only: dp_min
   use mod_xc,         only: mnproc
-  use mo_control_bgc, only: dtb
   use mo_param1_bgc,  only: ialkali,ianh4,iano2,ian2o,iano3,idet,igasnit,iiron,ioxygen,iphosph,    &
                           & isco212
   use mo_carbch,      only: ocetra
@@ -63,7 +62,7 @@ module mo_extNwatercol
                           & n2oybeta,NOB2AOAy,bn2o,mufn2o,                                         &
                           & rc2n,ro2nnit,rnoxp,rnoxpi,rno2anmx,rno2anmxi,rnh4anmx,                 &
                           & rnh4anmxi,rno2dnra,rno2dnrai,rnh4dnra,rnh4dnrai,rnm1,                  &
-                          &  bkphyanh4,bkphyano3,bkphosph,bkiron,ro2utammo
+                          & bkphyanh4,bkphyano3,bkphosph,bkiron,ro2utammo,max_limiter
   use mo_biomod,      only: nitr_NH4,nitr_NO2,nitr_N2O_prod,nitr_NH4_OM,nitr_NO2_OM,denit_NO3,     &
                           & denit_NO2,denit_N2O,DNRA_NO2,anmx_N2_prod,anmx_OM_prod
   implicit none
@@ -74,7 +73,6 @@ module mo_extNwatercol
   public :: nitrification,denit_NO3_to_NO2,anammox,denit_dnra,extN_inv_check
 
   real :: eps    = 1.e-25
-  real :: minlim = 1.e-9
 
 contains
 
@@ -164,15 +162,17 @@ contains
 
             totd = max(0.,                                                                         &
                  &   min(totd,                                                                     &
-                 &       ocetra(i,j,k,ianh4)/(amoxfrac + fdetnitr*nitrfrac + eps),                 & ! ammonium
-                 &       ocetra(i,j,k,isco212)/(rc2n*(fdetamox*amoxfrac + fdetnitr*nitrfrac) +eps),& ! CO2
-                 &       ocetra(i,j,k,iphosph)/(rnoi*(fdetamox*amoxfrac + fdetnitr*nitrfrac) +eps),& ! PO4
-                 &       ocetra(i,j,k,iiron)/(riron*rnoi*(fdetamox*amoxfrac + fdetnitr*nitrfrac)   &
-                 &                            + eps),                                              & ! Fe
-                 &       ocetra(i,j,k,ioxygen)                                                     &
+                 &       max_limiter*ocetra(i,j,k,ianh4)/(amoxfrac + fdetnitr*nitrfrac + eps),     & ! ammonium
+                 &       max_limiter*ocetra(i,j,k,isco212)/                                        &
+                 &                             (rc2n*(fdetamox*amoxfrac + fdetnitr*nitrfrac) +eps),& ! CO2
+                 &       max_limiter*ocetra(i,j,k,iphosph)/                                        &
+                 &                             (rnoi*(fdetamox*amoxfrac + fdetnitr*nitrfrac) +eps),& ! PO4
+                 &       max_limiter*ocetra(i,j,k,iiron)/                                          &
+                 &              (riron*rnoi*(fdetamox*amoxfrac + fdetnitr*nitrfrac) + eps),        & ! Fe
+                 &       max_limiter*ocetra(i,j,k,ioxygen)                                         &
                  &       /((1.5*fno2 + fn2o - ro2nnit*fdetamox)*amoxfrac                           &
                                             + (0.5 - ro2nnit*fdetnitr)*nitrfrac + eps),            & ! O2
-                 &       ocetra(i,j,k,ialkali)                                                     &
+                 &       max_limiter*ocetra(i,j,k,ialkali)                                         &
                  &       /((2.*fno2 + fn2o + rnm1*rnoi*fdetamox)*amoxfrac                          &
                  &                         + (rnm1*rnoi*fdetnitr)*nitrfrac + eps)))                  ! alkalinity
             amox = amoxfrac*totd
@@ -229,10 +229,11 @@ contains
             Tdep      = q10ano3denit**((temp-Trefano3denit)/10.)
             O2inhib   = 1. - tanh(sc_ano3denit*ocetra(i,j,k,ioxygen))
             nutlim    = ocetra(i,j,k,iano3)/(ocetra(i,j,k,iano3) + bkano3denit)
- 
+
             ano3new   = ocetra(i,j,k,iano3)/(1. + rano3denit*Tdep*O2inhib*nutlim)
 
-            ano3denit = max(0.,min(ocetra(i,j,k,iano3) - ano3new, ocetra(i,j,k,idet)*rnoxp))
+            ano3denit = max(0.,min(ocetra(i,j,k,iano3) - ano3new,                                  &
+                                   max_limiter*ocetra(i,j,k,idet)*rnoxp))
 
             ocetra(i,j,k,iano3)   = ocetra(i,j,k,iano3)   - ano3denit
             ocetra(i,j,k,iano2)   = ocetra(i,j,k,iano2)   + ano3denit
@@ -284,11 +285,11 @@ contains
             ano2new  = ocetra(i,j,k,iano2)/(1. + rano2anmx*Tdep*O2inhib*nut1lim*nut2lim)
 
             ano2anmx = max(0.,min(ocetra(i,j,k,iano2) - ano2new,                                   &
-                                  ocetra(i,j,k,ianh4)*rno2anmx*rnh4anmxi,                          &
-                                  ocetra(i,j,k,isco212)*rno2anmx/rcar,                             &
-                                  ocetra(i,j,k,iphosph)*rno2anmx,                                  &
-                                  ocetra(i,j,k,iiron)*rno2anmx/riron,                              &
-                                  ocetra(i,j,k,ialkali)*rno2anmx/rnm1))
+                                  max_limiter*ocetra(i,j,k,ianh4)*rno2anmx*rnh4anmxi,              &
+                                  max_limiter*ocetra(i,j,k,isco212)*rno2anmx/rcar,                 &
+                                  max_limiter*ocetra(i,j,k,iphosph)*rno2anmx,                      &
+                                  max_limiter*ocetra(i,j,k,iiron)*rno2anmx/riron,                  &
+                                  max_limiter*ocetra(i,j,k,ialkali)*rno2anmx/rnm1))
 
             ocetra(i,j,k,iano2)   = ocetra(i,j,k,iano2)   - ano2anmx
             ocetra(i,j,k,ianh4)   = ocetra(i,j,k,ianh4)   - ano2anmx*rnh4anmx*rno2anmxi
@@ -387,7 +388,7 @@ contains
             fdetano2denit = rnoxpi*ano2denit/(potddet + eps)
             fdetan2odenit = rnoxpi*an2odenit/(potddet + eps)
             fdetdnra      = 1. - fdetano2denit - fdetan2odenit
-            potddet       = max(0.,min(potddet,ocetra(i,j,k,idet)))
+            potddet       = max(0.,min(potddet,max_limiter*ocetra(i,j,k,idet)))
 
             ! change of NO2 and N2O in N units
             ano2denit     = fdetano2denit*rnoxp*potddet
@@ -426,7 +427,7 @@ contains
 !==================================================================================================================================
   subroutine extN_inv_check(kpie,kpje,kpke,pdlxp,pdlyp,pddpo,omask,inv_message)
     use mo_inventory_bgc, only: inventory_bgc
-    use mo_control_bgc,   only: io_stdo_bgc,dtb,use_PBGC_OCNP_TIMESTEP
+    use mo_control_bgc,   only: io_stdo_bgc,use_PBGC_OCNP_TIMESTEP
 
     implicit none
     ! provide inventory calculation for extended nitrogen cycle

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -137,7 +137,6 @@ contains
     real :: wpocd,wcald,wopald,wdustd,dagg
     real :: wcal,wdust,wopal,wpoc
     real :: o2lim ! O2 limitation of ammonification (POC remin)
-    real, parameter :: tiny_num = epsilon(1.)
     ! sedbypass
     real :: florca,flcaca,flsil
     ! cisonew
@@ -334,7 +333,7 @@ contains
               nlim       = ano3up_inh*ocetra(i,j,k,iano3)/(ocetra(i,j,k,iano3) +  bkphyano3) + anh4lim
               grlim      = min(nutlim,nlim) ! growth limitation
 
-              nh4uptfrac = anh4lim/(nlim+tiny_num)
+              nh4uptfrac = anh4lim/(nlim+epsilon(1.))
               ! re-check avnut - can sum N avail exceed indiv. contrib?
               avanut     = max(0.,min(ocetra(i,j,k,iphosph), ocetra(i,j,k,iiron)/riron,                              &
                          &        rnoi*((1.-nh4uptfrac)*ocetra(i,j,k,iano3) + nh4uptfrac*ocetra(i,j,k,ianh4))))

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -137,7 +137,7 @@ contains
     real :: wpocd,wcald,wopald,wdustd,dagg
     real :: wcal,wdust,wopal,wpoc
     real :: o2lim ! O2 limitation of ammonification (POC remin)
-    real, parameter :: tiny_num = 1e-25
+    real, parameter :: tiny_num = epsilon(1.)
     ! sedbypass
     real :: florca,flcaca,flsil
     ! cisonew

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -77,7 +77,7 @@ contains
                                 dmsp1,dmsp2,dmsp3,dmsp4,dmsp5,dmsp6,dms_gamma,                     &
                                 fbro1,fbro2,atten_f,atten_c,atten_uv,atten_w,bkopal,bkphy,bkzoo,   &
                                 POM_remin_q10,POM_remin_Tref,opal_remin_q10,opal_remin_Tref,       &
-                                bkphyanh4,bkphyano3,bkphosph,bkiron,ro2utammo
+                                bkphyanh4,bkphyano3,bkphosph,bkiron,ro2utammo,max_limiter
     use mo_biomod,        only: bsiflx0100,bsiflx0500,bsiflx1000,bsiflx2000,bsiflx4000,bsiflx_bot, &
                                 calflx0100,calflx0500,calflx1000,calflx2000,calflx4000,calflx_bot, &
                                 carflx0100,carflx0500,carflx1000,carflx2000,carflx4000,carflx_bot, &
@@ -137,6 +137,7 @@ contains
     real :: wpocd,wcald,wopald,wdustd,dagg
     real :: wcal,wdust,wopal,wpoc
     real :: o2lim ! O2 limitation of ammonification (POC remin)
+    real, parameter :: tiny_num = 1e-25
     ! sedbypass
     real :: florca,flcaca,flsil
     ! cisonew
@@ -333,14 +334,13 @@ contains
               nlim       = ano3up_inh*ocetra(i,j,k,iano3)/(ocetra(i,j,k,iano3) +  bkphyano3) + anh4lim
               grlim      = min(nutlim,nlim) ! growth limitation
 
-              nh4uptfrac = 1.
-              if(nlim .gt. 1.e-18) nh4uptfrac = anh4lim/nlim
+              nh4uptfrac = anh4lim/(nlim+tiny_num)
               ! re-check avnut - can sum N avail exceed indiv. contrib?
               avanut     = max(0.,min(ocetra(i,j,k,iphosph), ocetra(i,j,k,iiron)/riron,                              &
                          &        rnoi*((1.-nh4uptfrac)*ocetra(i,j,k,iano3) + nh4uptfrac*ocetra(i,j,k,ianh4))))
 
               xn         = avphy/(1. - pho*grlim)       ! phytoplankton growth
-              phosy      = max(0.,min(xn-avphy,avanut)) ! limit PP growth to available nutr.
+              phosy      = max(0.,min(xn-avphy,max_limiter*avanut)) ! limit PP growth to available nutr.
             else
               avanut = max(0.,min(ocetra(i,j,k,iphosph),rnoi*ocetra(i,j,k,iano3)))
               avanfe = max(0.,min(avanut,ocetra(i,j,k,iiron)/riron))

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -121,7 +121,8 @@ module mo_param_bgc
           & bkoxamox_sed,bkanh4nitr_sed,bkamoxn2o_sed,bkyamox_sed,               &
           & rano2nitr_sed,q10ano2nitr_sed,Trefano2nitr_sed,bkoxnitr_sed,         &
           & bkano2nitr_sed,n2omaxy_sed,n2oybeta_sed,NOB2AOAy_sed,bn2o_sed,       &
-          & mufn2o_sed,POM_remin_q10_sed, POM_remin_Tref_sed,bkox_drempoc_sed
+          & mufn2o_sed,POM_remin_q10_sed, POM_remin_Tref_sed,bkox_drempoc_sed,   &
+          & max_limiter
 
 
   !********************************************************************
@@ -152,6 +153,7 @@ module mo_param_bgc
   real, parameter :: c14_t_half = 5700.*365.      ! Half life of 14C [days]
 
   ! Extended nitrogen cycle
+  real, parameter :: max_limiter   = 0.9999          ! maximum in concentrations that can consumed at once
   real, parameter :: rc2n          = rcar/rnit       ! iHAMOCC C:N ratio
   real, parameter :: ro2utammo     = 140.            ! Oxygen utilization per mol detritus during ammonification
   real, parameter :: ro2nnit       = ro2utammo/rnit  !

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -153,7 +153,7 @@ module mo_param_bgc
   real, parameter :: c14_t_half = 5700.*365.      ! Half life of 14C [days]
 
   ! Extended nitrogen cycle
-  real, parameter :: max_limiter   = 0.9999          ! maximum in concentrations that can consumed at once
+  real, parameter :: max_limiter   = 0.9999          ! maximum in concentrations that can be consumed at once
   real, parameter :: rc2n          = rcar/rnit       ! iHAMOCC C:N ratio
   real, parameter :: ro2utammo     = 140.            ! Oxygen utilization per mol detritus during ammonification
   real, parameter :: ro2nnit       = ro2utammo/rnit  !


### PR DESCRIPTION
**This PR only affects runs with the extended nitrogen cycle being switched on.** It fixes a bug in the sediment DNRA pathway. In addition, I introduce a limiter (`max_limiter`) to avoid coming too close to available concentrations in one time step (avoiding turning values negative due to precision issues). Further: minor clean-up.

I am currently running a test by applying those changes to a BLOM v1.6.2 setup.

@JorgSchwinger and @TomasTorsvik, if possible and if tests are giving positive results, I would consider to request to also cherry pick this fix to the v.1.6.2 tag - leading to a bugfixed v1.6.3 which I can then use in my setups - I assume that this would be feasible since the N-cycle was anyway optional in v1.6.x