### PR TITLE
Adjust pkgs meson file for transitioning M4AGO

### DIFF
--- a/pkgs/meson.build
+++ b/pkgs/meson.build
@@ -1,3 +1,4 @@
+fs = import('fs') # import fs system module: https://mesonbuild.com/Fs-module.html
 sources += files('CVMix-src/src/shared/cvmix_background.F90',
 'CVMix-src/src/shared/cvmix_convection.F90', 
 'CVMix-src/src/shared/cvmix_ddiff.F90',
@@ -13,4 +14,7 @@ if get_option('ecosys')
    sources += files('M4AGO-sinking-scheme/src/mo_m4ago_core.f90',
                     'M4AGO-sinking-scheme/src/mo_m4ago_physics.f90',
        		    'M4AGO-sinking-scheme/src/mo_ihamocc4m4ago.f90')
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_kind.F90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_kind.F90')
+   endif
 endif


### PR DESCRIPTION
**This PR informs about potential issues when setting up a run with meson - cime-managed runs are NOT affected.**

The PR provides support for any of the current M4AGO versions provided meson >= 0.57 is used. 

**Background**
I recently worked on the M4AGO-sinking-scheme package and introduced a new file, which requires to be explicitly set via `meson.build`. Typically, a particular tag/sha of M4AGO is checked out (where this change isn't needed), but if one for any reason moves on to M4AGO `master`, this will create issues when compiling with meson. The code snippet is applicable for meson versions >=0.57, where the meson file system module has been introduced. Otherwise, the file needs to be manually added in the `meson.build` file. Hope it helps in the current transition period for M4AGO which is for making it more general and future-ready. 

@JorgSchwinger and @TomasTorsvik : if wished, I can push it to `master` - I was just hesitant since the required meson release was Feb. 2021, which isn't too long ago. 

@matsbn : I put you in here explicitly, since I know that you are using meson every now and then (not sure, which meson version you're running, though).  