### PR TITLE
New compsets for JRA forcing and fix for PE layout

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -92,8 +92,18 @@
   </compset>
   <compset>
     <!-- not valid for noresm2.5 -->
-    <alias>NOIIAJRAOC</alias>
+    <alias>N2NOIIAJRAOC</alias>
     <lname>2000_DATM%JRA_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>NOIIAJRAOC1850</alias>
+    <lname>1850_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
+  </compset>
+  <compset>
+    <!-- not valid for noresm2.5 -->
+    <alias>N2NOIIAJRAOC1850</alias>
+    <lname>1850_DATM%JRA_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -106,6 +116,22 @@
     <lname>20TR_DATM%JRA_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
+
+  <!-- JRA repeat year forcing - no prognostic wave -->
+  
+  <compset>
+    <alias>NOINYJRARYF1961OC</alias>
+    <lname>1850_DATM%JRARYF1961_SLND_CICE_BLOM%ECO_DROF%JRARYF1961_SGLC_SWAV</lname>
+  </compset>
+  <compset>
+    <!-- not valid for noresm2.5 -->
+    <alias>N2NOINYJRARYF1961OC</alias>
+    <lname>1850_DATM%JRARYF1961_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRARYF_SGLC_SWAV</lname>
+  </compset>
+   
+  
+  <!-- CPLHIST forcing - no prognostic wave -->
+
   <compset>
     <alias>NOICPLHISTOC</alias>
     <lname>1850_DATM%CPLHIST_SLND_CICE_BLOM%ECO_DROF%CPLHIST_SGLC_SWAV</lname>
@@ -116,6 +142,8 @@
       <values match="last">
         <value  compset="20TR_DATM%IAF_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%IAF_SGLC_SWAV">1700-01-01</value>
         <value  compset="20TR_DATM%JRA_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRA_SGLC_SWAV">1653-01-01</value>
+        <value  compset="20TR_DATM%IAF_SLND_CICE_BLOM%ECO_DROF%IAF_SGLC_SWAV">1700-01-01</value>
+        <value  compset="20TR_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV">1653-01-01</value>
       </values>
     </entry>
   </entries>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -187,10 +187,10 @@
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
         <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>1</rootpe_ice>
+          <rootpe_atm>80</rootpe_atm>
+          <rootpe_lnd>80</rootpe_lnd>
+          <rootpe_rof>80</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
           <rootpe_ocn>81</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>


### PR DESCRIPTION
This PR introduces a few new compsets for JRA forcing. The JRA-repeat year forcing also requires updates to datm and drof configuration files, which I will bring later in in a seperate PR.

I also include a fix for the PE layout for the NOINYOC compset because the model was hanging (during startup) in release 2.1.3 (the PE layout was working under release 2.1.1). It might be a coincidence, but changing the order of CICE and DATM/DROF did the trick.