### PR TITLE
Add error message if user_nl_blom includes hash comments

### DIFF
--- a/cime_config/ocn_in_paramgen.py
+++ b/cime_config/ocn_in_paramgen.py
@@ -1337,6 +1337,22 @@ class OcnInParamGen(ParamGen):
                         line = remove_user_nl_comment(line)
                     #End if
 
+                    #Check if the first character on the line is a hash sign (#):
+                    #This is no longer allowed as a first character, and may indicate
+                    #the use of an old user_nl_blom file
+                    if line.strip()[0] == "#":
+                        emsg = f"Line number {line_num+1} in 'user_nl_blom'"
+                        emsg += " starts with a hash sign (#). This may"
+                        emsg += " indicate an outdated format of your"
+                        emsg += "\nuser_nl_blom file. Current versions of"
+                        emsg += " user_nl_blom file conform to the standard"
+                        emsg += " Fortran namelist syntax, indicating comments"
+                        emsg += "\nwith exclamation mark (!). Please check that"
+                        emsg += " your user_nl_blom file conforms with the"
+                        emsg += " current accepted file format."
+                        raise OcnInParamGenError(emsg)
+                    #End if
+
                     #Check if the first character on the line is a comma (,):
                     if line.strip()[0] == ",":
                         #Is this an array variable:


### PR DESCRIPTION
If someone use an old `user_nl_blom` file with hash symbols (#) for comments, there will be an error message on the form:

```
ocn_in_paramgen.OcnInParamGenError: Line number 1 in 'user_nl_blom' starts with a hash sign (#). This may indicate an outdated format of your
user_nl_blom file. Current versions of user_nl_blom file conform to the standard Fortran namelist syntax, indicating comments
with exclamation mark (!). Please check that your user_nl_blom file conforms with the current accepted file format.
```

This does not guarantee that older files will be caught, only in case comment lines are kept.
Response to [NorESM issue #618](https://github.com/NorESMhub/NorESM/issues/618).

If this PR receives positive reviews, I would include the same error message in `release-1.6` and `master` branches as well.