### PR TITLE
Update buildlib, buildlib_2.1, buildlib_2.2

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -3,7 +3,7 @@
 """
 build blom library
 """
-import os, shutil, sys, glob, imp
+import os, sys
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:

--- a/cime_config/buildlib_2.1
+++ b/cime_config/buildlib_2.1
@@ -3,7 +3,8 @@
 """
 build blom library
 """
-import os, shutil, sys, glob, imp
+import os, shutil, sys, glob
+from importlib.machinery import SourceFileLoader
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -32,7 +33,7 @@ def _main_func():
         cmd = os.path.join(os.path.join(comp_root_dir_ocn, "cime_config", "buildcpp"))
         logger.info("     ...calling blom buildcpp to set build time options")
         try:
-            mod = imp.load_source("buildcpp", cmd)
+            mod = SourceFileLoader("buildcpp", cmd).load_module()
             blom_cppdefs = mod.buildcpp(case)
         except:
             raise

--- a/cime_config/buildlib_2.2
+++ b/cime_config/buildlib_2.2
@@ -3,7 +3,8 @@
 """
 build blom library
 """
-import os, shutil, sys, glob, imp
+import os, shutil, sys, glob
+from importlib.machinery import SourceFileLoader
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -33,7 +34,7 @@ def _main_func():
         cmd = os.path.join(os.path.join(comp_root_dir_ocn, "cime_config", "buildcpp"))
         logger.info("     ...calling blom buildcpp to set build time options")
         try:
-            mod = imp.load_source("buildcpp", cmd)
+            mod = SourceFileLoader("buildcpp", cmd).load_module()
             blom_cppdefs = mod.buildcpp(case)
         except:
             raise


### PR DESCRIPTION
The "imp" module is deprecated in favor of importlib. Updating release-1.4 branch according to changes in master branch.