### PR TITLE
Update M4AGO to v1.1.1 (equiv. to dev-1.1.1)

### DIFF
--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -46,7 +46,7 @@ contains
                               do_ndep_coupled,leuphotic_cya,do_n2onh3_coupled,                     &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
-    use mo_param_bgc,   only: ini_parambgc
+    use mo_param_bgc,   only: ini_parambgc,claydens,calcdens,calcwei,opaldens,opalwei,ropal
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
     use mo_biomod,      only: alloc_mem_biomod
     use mo_sedmnt,      only: alloc_mem_sedmnt,sedlay,powtra,burial,ini_sedmnt
@@ -65,7 +65,8 @@ contains
     use mo_ini_fields,  only: ini_fields_ocean,ini_fields_atm
     use mo_aufr_bgc,    only: aufr_bgc
     use mo_extNsediment,only: alloc_mem_extNsediment_diag
-    use mo_ihamocc4m4ago, only: alloc_mem_m4ago,init_m4ago_nml_params, init_m4ago_params
+    use mo_ihamocc4m4ago, only: alloc_mem_m4ago
+    use mo_m4ago_HAMOCCinit,only: init_m4ago_nml_params, init_m4ago_derived_params
 
 
     ! Arguments
@@ -180,8 +181,8 @@ contains
     !
     call ini_parambgc(idm,jdm)
     if (use_M4AGO) then
-      call init_m4ago_nml_params
-      call init_m4ago_params
+      call init_m4ago_nml_params(claydens,calcdens,calcwei,opaldens,opalwei)
+      call init_m4ago_derived_params(ropal)
     endif
 
     ! --- Initialize atmospheric fields with (updated) parameter values

--- a/pkgs/meson.build
+++ b/pkgs/meson.build
@@ -1,3 +1,4 @@
+fs = import('fs') # import fs system module: https://mesonbuild.com/Fs-module.html
 sources += files('CVMix-src/src/shared/cvmix_background.F90',
 'CVMix-src/src/shared/cvmix_convection.F90', 
 'CVMix-src/src/shared/cvmix_ddiff.F90',
@@ -13,4 +14,22 @@ if get_option('ecosys')
    sources += files('M4AGO-sinking-scheme/src/mo_m4ago_core.f90',
                     'M4AGO-sinking-scheme/src/mo_m4ago_physics.f90',
        		    'M4AGO-sinking-scheme/src/mo_ihamocc4m4ago.f90')
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_kind.F90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_kind.F90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_control.f90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_control.f90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_params.f90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_params.f90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_types.f90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_types.f90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCinit.F90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCinit.F90')
+   endif
+   if fs.exists('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCPrimPart.F90')
+     sources += files('M4AGO-sinking-scheme/src/mo_m4ago_HAMOCCPrimPart.F90')
+   endif
 endif


### PR DESCRIPTION
This PR to the release-branch 1.6 updates the thus far optional M4AGO sinking scheme to the more robust version v1.1.1 (which is equivalent to version dev-1.1.1). Minor changes in M4AGO results can be expected (see M4AGO release notes:  https://github.com/jmaerz/M4AGO-sinking-scheme/releases/tag/v1.1.0 and https://github.com/jmaerz/M4AGO-sinking-scheme/releases/tag/v1.1.1) 

The new version has also been introduced in `master` via PR #460 and is part of BLOM tag 1.7.

Tested in PR #460 and this branch via `single_column` test case.