### PR TITLE
Remove redundant OMP call

### DIFF
--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -414,7 +414,6 @@ contains
          if (ChkErr(rc, __LINE__, u_FILE_u)) return
          read(cvalue,*) nthrds
       endif
-      !$    call omp_set_num_threads(nthrds)
 
       ! Reset shr logging to components log file.
       call set_component_logging(gcomp, localPet==0, lp, shrlogunit, rc)


### PR DESCRIPTION
This call to `omp_set_num_threads(nthrds)` has never been used and would appear to be redundant in the the NUOPC driver. I suggest to remove it.

Closes #379 