### PR TITLE
Add Externals_BLOM.cfg file for use with NorESM2.3

### DIFF
--- a/Externals_BLOM.cfg
+++ b/Externals_BLOM.cfg
@@ -1,0 +1,16 @@
+[CVMix]
+tag = v0.98-beta
+protocol = git
+repo_url = https://github.com/CVMix/CVMix-src
+local_path = pkgs/CVMix-src
+required = True
+
+[M4AGO]
+tag = v1.1.1
+protocol = git
+repo_url = https://github.com/jmaerz/M4AGO-sinking-scheme
+local_path = pkgs/M4AGO-sinking-scheme
+required = True
+
+[externals_description]
+schema_version = 1.0.0


### PR DESCRIPTION
This PR re-introduces the `Externals_BLOM.cfg` file, so that we can use the current `master` branch (currently `v1.7` tag and potentially the upcoming `v1.8` tag) in NorESM2.3.

See discussion in #470 