### PR TITLE
Add N2 compset for NOINYOC that still uses isopycnic coordinates

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -43,6 +43,11 @@
     <alias>NOINYOC</alias>
     <lname>1850_DATM%NYF_SLND_CICE_BLOM%HYB%ECO_DROF%NYF_SGLC_SWAV</lname>
   </compset>
+  <compset>
+    <!-- not valid for noresm2.5 -->
+    <alias>N2NOINYOC</alias>
+    <lname>1850_DATM%NYF_SLND_CICE_BLOM%ECO_DROF%NYF_SGLC_SWAV</lname>
+  </compset>
 
   <compset>
     <alias>NOIIA</alias>


### PR DESCRIPTION
The NOINYOC compset is used a lot for testing, so we need a N2NOINYOC compset that still selects isopucnic coordinates as a default.