### PR TITLE
Revert setting of use_ARCTIC variable

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -89,6 +89,9 @@ def buildcpp(case):
     if pio_typename == "pnetcdf":
         blom_cppdefs = blom_cppdefs + " -DPNETCDF"
 
+    if ocn_grid in ["tnx2v1", "tnx1.5v1", "tnx1v1", "tnx1v3", "tnx1v4", "tnx0.5v1", "tnx0.25v1", "tnx0.25v3", "tnx0.25v4", "tnx0.125v4"]:
+        blom_cppdefs = blom_cppdefs + " -DARCTIC"
+
     if ocn_grid in ["gx1v5", "gx1v6", "tnx1v1", "tnx1v3", "tnx1v4", "tnx0.5v1", "tnx0.25v1", "tnx0.25v3", "tnx0.25v4", "tnx0.125v4"]:
         blom_cppdefs = blom_cppdefs + " -DLEVITUS2X"
 

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -902,16 +902,6 @@
     <desc>optionally turn on additional diagnostics</desc>
   </entry>
 
-  <entry id="use_arctic">
-    <type>logical</type>
-    <category>limits</category>
-    <group>limits</group>
-    <values>
-      <value>.true.</value>
-    </values>
-    <desc>if region includes arctic ocean</desc>
-  </entry>
-
   <!-- ========================= -->
   <!-- namelist group: vcoord -->
   <!-- ========================= -->

--- a/phy/mod_ifdefs.F90
+++ b/phy/mod_ifdefs.F90
@@ -43,6 +43,11 @@ module mod_ifdefs
 #else
   logical :: use_MKS = .false.
 #endif
+#ifdef ARCTIC
+  logical :: use_ARCTIC = .true.
+#else
+  logical :: use_ARCTIC = .false.
+#endif
 
   ! Namelist input
   logical :: use_diag = .false.

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -28,7 +28,7 @@ module mod_rdlim
                              nstep2, nstep, lstep, nstep_in_day, time0, &
                              time, baclin, batrop, init_timevars, &
                              set_day_of_year, step_time
-  use mod_xc,          only: xcbcst, xchalt, xcstop, mnproc, lp, use_arctic
+  use mod_xc,          only: xcbcst, xchalt, xcstop, mnproc, lp
   use mod_grid,        only: grfile
   use mod_eos,         only: pref
   use mod_inicon,      only: icfile
@@ -144,7 +144,7 @@ contains
          cnsvdi, &
          csdiag, &
          rstfrq,rstfmt,rstcmp,iotype,use_stream_relaxation, &
-         use_diag, use_arctic
+         use_diag
 
     ! read limits namelist
 
@@ -250,7 +250,6 @@ contains
       write (lp,*) 'IOTYPE',IOTYPE
       write (lp,*) 'USE_STREAM_RELAXATION',use_stream_relaxation
       write (lp,*) 'USE_DIAG',use_diag
-      write (lp,*) 'USE_ARCTIC',use_arctic
       write (lp,*)
 
     end if
@@ -335,7 +334,6 @@ contains
     call xcbcst(iotype)
     call xcbcst(use_stream_relaxation)
     call xcbcst(use_diag)
-    call xcbcst(use_arctic)
 
     ! resolve options
     select case (trim(wavsrc))

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -25,6 +25,7 @@ module mod_xc
   use dimensions, only: idm,jdm,kdm,itdm,jtdm,iqr,jqr,ijqr,&
                         ii_pe,jj_pe,i0_pe,j0_pe,nreg
   use mod_wtime,  only: wtime
+  use mod_ifdefs, only: use_arctic
 
   implicit none
   public
@@ -174,9 +175,6 @@ module mod_xc
   logical :: use_DEBUG_TIMER_ALL = .false.
   logical :: use_DEBUG_ALL       = .false.
   logical :: use_TIMER           = .false.
-
-  ! other namelist flags
-  logical :: use_ARCTIC = .true.
 
 contains
 


### PR DESCRIPTION
This PR reverts the setting of the `use_arctic` variable back to being determined by a CPP flag.

The `use_arctic` variable is applied in the subroutine `xcspmd` from `mod_xc`, which is called in `blom_init`before `rdlim`. Hence, `use_arctic` is used before the namelist variables are read. It would be nice if we could remove the ARCTIC CPP flag, but it will have to be done in a different way.

Testing:
- This PR works for the stand-alone `single_column` test run.
- PASS for test SMS_D_Ld1.T62_tn14.NOINYOC.betzy_intel based on noresm2_5_alpha07