### PR TITLE
Fix some namelist parameters for tnx2v1 grid

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -337,6 +337,7 @@
     <group>limits</group>
     <values>
       <value>5.e-5</value>
+      <value ocn_grid="tnx2v1"    >.75e-4</value>
       <value ocn_grid="tnx1v4" ocn_ncpl="24">.75e-4</value>
       <value ocn_grid="tnx0.5v1"  >.75e-4</value>
       <value ocn_grid="tnx0.25v4" >.75e-4</value>
@@ -403,6 +404,7 @@
     <group>limits</group>
     <values>
       <value>.06</value>
+      <value ocn_grid="tnx2v1"    blom_vcoord="isopyc_bulkml"              >.5</value>
       <value ocn_grid="tnx1v4"    blom_vcoord="isopyc_bulkml" ocn_ncpl="24">.5</value>
       <value ocn_grid="tnx0.5v1"  blom_vcoord="isopyc_bulkml" ocn_ncpl="24">.5</value>
       <value ocn_grid="tnx0.25v4" blom_vcoord="isopyc_bulkml">1.0</value>


### PR DESCRIPTION
There were two BLOM namelist parameter that were not set differently from default for the tnx2v1 grid. This PR fixes this since the defaults did not make sense for the 2-degree grid (although it hasn't been explored if the new setting are optimal). The changes due to the new remain relatively small, but notably there is a small reduction in overall temperature biases. Diagnostics can be found here (comparison valid for physics only):

https://ns2345k.web.sigma2.no/datalake/diagnostics/noresm/jschwing/NOINYOC_T62_tn21_45/BLOM_DIAG/yrs991to1000-NOINYOC_T62_tn21_42/