### PR TITLE
Fix CI test system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 env:
   # This version of Meson should be available as an EasyBuild on Fram and Betzy
-  MESON_VERSION: '1.1.1'
+  MESON_VERSION: '1.4.0'
 jobs:
   build:
     name: Build BLOM on Github provided OS
@@ -11,7 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]      # Testing with macos-latest currently not working
+        # os: [macos-lates]       # Disabled, testing with macos-latest currently not working
+        # os: [ubuntu-latest]     # Disabled, Testing with ubuntu-24.04 currently not working
+        os: [ubuntu-22.04]
         mpi: [true, false]
         openmp: ['enabled', 'disabled']
         ecosys: [false]   # ecosys==true fails with gcc, disable for now but leave placeholder
@@ -30,6 +32,7 @@ jobs:
       - name: Install dependencies - Ubuntu
         run: |
           sudo apt update
+          sudo apt upgrade -y
           sudo apt install -y libnetcdff-dev mpi-default-dev ninja-build
         if: runner.os == 'Linux'
 
@@ -42,7 +45,7 @@ jobs:
       - name: Setup Python for newer version of Meson
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Meson
         run: python -m pip install meson==${{ env.MESON_VERSION }}


### PR DESCRIPTION
- Revert to ubuntu-22.04
- Update meson and python versions

Same as #453 , but applied to the `master` branch.