### PR TITLE
Dust fluxes output and add descriptions in the xml-namelist file

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -83,7 +83,7 @@ def buildnml(case, caseroot, compname):
     hamocc_extncycle          = case.get_value("HAMOCC_EXTNCYCLE")
     hamocc_n2oc               = case.get_value("HAMOCC_N2OC")
     hamocc_atmndepc           = case.get_value("HAMOCC_ATMNDEPC")
-    hamocc_m4ago              = case.get_value("HAMOCC_M4AGO")
+    hamocc_sinking_scheme     = case.get_value("HAMOCC_SINKING_SCHEME")
     hamocc_sedbypass          = case.get_value("HAMOCC_SEDBYPASS")
     hamocc_sedspinup          = case.get_value("HAMOCC_SEDSPINUP")
     hamocc_sedspinup_yr_start = case.get_value("HAMOCC_SEDSPINUP_YR_START")
@@ -192,7 +192,6 @@ def buildnml(case, caseroot, compname):
         config["hamocc_extncycle"] = "yes" if hamocc_extncycle else "no"
         config["hamocc_n2oc"] = "yes" if hamocc_n2oc else "no"
         config["hamocc_atmndepc"] = "yes" if hamocc_atmndepc else "no"
-        config["hamocc_m4ago"] = "yes" if hamocc_m4ago else "no"
         config["hamocc_sedbypass"] = "yes" if hamocc_sedbypass else "no"
         config["hamocc_sedspinup"] = "yes" if hamocc_sedspinup else "no"
         config["hamocc_sedspinup_yr_start"] = hamocc_sedspinup_yr_start
@@ -201,9 +200,29 @@ def buildnml(case, caseroot, compname):
         config["is_test"] = "yes" if is_test else "no"
         config["comp_interface"] = comp_interface
 
-        # TODO: the following needs to have new ways to turn this to "yes"
-        config["use_agg"] = "no"
-        config["use_wlin"] = "yes"
+        # Set the sinking scheme in iHAMOCC 
+        # Note: the following part requires to have set options for no/yes 
+        # in the namelist_definition_blom.xml for the 'use_XXX' switches
+        if hamocc_sinking_scheme == 'WLIN': # current default
+           config['use_wlin']  = 'yes'
+           config['use_agg']   = 'no'
+           config['use_m4ago'] = 'no'
+        elif hamocc_sinking_scheme == 'M4AGO':
+           config['use_wlin']  = 'no'
+           config['use_agg']   = 'no'
+           config['use_m4ago'] = 'yes'
+        elif hamocc_sinking_scheme == 'AGG':
+           config['use_wlin']  = 'no'
+           config['use_agg']   = 'yes'
+           config['use_m4ago'] = 'no'
+        elif hamocc_sinking_scheme == 'CONST': 
+           # if all options are 'no' iHAMOCC falls back to constant sinking velocities
+           config['use_wlin']  = 'no'
+           config['use_agg']   = 'no'
+           config['use_m4ago'] = 'no'
+        else: # likely doesn't enter here due to previous cime checkings for available options
+           print('Unknown sinking scheme option in BLOM buildnml- exit now')
+           exit
 
         if is_test:
             testcase = case.get_value("TESTCASE")

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -180,13 +180,13 @@
     <desc>N2O and NH3 fluxes coupled from atmosphere. Requires module ecosys and extncycle</desc>
   </entry>
 
-  <entry id="HAMOCC_M4AGO">
-    <type>logical</type>
-    <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+  <entry id="HAMOCC_SINKING_SCHEME">
+    <type>char</type>
+    <valid_values>WLIN,M4AGO,AGG,CONST</valid_values>
+    <default_value>WLIN</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>Set namelist option to activate the M4AGO sinking scheme. Requires module ecosys</desc>
+    <desc>Namelist option to set sinking scheme. Requires module ecosys</desc>
   </entry>
 
   <entry id="HAMOCC_PREF_TRACERS">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5296,7 +5296,7 @@
     <values>
       <value>0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>switch for compressed/uncompressed output</desc>
   </entry>
 
   <entry id="glb_ncformat@diabgc">
@@ -5308,7 +5308,7 @@
       <value pio_netcdf_format_ocn="64bit_offset">1,1,1</value>
       <value pio_netcdf_format_ocn="64bit_data">1,1,1</value>
     </values>
-    <desc>add desc</desc>
+    <desc>netcdf format (valid arguments are 0 for classic, 1 for 64-bit offset and 2 for netcdf4/hdf5 format)</desc>
   </entry>
 
   <entry id="glb_inventory">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4042,7 +4042,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Switch to use variable sediment porosity</desc>
   </entry>
 
   <entry id="sedporfile" is_inputdata="yes">
@@ -4195,7 +4195,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Activate interactive phytoplankton absorption</desc>
   </entry>
 
   <entry id="use_pref_tracers" modify_via_xml="HAMOCC_PREF_TRACERS">
@@ -5262,7 +5262,7 @@
     <values>
       <value>'hbgcd','hbgcm','hbgcy'</value>
     </values>
-    <desc>add desc</desc>
+    <desc>File name extension for BGC output frequencies</desc>
   </entry>
 
   <entry id="glb_aveperio@diabgc">
@@ -5272,7 +5272,7 @@
     <values>
       <value>1,30,365</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Averaging period for BGC diagnostic output</desc>
   </entry>
 
   <entry id="glb_filefreq@diabgc">
@@ -5284,7 +5284,7 @@
       <value is_test="yes">1,30,365</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Frequency for writing the BGC output</desc>
   </entry>
 
   <entry id="glb_compflag@diabgc">
@@ -5316,7 +5316,7 @@
     <values>
       <value>0,1,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Writing the BGC inventory files at BGC frequencies</desc>
   </entry>
 
   <entry id="srf_phosph">
@@ -5412,7 +5412,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Surface silicate concentration [mol Si m-3]</desc>
   </entry>
 
   <entry id="srf_dic">
