### PR TITLE
Modified compsets with JRA interannual forcing to use year range 1958-2018

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -78,7 +78,7 @@
 
   <compset>
     <alias>NOIIAJRA</alias>
-    <lname>2000_DATM%JRA_SLND_CICE_BLOM_DROF%JRA_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_CICE_BLOM_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>
   <compset>
     <!-- not valid for noresm2.5 -->
@@ -88,7 +88,7 @@
 
   <compset>
     <alias>NOIIAJRAOC</alias>
-    <lname>2000_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_CICE_BLOM%ECO_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>
   <compset>
     <!-- not valid for noresm2.5 -->
@@ -98,7 +98,7 @@
 
   <compset>
     <alias>NOIIAJRAOC1850</alias>
-    <lname>1850_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
+    <lname>1850_DATM%JRA-1p4-2018_SLND_CICE_BLOM%ECO_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>
   <compset>
     <!-- not valid for noresm2.5 -->
@@ -108,7 +108,7 @@
 
   <compset>
     <alias>NOIIAJRAOC20TR</alias>
-    <lname>20TR_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
+    <lname>20TR_DATM%JRA-1p4-2018_SLND_CICE_BLOM%ECO_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>
   <compset>
     <!-- not valid for noresm2.5 -->
@@ -143,7 +143,7 @@
         <value  compset="20TR_DATM%IAF_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%IAF_SGLC_SWAV">1700-01-01</value>
         <value  compset="20TR_DATM%JRA_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRA_SGLC_SWAV">1653-01-01</value>
         <value  compset="20TR_DATM%IAF_SLND_CICE_BLOM%ECO_DROF%IAF_SGLC_SWAV">1700-01-01</value>
-        <value  compset="20TR_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV">1653-01-01</value>
+        <value  compset="20TR_DATM%JRA-1p4-2018_SLND_CICE_BLOM%ECO_DROF%JRA-1p4-2018_SGLC_SWAV">1653-01-01</value>
       </values>
     </entry>
   </entries>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -246,44 +246,6 @@
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>16</ntasks_rof>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>156</ntasks_ocn>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_lnd>128</ntasks_lnd>
-          <ntasks_glc>128</ntasks_glc>
-          <ntasks_wav>128</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>16</rootpe_rof>
-          <rootpe_ice>32</rootpe_ice>
-          <rootpe_ocn>128</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%TL319.+oi%tnx1v4">
-    <mach name="any">
-      <pes pesize="M" compset="_DATM.*_BLOM%ECO">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
           <ntasks_rof>128</ntasks_rof>
           <ntasks_ice>128</ntasks_ice>
           <ntasks_ocn>354</ntasks_ocn>
@@ -319,17 +281,17 @@
   <!-- 512 pes is minimum setting for normal job size on betzy !-->
   <grid name="a%TL319.+oi%tnx1v4">
     <mach name="betzy">
-      <pes pesize="L" compset="_DATM.*_BLOM">
+      <pes pesize="L" compset="any">
         <comment>Large pe-layout with 512 pes in total</comment>
         <ntasks>
-          <ntasks_atm>1</ntasks_atm>
-          <ntasks_rof>1</ntasks_rof>
-          <ntasks_ice>154</ntasks_ice>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_ice>128</ntasks_ice>
           <ntasks_ocn>354</ntasks_ocn>
-          <ntasks_cpl>158</ntasks_cpl>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_glc>128</ntasks_glc>
+          <ntasks_wav>128</ntasks_wav>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -342,11 +304,11 @@
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
         <rootpe>
-          <rootpe_atm>155</rootpe_atm>
-          <rootpe_lnd>156</rootpe_lnd>
-          <rootpe_rof>157</rootpe_rof>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>158</rootpe_ocn>
+          <rootpe_ocn>128</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>


### PR DESCRIPTION
With this both NUOPC and MCT based NorESM will use the same year range for JRA interannual forcing (1958-2018). This is then consistent with what was used for NorESM2 in CMIP6/OMIP2.

This PR also modifies the processor configuration for TL319_tnx1v4 grid combination to be consistent with or without iHAMOCC enabled. This avoids the PIO_STRIDE related crash on Betzy reported in https://github.com/NorESMhub/NorESM/issues/593.