### PR TITLE
Introduce switch dor T- and O2-dependent remineralization

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3882,6 +3882,16 @@
     <desc>Switch for primary production and remineralization throughout the whole water column</desc>
   </entry>
 
+  <entry id="lTO2depremin">
+    <type>logical</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>.false.</value>
+    </values>
+    <desc>Switch for T- and O2-dependent remineralization of POM</desc>
+  </entry>
+
   <entry id="do_oalk">
     <type>logical</type>
     <category>bgcnml</category>

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -61,6 +61,7 @@ module mo_control_bgc
   logical           :: with_dmsph             = .false. ! apply DMS with pH dependence
   logical           :: use_M4AGO              = .false. ! run with M4AGO settling scheme
   logical           :: lkwrbioz_off           = .false. ! if true, allow remin and primary prod throughout full water column
+  logical           :: lTO2depremin           = .false. ! Temperature- and O2-dependent remineralization of POM
   integer           :: sedspin_yr_s           = -1      ! start year for sediment spin-up
   integer           :: sedspin_yr_e           = -1      ! end   year for sediment spin-up
   integer           :: sedspin_ncyc           = -1      ! sediment spin-up sub-cycles


### PR DESCRIPTION
With this PR, the option will be provided to enable T- and O2-dependent remineralization for all model versions (thus far, this was only for the extended nitrogen cycle and when M4AGO was switched on). It is the first step in the two step process towards making the T- and O2-dependency default (#400). 

The remineralization rate for POM `drempoc` might need adjustment, when switching on the T- and O2-dependent remineralization. I suspect that the rate as set, when `HAMOCC_SINKING_SCHEME=M4AGO` is switched on won't apply for the default sinking scheme `WLIN`. I suspect the rate for `WLIN` being of similar order as currently set (so one could give it a try without changing `drempoc`). 

**Thus far, this only concerns the water column, but I can also introduce it to the sediment (as done for the N-cycle)** - comments on this? I suspect it could be of interest to enable it for the sediment as well in the default model at least for the aerobic remineralization. 

I put this as PR, while I anticipate that there will be changes wrt the sediment, once I receive your comments.

closes #400