@@ -5952,7 +5952,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Surface bromoform concentration [mol CHBr3 m-3]</desc>
   </entry>
 
   <entry id="srf_bromofx">
@@ -5964,7 +5964,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Surface bromoform flux [mol CHBr3 -m2 s-1]</desc>
   </entry>
 
   <entry id="int_bromopro">
@@ -5976,7 +5976,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Integrated bromoform production [mol CHBr3 m-2 s-1]</desc>
   </entry>
 
   <entry id="int_bromouv">
@@ -5988,7 +5988,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Integrated bromoform loss to photolysis [mol CHBr m-2 s-1]</desc>
   </entry>
 
   <entry id="int_phosy">
@@ -6072,7 +6072,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational POC flux at 100m [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_car0500">
@@ -6084,7 +6084,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational POC flux at 500m [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_car1000">
@@ -6096,7 +6096,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational POC flux at 1000m [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_car2000">
@@ -6108,7 +6108,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational POC flux at 2000m [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_car4000">
@@ -6120,7 +6120,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational POC flux at 4000m [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_car_bot">
@@ -6132,7 +6132,79 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational POC flux to the sediment [mol C m-2 s-1]</desc>
+  </entry>
+
+  <entry id="flx_dust0100">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>Gravitational dust fluxes at 100m</desc>
+  </entry>
+
+  <entry id="flx_dust0500">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>Gravitational dust fluxes at 500m</desc>
+  </entry>
+
+  <entry id="flx_dust1000">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>Gravitational dust fluxes at 1000m</desc>
+  </entry>
+
+  <entry id="flx_dust2000">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>Gravitational dust fluxes at 2000m</desc>
+  </entry>
+
+  <entry id="flx_dust4000">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>Gravitational dust fluxes at 4000m</desc>
+  </entry>
+
+  <entry id="flx_dust_bot">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+    </values>
+    <desc>Gravitational dust fluxes to sediment</desc>
   </entry>
 
   <entry id="flx_bsi0100">
@@ -6144,7 +6216,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational opal flux at 100m [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_bsi0500">
@@ -6156,7 +6228,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational opal flux at 500m [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_bsi1000">
@@ -6168,7 +6240,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational opal flux at 1000m [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_bsi2000">
@@ -6180,7 +6252,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational opal flux at 2000m [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_bsi4000">
@@ -6192,7 +6264,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational opal flux at 4000m [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_bsi_bot">
@@ -6204,7 +6276,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational opal flux to the sediment [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_cal0100">
@@ -6216,7 +6288,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational CaCO3 flux at 100m [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_cal0500">
@@ -6228,7 +6300,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational CaCO3 flux at 500m [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_cal1000">
@@ -6240,7 +6312,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational CaCO3 flux at 1000m [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_cal2000">
@@ -6252,7 +6324,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational CaCO3 flux at 2000m [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_cal4000">
@@ -6264,7 +6336,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational CaCO3 flux at 4000m [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_cal_bot">
@@ -6276,7 +6348,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Gravitational CaCO3 flux to the sediment [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="lyr_phyto">
@@ -6288,7 +6360,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Phytoplankton [mol P m-3]</desc>
   </entry>
 
   <entry id="lyr_grazer">
@@ -6300,7 +6372,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Zooplankton [mol P m-3]</desc>
   </entry>
 
   <entry id="lyr_doc">
@@ -6312,7 +6384,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Dissolved organic carbon [mol P m-3]</desc>
   </entry>
 
   <entry id="lyr_phosy">
@@ -6324,7 +6396,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Primary production [mol C m-3]</desc>
   </entry>
 
   <entry id="lyr_phosph">
@@ -6372,7 +6444,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Nitrate concentration [mol NO3 m-3]</desc>
   </entry>
 
   <entry id="lyr_ano2">
@@ -6732,7 +6804,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Alkalinity [eq m-3]</desc>
   </entry>
 
   <entry id="lyr_silica">
@@ -6744,7 +6816,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Silicate [mol Si m-3]</desc>
   </entry>
 
   <entry id="lyr_dic">
@@ -6756,7 +6828,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Dissolved inorganic carbon [mol C m-3]</desc>
   </entry>
 
   <entry id="lyr_poc">
@@ -6768,7 +6840,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Detritus [mol P m-3]</desc>
   </entry>
 
   <entry id="lyr_calc">
@@ -6828,7 +6900,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>pH [-log10([H+])]</desc>
   </entry>
 
   <entry id="lyr_omegac">
@@ -6888,7 +6960,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Preformed phosphorus [mol P m-3]</desc>
   </entry>
 
   <entry id="lyr_prefsilica">
@@ -6900,7 +6972,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>Pre-formed silica [mol m-3]</desc>
+    <desc>Pre-formed silica [mol Si m-3]</desc>
   </entry>
 
   <entry id="lyr_prefalk">
@@ -7246,7 +7318,7 @@
     <values>
       <value>0,0,2</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Bromoform [mol CHBr3 m-3]</desc>
   </entry>
 
   <entry id="lyr_dp@diabgc">
@@ -7258,7 +7330,7 @@
       <value is_test="yes">0,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Layer thickness [m]</desc>
   </entry>
 
   <entry id="lvl_phyto">
@@ -7810,7 +7882,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>pH [-log10(H+)]</desc>
   </entry>
 
   <entry id="lvl_omegac">
@@ -8204,7 +8276,7 @@
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Bromoform [mol CHBr3 m-3]</desc>
   </entry>
 
   <entry id="flx_sediffic">
@@ -8216,7 +8288,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Diffusive DIC flux to sediment (positive downward) [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_sediffal">
@@ -8228,7 +8300,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Diffusive alkalinity flux to sediment (positive downward) [mol eq m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_sediffph">
@@ -8240,7 +8312,7 @@
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Diffusive phosphate flux to sediment (positive downward) [mol P m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_sediffox">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4075,6 +4075,7 @@
     <group>config_bgc</group>
     <values>
       <value>.true.</value>
+      <value use_m4ago="yes">.false.</value>
     </values>
     <desc>Use POC sinking scheme with increasing sinking velocity with depth</desc>
   </entry>
@@ -4184,6 +4185,7 @@
     <group>config_bgc</group>
     <values>
       <value>.false.</value>
+      <value use_m4ago="yes">.false.</value>
     </values>
     <desc>Use aggregation scheme for sinking of particles</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3861,13 +3861,13 @@
     <desc>Switch to couple N2O and NH3 fluxes</desc>
   </entry>
 
-  <entry id="use_m4ago" modify_via_xml="HAMOCC_M4AGO">
+  <entry id="use_m4ago">
     <type>logical</type>
     <category>bgcnml</category>
     <group>bgcnml</group>
     <values>
       <value>.false.</value>
-      <value hamocc_m4ago="yes">.true.</value>
+      <value use_m4ago="yes">.true.</value>
     </values>
     <desc>Switch for M4AGO settling scheme</desc>
   </entry>
@@ -4075,7 +4075,7 @@
     <group>config_bgc</group>
     <values>
       <value>.true.</value>
-      <value use_m4ago="yes">.false.</value>
+      <value use_wlin="no">.false.</value>
     </values>
     <desc>Use POC sinking scheme with increasing sinking velocity with depth</desc>
   </entry>
@@ -4185,7 +4185,7 @@
     <group>config_bgc</group>
     <values>
       <value>.false.</value>
-      <value use_m4ago="yes">.false.</value>
+      <value use_agg="yes">.true.</value>
     </values>
     <desc>Use aggregation scheme for sinking of particles</desc>
   </entry>

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -593,6 +593,7 @@
 !   CARFLX****     - POC flux at **** metres depth [mol C m-2 s-1]
 !   BSIFLX****     - Biogenic silica flux at **** metres depth [mol Si m-2 s-1]
 !   CALFLX****     - Calcium carbonate flux at **** metres depth [mol C m-2 s-1]
+!   DUSTFLX****    - Dust flux at **** metres depth [g m-2 s-1]
 !   SEDIFFIC       - sediment - water-column diffusive flux of DIC [mol C m-2 s-1]
 !   SEDIFFAL       - sediment - water-column diffusive flux of alkalinity [mol m-2 s-1]
 !   SEDIFFPH       - sediment - water-column diffusive flux of phosphate [mol PO3 m-2 s-1]

--- a/hamocc/mo_accfields.F90
+++ b/hamocc/mo_accfields.F90
@@ -50,6 +50,8 @@ contains
                                 bsiflx2000,bsiflx4000,calflx_bot,calflx0100,calflx0500,            &
                                 calflx1000,calflx2000,calflx4000,carflx_bot,carflx0100,            &
                                 carflx0500,carflx1000,carflx2000,carflx4000,                       &
+                                dustflx_bot,dustflx0100,                                           &
+                                dustflx0500,dustflx1000,dustflx2000,dustflx4000,                   &
                                 expoca,expoor,exposi,intdms_bac,intdms_uv,intdmsprod,              &
                                 intdnit,intnfix,intphosy,phosy3d,                                  &
                                 int_chbr3_prod,int_chbr3_uv,asize3d,eps3d,wnumb,wmass,             &
@@ -63,6 +65,8 @@ contains
                                 jcalflx1000,jcalflx2000,jcalflx4000,                               &
                                 jcalflx_bot,jcarflx0100,jcarflx0500,                               &
                                 jcarflx1000,jcarflx2000,jcarflx4000,jcarflx_bot,                   &
+                                jdustflx0100,jdustflx0500,                                         &
+                                jdustflx1000,jdustflx2000,jdustflx4000,jdustflx_bot,               &
                                 jsediffic,jsediffal,jsediffph,jsediffox,                           &
                                 jburflxsso12,jburflxsssc12,jburflxssssil,jburflxssster,            &
                                 jsediffn2,jsediffno3,jsediffsi,jco2flux,                           &
@@ -337,21 +341,27 @@ contains
       call accsrf(jcarflx0100,carflx0100,omask,0)
       call accsrf(jbsiflx0100,bsiflx0100,omask,0)
       call accsrf(jcalflx0100,calflx0100,omask,0)
+      call accsrf(jdustflx0100,dustflx0100,omask,0)
       call accsrf(jcarflx0500,carflx0500,omask,0)
       call accsrf(jbsiflx0500,bsiflx0500,omask,0)
       call accsrf(jcalflx0500,calflx0500,omask,0)
+      call accsrf(jdustflx0500,dustflx0500,omask,0)
       call accsrf(jcarflx1000,carflx1000,omask,0)
       call accsrf(jbsiflx1000,bsiflx1000,omask,0)
       call accsrf(jcalflx1000,calflx1000,omask,0)
+      call accsrf(jdustflx1000,dustflx1000,omask,0)
       call accsrf(jcarflx2000,carflx2000,omask,0)
       call accsrf(jbsiflx2000,bsiflx2000,omask,0)
       call accsrf(jcalflx2000,calflx2000,omask,0)
+      call accsrf(jdustflx2000,dustflx2000,omask,0)
       call accsrf(jcarflx4000,carflx4000,omask,0)
       call accsrf(jbsiflx4000,bsiflx4000,omask,0)
       call accsrf(jcalflx4000,calflx4000,omask,0)
+      call accsrf(jdustflx4000,dustflx4000,omask,0)
       call accsrf(jcarflx_bot,carflx_bot,omask,0)
       call accsrf(jbsiflx_bot,bsiflx_bot,omask,0)
       call accsrf(jcalflx_bot,calflx_bot,omask,0)
+      call accsrf(jdustflx_bot,dustflx_bot,omask,0)
     endif
 
     if (.not. use_sedbypass) then

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -877,7 +877,7 @@ CONTAINS
       jdustflx2000(n)=i_bsc_m2d*min(1,FLX_DUST2000(n))
       if (FLX_DUST4000(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jdustflx4000(n)=i_bsc_m2d*min(1,FLX_DUST4000(n))
-      if (FLX_CAL_BOT(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      if (FLX_DUST_BOT(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jdustflx_bot(n)=i_bsc_m2d*min(1,FLX_DUST_BOT(n))
 
       if (.not. use_sedbypass) then

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -121,6 +121,8 @@ module mo_bgcmean
        & FLX_BSI2000   =0    ,FLX_BSI4000   =0    ,FLX_BSI_BOT   =0    ,  &
        & FLX_CAL0100   =0    ,FLX_CAL0500   =0    ,FLX_CAL1000   =0    ,  &
        & FLX_CAL2000   =0    ,FLX_CAL4000   =0    ,FLX_CAL_BOT   =0    ,  &
+       & FLX_DUST0100  =0    ,FLX_DUST0500  =0    ,FLX_DUST1000  =0    ,  &
+       & FLX_DUST2000  =0    ,FLX_DUST4000  =0    ,FLX_DUST_BOT  =0    ,  &
        & FLX_SEDIFFIC  =0    ,FLX_SEDIFFAL  =0    ,FLX_SEDIFFPH  =0    ,  &
        & FLX_SEDIFFOX  =0    ,FLX_SEDIFFN2  =0    ,FLX_SEDIFFNO3 =0    ,  &
        & FLX_SEDIFFSI  =0    ,FLX_SEDIFFNH4 =0    ,FLX_SEDIFFN2O =0    ,  &
@@ -266,7 +268,7 @@ module mo_bgcmean
        & LYR_nitr_NH4_OM   ,LYR_nitr_NO2_OM   ,LYR_denit_NO3     ,        &
        & LYR_denit_NO2     ,LYR_denit_N2O     ,LYR_DNRA_NO2      ,        &
        & LYR_anmx_N2_prod  ,LYR_anmx_OM_prod  ,LYR_phosy_NH4     ,        &
-       & LYR_phosy_NO3     ,LYR_remin_aerob   ,LYR_remin_sulf    ,        & 
+       & LYR_phosy_NO3     ,LYR_remin_aerob   ,LYR_remin_sulf    ,        &
        & LYR_agg_ws        ,LYR_dynvis        ,LYR_agg_stick     ,        &
        & LYR_agg_stickf    ,LYR_agg_dmax      ,LYR_agg_avdp      ,        &
        & LYR_agg_avrhop    ,LYR_agg_avdC      ,LYR_agg_df        ,        &
@@ -294,11 +296,11 @@ module mo_bgcmean
        & LVL_nitr_NH4_OM   ,LVL_nitr_NO2_OM   ,LVL_denit_NO3     ,        &
        & LVL_denit_NO2     ,LVL_denit_N2O     ,LVL_DNRA_NO2      ,        &
        & LVL_anmx_N2_prod  ,LVL_anmx_OM_prod  ,LVL_phosy_NH4     ,        &
-       & LVL_phosy_NO3     ,LVL_remin_aerob   ,LVL_remin_sulf    ,        & 
+       & LVL_phosy_NO3     ,LVL_remin_aerob   ,LVL_remin_sulf    ,        &
        & LVL_agg_ws        ,LVL_dynvis        ,LVL_agg_stick     ,        &
        & LVL_agg_stickf    ,LVL_agg_dmax      ,LVL_agg_avdp      ,        &
        & LVL_agg_avrhop    ,LVL_agg_avdC      ,LVL_agg_df        ,        &
-       & LVL_agg_b         ,LVL_agg_Vrhof     ,LVL_agg_Vpor      ,        &        
+       & LVL_agg_b         ,LVL_agg_Vrhof     ,LVL_agg_Vpor      ,        &
        & SDM_POWAIC        ,SDM_POWAAL        ,SDM_POWAPH        ,        &
        & SDM_POWAOX        ,SDM_POWN2         ,SDM_POWNO3        ,        &
        & SDM_POWASI        ,SDM_SSSO12        ,SDM_SSSSIL        ,        &
@@ -408,7 +410,13 @@ module mo_bgcmean
        &          jcalflx1000= 0 ,                                        &
        &          jcalflx2000= 0 ,                                        &
        &          jcalflx4000= 0 ,                                        &
-       &          jcalflx_bot= 0
+       &          jcalflx_bot= 0 ,                                        &
+       &          jdustflx0100= 0 ,                                       &
+       &          jdustflx0500= 0 ,                                       &
+       &          jdustflx1000= 0 ,                                       &
+       &          jdustflx2000= 0 ,                                       &
+       &          jdustflx4000= 0 ,                                       &
+       &          jdustflx_bot= 0
 
   integer, dimension(nbgcmax) ::                                          &
        &          jsediffic  = 0 ,                                        &
@@ -859,6 +867,19 @@ CONTAINS
       jcalflx4000(n)=i_bsc_m2d*min(1,FLX_CAL4000(n))
       if (FLX_CAL_BOT(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jcalflx_bot(n)=i_bsc_m2d*min(1,FLX_CAL_BOT(n))
+      if (FLX_DUST0100(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jdustflx0100(n)=i_bsc_m2d*min(1,FLX_DUST0100(n))
+      if (FLX_DUST0500(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jdustflx0500(n)=i_bsc_m2d*min(1,FLX_DUST0500(n))
+      if (FLX_DUST1000(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jdustflx1000(n)=i_bsc_m2d*min(1,FLX_DUST1000(n))
+      if (FLX_DUST2000(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jdustflx2000(n)=i_bsc_m2d*min(1,FLX_DUST2000(n))
+      if (FLX_DUST4000(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jdustflx4000(n)=i_bsc_m2d*min(1,FLX_DUST4000(n))
+      if (FLX_CAL_BOT(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jdustflx_bot(n)=i_bsc_m2d*min(1,FLX_DUST_BOT(n))
+
       if (.not. use_sedbypass) then
         if (FLX_SEDIFFIC(n) > 0) i_bsc_m2d=i_bsc_m2d+1
         jsediffic(n)=i_bsc_m2d*min(1,FLX_SEDIFFIC(n))
@@ -951,7 +972,9 @@ CONTAINS
          jbsiflx0100+jbsiflx0500+jbsiflx1000+ &
          jbsiflx2000+jbsiflx4000+jbsiflx_bot+ &
          jcalflx0100+jcalflx0500+jcalflx1000+ &
-         jcalflx2000+jcalflx4000+jcalflx_bot  > 0)
+         jcalflx2000+jcalflx4000+jcalflx_bot+ &
+         jdustflx0100+jdustflx0500+jdustflx1000+ &
+         jdustflx2000+jdustflx4000+jdustflx_bot > 0)
 
     i_atm_m2d=i_bsc_m2d
     do n=1,nbgc

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -238,6 +238,8 @@ module mo_bgcmean
        & FLX_BSI2000       ,FLX_BSI4000       ,FLX_BSI_BOT       ,        &
        & FLX_CAL0100       ,FLX_CAL0500       ,FLX_CAL1000       ,        &
        & FLX_CAL2000       ,FLX_CAL4000       ,FLX_CAL_BOT       ,        &
+       & FLX_DUST0100      ,FLX_DUST0500      ,FLX_DUST1000      ,        &
+       & FLX_DUST2000      ,FLX_DUST4000      ,FLX_DUST_BOT      ,        &
        & FLX_SEDIFFIC      ,FLX_SEDIFFAL      ,FLX_SEDIFFPH      ,        &
        & FLX_SEDIFFOX      ,FLX_SEDIFFN2      ,FLX_SEDIFFNO3     ,        &
        & FLX_SEDIFFSI      ,FLX_SEDIFFNH4     ,FLX_SEDIFFN2O     ,        &

--- a/hamocc/mo_biomod.F90
+++ b/hamocc/mo_biomod.F90
@@ -69,6 +69,12 @@ module mo_biomod
   real, dimension (:,:),   allocatable, public :: calflx2000
   real, dimension (:,:),   allocatable, public :: calflx4000
   real, dimension (:,:),   allocatable, public :: calflx_bot
+  real, dimension (:,:),   allocatable, public :: dustflx0100
+  real, dimension (:,:),   allocatable, public :: dustflx0500
+  real, dimension (:,:),   allocatable, public :: dustflx1000
+  real, dimension (:,:),   allocatable, public :: dustflx2000
+  real, dimension (:,:),   allocatable, public :: dustflx4000
+  real, dimension (:,:),   allocatable, public :: dustflx_bot
   real, dimension (:,:,:), allocatable, public :: phosy3d
 
   ! Variables for interactive phytoplanktion absorption (use_FB_BGC_OCE=.true.)
@@ -277,13 +283,33 @@ CONTAINS
     allocate (calflx2000(kpie,kpje),stat=errstat)
     allocate (calflx4000(kpie,kpje),stat=errstat)
     allocate (calflx_bot(kpie,kpje),stat=errstat)
-    if(errstat.ne.0) stop 'not enough memory bsiflx*'
+    if(errstat.ne.0) stop 'not enough memory calflx*'
     calflx0100(:,:) = 0.0
     calflx0500(:,:) = 0.0
     calflx1000(:,:) = 0.0
     calflx2000(:,:) = 0.0
     calflx4000(:,:) = 0.0
     calflx_bot(:,:) = 0.0
+
+    if (mnproc.eq.1) then
+      write(io_stdo_bgc,*)'Memory allocation for variable dustflx* ...'
+      write(io_stdo_bgc,*)'First dimension    : ',kpie
+      write(io_stdo_bgc,*)'Second dimension   : ',kpje
+    endif
+
+    allocate (dustflx0100(kpie,kpje),stat=errstat)
+    allocate (dustflx0500(kpie,kpje),stat=errstat)
+    allocate (dustflx1000(kpie,kpje),stat=errstat)
+    allocate (dustflx2000(kpie,kpje),stat=errstat)
+    allocate (dustflx4000(kpie,kpje),stat=errstat)
+    allocate (dustflx_bot(kpie,kpje),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory dustflx*'
+    dustflx0100(:,:) = 0.0
+    dustflx0500(:,:) = 0.0
+    dustflx1000(:,:) = 0.0
+    dustflx2000(:,:) = 0.0
+    dustflx4000(:,:) = 0.0
+    dustflx_bot(:,:) = 0.0
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)'Memory allocation for variable phosy3d ...'

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -46,6 +46,8 @@ contains
                               flx_car2000,flx_car4000,flx_car_bot,                                 &
                               flx_bsi0100,flx_bsi0500,flx_bsi1000,                                 &
                               flx_bsi2000,flx_bsi4000,flx_bsi_bot,                                 &
+                              flx_dust0100,flx_dust0500,flx_dust1000,                              &
+                              flx_dust2000,flx_dust4000,flx_dust_bot,                              &
                               flx_sediffic,flx_sediffal,flx_sediffph,                              &
                               flx_sediffox,flx_sediffn2,flx_sediffno3,flx_sediffsi,                &
                               flx_bursso12,flx_bursssc12,flx_burssssil,                            &
@@ -61,6 +63,8 @@ contains
                               jcalflx2000,jcalflx4000,jcalflx_bot,                                 &
                               jcarflx0100,jcarflx0500,jcarflx1000,                                 &
                               jcarflx2000,jcarflx4000,jcarflx_bot,                                 &
+                              jdustflx0100,jdustflx0500,jdustflx1000,                              &
+                              jdustflx2000,jdustflx4000,jdustflx_bot,                              &
                               jco2fxd,jco2fxu,jco3,jdic,jdicsat,                                   &
                               jdms,jdms_bac,jdms_uv,jdmsflux,jdmsprod,                             &
                               jdoc,jdp,jeps,jexpoca,jexport,jexposi,jgrazer,                       &
@@ -420,6 +424,11 @@ contains
     call msksrf(jcalflx1000(iogrp),k1000)
     call msksrf(jcalflx2000(iogrp),k2000)
     call msksrf(jcalflx4000(iogrp),k4000)
+    call msksrf(jdustflx0100(iogrp),k0100)
+    call msksrf(jdustflx0500(iogrp),k0500)
+    call msksrf(jdustflx1000(iogrp),k1000)
+    call msksrf(jdustflx2000(iogrp),k2000)
+    call msksrf(jdustflx4000(iogrp),k4000)
 
     ! --- Mask sea floor in level data
     call msklvl(jlvlphyto(iogrp),depths)
@@ -585,6 +594,12 @@ contains
     call wrtsrf(jcalflx2000(iogrp),  FLX_CAL2000(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'calflx2000')
     call wrtsrf(jcalflx4000(iogrp),  FLX_CAL4000(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'calflx4000')
     call wrtsrf(jcalflx_bot(iogrp),  FLX_CAL_BOT(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'calflx_bot')
+    call wrtsrf(jdustflx0100(iogrp),  FLX_DUST0100(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dustflx0100')
+    call wrtsrf(jdustflx0500(iogrp),  FLX_DUST0500(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dustflx0500')
+    call wrtsrf(jdustflx1000(iogrp),  FLX_DUST1000(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dustflx1000')
+    call wrtsrf(jdustflx2000(iogrp),  FLX_DUST2000(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dustflx2000')
+    call wrtsrf(jdustflx4000(iogrp),  FLX_DUST4000(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dustflx4000')
+    call wrtsrf(jdustflx_bot(iogrp),  FLX_DUST_BOT(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'dustflx_bot')
     if (.not. use_sedbypass) then
       call wrtsrf(jsediffic(iogrp),    FLX_SEDIFFIC(iogrp), rnacc*1e3/dtbgc,0.,cmpflg,'sedfdic')
       call wrtsrf(jsediffal(iogrp),    FLX_SEDIFFAL(iogrp), rnacc*1e3/dtbgc,0.,cmpflg,'sedfalk')
@@ -944,6 +959,12 @@ contains
     call inisrf(jcalflx2000(iogrp),0.)
     call inisrf(jcalflx4000(iogrp),0.)
     call inisrf(jcalflx_bot(iogrp),0.)
+    call inisrf(jdustflx0100(iogrp),0.)
+    call inisrf(jdustflx0500(iogrp),0.)
+    call inisrf(jdustflx1000(iogrp),0.)
+    call inisrf(jdustflx2000(iogrp),0.)
+    call inisrf(jdustflx4000(iogrp),0.)
+    call inisrf(jdustflx_bot(iogrp),0.)
     if (.not. use_sedbypass) then
       call inisrf(jsediffic(iogrp),0.)
       call inisrf(jsediffal(iogrp),0.)
@@ -1265,6 +1286,8 @@ contains
                               flx_bsi0100,flx_bsi0500,flx_bsi1000,flx_bsi2000,flx_bsi4000,         &
                               flx_bsi_bot,flx_cal0100,flx_cal0500,flx_cal1000,flx_cal2000,         &
                               flx_cal4000,flx_cal_bot,flx_sediffic,flx_sediffal,                   &
+                              flx_dust0100,flx_dust0500,flx_dust1000,flx_dust2000,flx_dust4000,    &
+                              flx_dust_bot,                                                        &
                               flx_sediffph,flx_sediffox,flx_sediffn2,flx_sediffno3,                &
                               flx_sediffsi,flx_bursso12,flx_bursssc12,flx_burssssil,flx_burssster, &
                               srf_n2ofx,srf_atmco2,lyr_dp,lyr_dic,                                 &
@@ -1493,6 +1516,19 @@ contains
          &   'CaCO3 flux at 4000m',' ','mol Ca m-2 s-1',0)
     call ncdefvar3d(FLX_CAL_BOT(iogrp),cmpflg,'p','calflx_bot',                 &
          &   'CaCO3 flux to sediment',' ','mol Ca m-2 s-1',0)
+    call ncdefvar3d(FLX_DUST0100(iogrp),cmpflg,'p','dustflx0100',               &
+         &   'Dust flux at 100m',' ','g m-2 s-1',0)
+    call ncdefvar3d(FLX_DUST0500(iogrp),cmpflg,'p','dustflx0500',               &
+         &   'Dust flux at 500m',' ','g m-2 s-1',0)
+    call ncdefvar3d(FLX_DUST1000(iogrp),cmpflg,'p','dustflx1000',               &
+         &   'Dust flux at 1000m',' ','g m-2 s-1',0)
+    call ncdefvar3d(FLX_DUST2000(iogrp),cmpflg,'p','dustflx2000',               &
+         &   'Dust flux at 2000m',' ','g m-2 s-1',0)
+    call ncdefvar3d(FLX_DUST4000(iogrp),cmpflg,'p','dustflx4000',               &
+         &   'Dust flux at 4000m',' ','g m-2 s-1',0)
+    call ncdefvar3d(FLX_DUST_BOT(iogrp),cmpflg,'p','dustflx_bot',               &
+         &   'Dust flux to sediment',' ','g m-2 s-1',0)
+
     call ncdefvar3d(SRF_N2OFX(iogrp),cmpflg,'p','n2oflux',                      &
          &   'N2O flux',' ','mol N2O m-2 s-1',0)
     if (.not. use_sedbypass) then
@@ -1504,7 +1540,7 @@ contains
            &   ' ','mol m-2 s-1',0)
       call ncdefvar3d(FLX_SEDIFFPH(iogrp),cmpflg,'p','sedfpho',                 &
            &   'diffusive phosphate flux to sediment (positive downwards)',     &
-           &   ' ','mol m-2 s-1',0)
+           &   ' ','mol P m-2 s-1',0)
       call ncdefvar3d(FLX_SEDIFFOX(iogrp),cmpflg,'p','sedfox',                  &
            &   'diffusive oxygen flux to sediment (positive downwards)',        &
            &   ' ','mol O2 m-2 s-1',0)
@@ -1667,7 +1703,7 @@ contains
       call ncdefvar3d(LYR_PREFPO4(iogrp),cmpflg,'p',                            &
            &   'p_po4','Preformed phosphorus',' ','mol P m-3',1)
       call ncdefvar3d(LYR_PREFSILICA(iogrp),cmpflg,'p',                         &
-         &   'p_silica','Preformed silica',' ','mol N m-3',1)
+         &   'p_silica','Preformed silica',' ','mol Si m-3',1)
       call ncdefvar3d(LYR_PREFALK(iogrp),cmpflg,'p',                            &
            &   'p_talk','Preformed alkalinity',' ','eq m-3',1)
       call ncdefvar3d(LYR_PREFDIC(iogrp),cmpflg,'p',                            &

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -81,6 +81,8 @@ contains
     use mo_biomod,        only: bsiflx0100,bsiflx0500,bsiflx1000,bsiflx2000,bsiflx4000,bsiflx_bot, &
                                 calflx0100,calflx0500,calflx1000,calflx2000,calflx4000,calflx_bot, &
                                 carflx0100,carflx0500,carflx1000,carflx2000,carflx4000,carflx_bot, &
+                                dustflx0100,dustflx0500,dustflx1000,dustflx2000,dustflx4000,       &
+                                dustflx_bot,                                                       &
                                 expoor,exposi,expoca,intdnit,intdms_bac,intdmsprod,intdms_uv,      &
                                 intphosy,int_chbr3_prod,int_chbr3_uv,                              &
                                 phosy3d,abs_oce,strahl,asize3d,wmass,wnumb,eps3d,phosy_NH4,        &
@@ -1188,6 +1190,16 @@ contains
                 wdust  = wdust_const
                 wdustd = wdust_const
                 dagg   = 0.0
+              else if (use_M4AGO) then
+                wpoc   = ws_agg(i,j,k)
+                wpocd  = ws_agg(i,j,kdonor)
+                wcal   = ws_agg(i,j,k)
+                wcald  = ws_agg(i,j,kdonor)
+                wopal  = ws_agg(i,j,k)
+                wopald = ws_agg(i,j,kdonor)
+                wdust  = ws_agg(i,j,k)
+                wdustd = ws_agg(i,j,kdonor)
+                dagg   = 0.0
               else
                 wpoc   = wpoc_const
                 wpocd  = wpoc_const
@@ -1199,17 +1211,6 @@ contains
                 wdustd = wdust_const
                 dagg   = 0.0
               endif
-              if (use_M4AGO) then ! superseding every other method
-                wpoc   = ws_agg(i,j,k)
-                wpocd  = ws_agg(i,j,kdonor)
-                wcal   = ws_agg(i,j,k)
-                wcald  = ws_agg(i,j,kdonor)
-                wopal  = ws_agg(i,j,k)
-                wopald = ws_agg(i,j,kdonor)
-                wdust  = ws_agg(i,j,k)
-                wdustd = ws_agg(i,j,kdonor)
-                dagg   = 0.0
-              endif
 
               if( k == 1 ) then
                 wpocd  = 0.0
@@ -1219,11 +1220,9 @@ contains
                 if (use_AGG) then
                   wnosd  = 0.0
                 else if (use_WLIN) then
-                  if (use_M4AGO) then
-                    wpoc = ws_agg(i,j,k)
-                  else
-                    wpoc = wmin
-                  endif
+                  wpoc = wmin
+                else if (use_M4AGO) then
+                  wpoc = ws_agg(i,j,k)
                 endif
               endif
 
@@ -1410,19 +1409,28 @@ contains
               wpoc  = wmass(i,j,k)
               wcal  = wmass(i,j,k)
               wopal = wmass(i,j,k)
+              wdust = dustsink
             else if (use_WLIN) then
               wpoc  = min(wmin+wlin*ptiestu(i,j,k), wmax)
-            endif
-            if (use_M4AGO) then
+              wdust = wdust_const
+            else if (use_M4AGO) then
               wpoc   = ws_agg(i,j,k)
               wcal   = ws_agg(i,j,k)
               wopal  = ws_agg(i,j,k)
+              wdust  = ws_agg(i,j,k)
+            else
+              wpoc   = wpoc_const
+              wcal   = wcal_const
+              wopal  = wopal_const
+              wdust  = wdust_const
             endif
 
             if (use_AGG) then
               carflx0100(i,j) = (ocetra(i,j,k,idet)+ocetra(i,j,k,iphy))*rcar*wpoc
+              dustflx0100(i,j)= ocetra(i,j,k,ifdust)*wdust + ocetra(i,j,k,iadust)*wpoc
             else
               carflx0100(i,j) = ocetra(i,j,k,idet)*rcar*wpoc
+              dustflx0100(i,j)= ocetra(i,j,k,ifdust)*wdust
             endif
             bsiflx0100(i,j) = ocetra(i,j,k,iopal)*wopal
             calflx0100(i,j) = ocetra(i,j,k,icalc)*wcal
@@ -1435,19 +1443,28 @@ contains
               wpoc  = wmass(i,j,k)
               wcal  = wmass(i,j,k)
               wopal = wmass(i,j,k)
+              wdust = dustsink
             else if (use_WLIN) then
               wpoc  = min(wmin+wlin*ptiestu(i,j,k), wmax)
+              wdust = wdust_const
+            else if (use_M4AGO) then
+              wpoc   = ws_agg(i,j,k)
+              wcal   = ws_agg(i,j,k)
+              wopal  = ws_agg(i,j,k)
+              wdust  = ws_agg(i,j,k)
+            else
+              wpoc   = wpoc_const
+              wcal   = wcal_const
+              wopal  = wopal_const
+              wdust  = wdust_const
             endif
-           if (use_M4AGO) then
-                wpoc   = ws_agg(i,j,k)
-                wcal   = ws_agg(i,j,k)
-                wopal  = ws_agg(i,j,k)
-           endif
 
             if (use_AGG) then
               carflx0500(i,j) = (ocetra(i,j,k,idet)+ocetra(i,j,k,iphy))*rcar*wpoc
+              dustflx0500(i,j)= ocetra(i,j,k,ifdust)*wdust + ocetra(i,j,k,iadust)*wpoc
             else
               carflx0500(i,j) = ocetra(i,j,k,idet)*rcar*wpoc
+              dustflx0500(i,j)= ocetra(i,j,k,ifdust)*wdust
             endif
             bsiflx0500(i,j) = ocetra(i,j,k,iopal)*wopal
             calflx0500(i,j) = ocetra(i,j,k,icalc)*wcal
@@ -1460,19 +1477,28 @@ contains
               wpoc  = wmass(i,j,k)
               wcal  = wmass(i,j,k)
               wopal = wmass(i,j,k)
+              wdust = dustsink
             else if (use_WLIN) then
               wpoc  = min(wmin+wlin*ptiestu(i,j,k), wmax)
-            endif
-            if (use_M4AGO) then
+              wdust = wdust_const
+            else if (use_M4AGO) then
               wpoc   = ws_agg(i,j,k)
               wcal   = ws_agg(i,j,k)
               wopal  = ws_agg(i,j,k)
+              wdust  = ws_agg(i,j,k)
+            else
+              wpoc   = wpoc_const
+              wcal   = wcal_const
+              wopal  = wopal_const
+              wdust  = wdust_const
             endif
 
             if (use_AGG) then
               carflx1000(i,j) = (ocetra(i,j,k,idet)+ocetra(i,j,k,iphy))*rcar*wpoc
+              dustflx1000(i,j)= ocetra(i,j,k,ifdust)*wdust + ocetra(i,j,k,iadust)*wpoc
             else
               carflx1000(i,j) = ocetra(i,j,k,idet)*rcar*wpoc
+              dustflx1000(i,j)= ocetra(i,j,k,ifdust)*wdust
             endif
             bsiflx1000(i,j) = ocetra(i,j,k,iopal)*wopal
             calflx1000(i,j) = ocetra(i,j,k,icalc)*wcal
@@ -1485,19 +1511,28 @@ contains
               wpoc  = wmass(i,j,k)
               wcal  = wmass(i,j,k)
               wopal = wmass(i,j,k)
+              wdust = dustsink
             else if (use_WLIN) then
               wpoc  = min(wmin+wlin*ptiestu(i,j,k), wmax)
-            endif
-            if (use_M4AGO) then
+              wdust = wdust_const
+            else if (use_M4AGO) then
               wpoc   = ws_agg(i,j,k)
               wcal   = ws_agg(i,j,k)
               wopal  = ws_agg(i,j,k)
+              wdust  = ws_agg(i,j,k)
+            else
+              wpoc   = wpoc_const
+              wcal   = wcal_const
+              wopal  = wopal_const
+              wdust  = wdust_const
             endif
 
             if (use_AGG) then
               carflx2000(i,j) = (ocetra(i,j,k,idet)+ocetra(i,j,k,iphy))*rcar*wpoc
+              dustflx2000(i,j)= ocetra(i,j,k,ifdust)*wdust + ocetra(i,j,k,iadust)*wpoc
             else
               carflx2000(i,j) = ocetra(i,j,k,idet)*rcar*wpoc
+              dustflx2000(i,j)= ocetra(i,j,k,ifdust)*wdust
             endif
             bsiflx2000(i,j) = ocetra(i,j,k,iopal)*wopal
             calflx2000(i,j) = ocetra(i,j,k,icalc)*wcal
@@ -1510,19 +1545,28 @@ contains
               wpoc  = wmass(i,j,k)
               wcal  = wmass(i,j,k)
               wopal = wmass(i,j,k)
+              wdust = dustsink
             else if (use_WLIN) then
               wpoc  = min(wmin+wlin*ptiestu(i,j,k), wmax)
-            endif
-            if (use_M4AGO) then
+              wdust = wdust_const
+            else if (use_M4AGO) then
               wpoc   = ws_agg(i,j,k)
               wcal   = ws_agg(i,j,k)
               wopal  = ws_agg(i,j,k)
+              wdust  = ws_agg(i,j,k)
+            else
+              wpoc   = wpoc_const
+              wcal   = wcal_const
+              wopal  = wopal_const
+              wdust  = wdust_const
             endif
 
             if (use_AGG) then
               carflx4000(i,j) = (ocetra(i,j,k,idet)+ocetra(i,j,k,iphy))*rcar*wpoc
+              dustflx4000(i,j)= ocetra(i,j,k,ifdust)*wdust + ocetra(i,j,k,iadust)*wpoc
             else
               carflx4000(i,j) = ocetra(i,j,k,idet)*rcar*wpoc
+              dustflx4000(i,j)= ocetra(i,j,k,ifdust)*wdust
             endif
             bsiflx4000(i,j) = ocetra(i,j,k,iopal)*wopal
             calflx4000(i,j) = ocetra(i,j,k,icalc)*wcal
@@ -1532,6 +1576,7 @@ contains
           carflx_bot(i,j) = prorca(i,j)*rcar
           bsiflx_bot(i,j) = silpro(i,j)
           calflx_bot(i,j) = prcaca(i,j)
+          dustflx_bot(i,j)= produs(i,j)
 
         endif ! omask > 0.5
       enddo


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger , as discussed, this PR brings in dust output and some descriptions in the xml-namelist file. I tried to fill all iHAMOCC gaps to my best knowledge. I cleaned the way, M4AGO sinking velocity is handled in `mo_ocprod` (wasn't ideal before).

Together with this PR, I introduced the xmlchange switch `HAMOCC_SINKING_SCHEME` (and removed the compset HAMOCC_M4AGO switch) that allows to select among the four supported sinking schemes: [WLIN, AGG, M4AGO, CONST], the default remains WLIN.

Ideally, this PR also enters the v1.6.x release version. Sorry for this delayed PR for the release tag - it just adds some potentially valuable output (and provides a more descriptive iHAMOCC xml-namelist definition file). 