### PR TITLE
Update M4AGO scheme to version v1.1.1 (equivalent to dev-1.1.1)

### DIFF
--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -47,7 +47,7 @@ contains
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
                               use_nuopc_ndep,lTO2depremin
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
-    use mo_param_bgc,   only: ini_parambgc
+    use mo_param_bgc,   only: ini_parambgc,claydens,calcdens,calcwei,opaldens,opalwei,ropal
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
     use mo_biomod,      only: alloc_mem_biomod
     use mo_sedmnt,      only: alloc_mem_sedmnt,sedlay,powtra,burial,ini_sedmnt
@@ -66,7 +66,8 @@ contains
     use mo_ini_fields,  only: ini_fields_ocean,ini_fields_atm
     use mo_aufr_bgc,    only: aufr_bgc
     use mo_extNsediment,only: alloc_mem_extNsediment_diag
-    use mo_ihamocc4m4ago, only: alloc_mem_m4ago,init_m4ago_nml_params, init_m4ago_params
+    use mo_ihamocc4m4ago, only: alloc_mem_m4ago
+    use mo_m4ago_HAMOCCinit,only: init_m4ago_nml_params, init_m4ago_derived_params
     use mo_read_shelfmask,only: ini_read_shelfmask,shelfsea_maskfile
 
 
@@ -182,8 +183,8 @@ contains
     !
     call ini_parambgc()
     if (use_M4AGO) then
-      call init_m4ago_nml_params
-      call init_m4ago_params
+      call init_m4ago_nml_params(claydens,calcdens,calcwei,opaldens,opalwei)
+      call init_m4ago_derived_params(ropal)
     endif
 
     ! --- Initialize atmospheric fields with (updated) parameter values

--- a/pkgs/meson.build
+++ b/pkgs/meson.build
@@ -26,4 +26,10 @@ if get_option('ecosys')
    if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_types.f90')
      sources += files('M4AGO-sinking-scheme/src/mo_m4ago_types.f90')
    endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCinit.F90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCinit.F90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCPrimPart.F90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCPrimPart.F90')
+   endif
 endif

--- a/pkgs/meson.build
+++ b/pkgs/meson.build
@@ -17,4 +17,13 @@ if get_option('ecosys')
    if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_kind.F90')
      sources += files('M4AGO-sinking-scheme/src/mo_m4ago_kind.F90')
    endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_control.f90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_control.f90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_params.f90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_params.f90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_types.f90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_types.f90')
+   endif
 endif


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger , with this PR, the M4AGO scheme tag is updated to an improved, updated M4AGO scheme version. For the updated version, see release notes: https://github.com/jmaerz/M4AGO-sinking-scheme/releases/tag/v1.1.0 and https://github.com/jmaerz/M4AGO-sinking-scheme/releases/tag/v1.1.1

Two notes:
- I have tested this only in the NorESM2.1 version thus far - I am not sure, if anything needs to be done wrt git fleximod
- I have kept the meson.build file backwards compatible to earlier M4AGO versions - not sure, if this should remain like this (it doesn't harm, but could be simplified with the updated version). 

Now steps taken to test with the NorESM development tag `noresm2_5_alpha08d` (for documenting the required steps to test branches)
```
git clone git@github.com:NorESMhub/NorESM.git
cd NorESM
git checkout noresm2_5_alpha08d
gvim .gitmodules
```
In `.gitmodules`, replaced
```
[submodule "blom"]
path = components/blom
url = https://github.com/NorESMhub/BLOM.git
fxtag = dev1.6.1.8
fxrequired = ToplevelRequired
fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
```
by (**Note:** `new-m4ago` is just a branch, not a tag)
```
[submodule "blom"]
path = components/blom
url = https://github.com/jmaerz/BLOM.git
fxtag = new-m4ago
fxrequired = ToplevelRequired
fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
```
Then, to update the submodules:
```
./bin/git-fleximod update --optional
```
After this call, everything should be/was in place to build and run the model as usual. For help on `git fleximod`, see also https://github.com/NorESMhub/NorESM/discussions/599 and https://github.com/ESMCI/git-fleximod.

However, currently the model version  `noresm2_5_alpha08d` fails, when running due to errors that seem not to be related to the updated scheme, but rather due to the ice mesh (see: https://github.com/NorESMhub/CMEPS/issues/28).