### PR TITLE
Enforce a range of layer interfaces to constant minimum pressure levels for BLOM hybrid vertical coordinate

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1120,6 +1120,16 @@
     <desc>Valid mehtods: 'nudge', 'direct'</desc>
   </entry>
 
+  <entry id="k_range_plevel">
+    <type>integer</type>
+    <category>ale_regrid_remap</category>
+    <group>ale_regrid_remap</group>
+    <values>
+      <value>4</value>
+    </values>
+    <desc>Interface index range from surface enforced to constant pressure levels</desc>
+  </entry>
+
   <entry id="regrid_nudge_ts">
     <type>real</type>
     <category>ale_regrid_remap</category>


### PR DESCRIPTION
Currently for BLOM hybrid vertical coordinate, a water column lighter that the reference potential density of the k = 2 interface would occupy only the first model layer. With this PR, a range of layer interfaces with indices [1, k_range_plevel] will be enforced to the prescribed constant minimum pressure levels, always ensuring some vertical resolution near the surface. Setting the namelist variable k_range_plevel = 1, reproduces the old behaviour. The default value of k_range_plevel has been set to 4 in NorESM configurations, which changes results for vcoord = 'cntiso_hybrid'.

@TomasTorsvik and @JorgSchwinger, it would be interesting to see if this PR would mitigate some of the issues reported in https://github.com/NorESMhub/BLOM/issues/390.