### PR TITLE
workaround for upper/lower case issue for namelist entry lTO2depremin

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3872,7 +3872,7 @@
     <desc>Switch for primary production and remineralization throughout the whole water column</desc>
   </entry>
 
-  <entry id="lTO2depremin">
+  <entry id="lto2depremin">
     <type>logical</type>
     <category>bgcnml</category>
     <group>bgcnml</group>


### PR DESCRIPTION
This PR provides a workaround to use the newly introduced namelist variable `lTO2depremin` by renaming it to `lto2depremin` (closes #428). In general, I believe this problem should be fixed in cime (@mvertens)?