### PR TITLE
add git fleximod support to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,12 @@
 [submodule "CVMix-src"]
 	path = pkgs/CVMix-src
 	url = https://github.com/CVMix/CVMix-src
+	fxtag = v0.98-beta
+	fxrequired = AlwaysRequired
+        fxDONOTUSEurl = https://github.com/CVMix/CVMix-src
 [submodule "pkgs/M4AGO-sinking-scheme"]
 	path = pkgs/M4AGO-sinking-scheme
 	url = https://github.com/jmaerz/M4AGO-sinking-scheme
+	fxtag = v1.1.1
+	fxrequired = AlwaysRequired
+	fxDONOTUSEurl = https://github.com/jmaerz/M4AGO-sinking-scheme


### PR DESCRIPTION
Hi @TomasTorsvik , @matsbn , @JorgSchwinger ,
This PR add full fleximod support for both, CVMIX and M4AGO submodules. 

**One thing to note:**
 `git fleximod` seems to first check the regular `git submodule update` command. If then a` fx...` (`git fleximod`) entry is found in the `.gitmodules` file, it supersedes the submodule version that is committed via a regular git command (if they are different from each other). Hence, one needs to take care, which command to run when, if the regular git committed change in the submodule is not identical to the tag/branch entry of `git fleximod` (the `fx...` entries). This can lead to divergent versions to be used, if not taken care of manually (I kind of miss a `git fleximod update-to-regular-git-submodule` command to not having to manually edit the `.gitmodules` file, when committing submodule changes...). 
I currently made the entries identical between `git fleximod` and the regular `git submodule`.

Closes #465