### PR TITLE
minor corrections to new JRA compsets

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -103,7 +103,7 @@
   <compset>
     <!-- not valid for noresm2.5 -->
     <alias>N2NOIIAJRAOC1850</alias>
-    <lname>1850_DATM%JRA_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
+    <lname>1850_DATM%JRA_SLND_CICE_BLOM%ECO_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -126,7 +126,7 @@
   <compset>
     <!-- not valid for noresm2.5 -->
     <alias>N2NOINYJRARYF1961OC</alias>
-    <lname>1850_DATM%JRARYF1961_SLND_CICE%NORESM-CMIP6_BLOM%ECO_DROF%JRARYF_SGLC_SWAV</lname>
+    <lname>1850_DATM%JRARYF1961_SLND_CICE_BLOM%ECO_DROF%JRARYF1961_SGLC_SWAV</lname>
   </compset>
    
   


### PR DESCRIPTION
This PR has two minor corrections to the newly introduced new JRA-forcing compsets
* do not switch on extended sea-ice output as for CMIP6
* correct writing of the JRA repeat-year-forcing 1961 as a DROF option