### PR TITLE
Change placement of LTO2depremin switch

### DIFF
--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -45,7 +45,7 @@ contains
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
                               lkwrbioz_off,do_n2onh3_coupled,                                      &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
-                              use_nuopc_ndep
+                              use_nuopc_ndep,lTO2depremin
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
     use mo_param_bgc,   only: ini_parambgc
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
@@ -82,7 +82,7 @@ contains
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,swaclimfile,       &
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
-         &            do_n2onh3_coupled,lkwrbioz_off
+         &            do_n2onh3_coupled,lkwrbioz_off,lTO2depremin
     !
     ! --- Set io units and some control parameters
     !

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -619,7 +619,7 @@ contains
                          bkoxan2odenit_sed,bkan2odenit_sed,q10dnra_sed,          &
                          bkoxdnra_sed,bkdnra_sed,q10anh4nitr_sed,                &
                          bkoxamox_sed,bkanh4nitr_sed,q10ano2nitr_sed,            &
-                         bkoxnitr_sed,bkano2nitr_sed,lTO2depremin
+                         bkoxnitr_sed,bkano2nitr_sed
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger , my bad, I have put the `lTO2depremin` switch into the wrong namelist... Fixed now with this PR.