### PR TITLE
Filtering of squared buoyancy frequency and Richardson number

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1374,9 +1374,10 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>1.2</value>
+      <value>0.7</value>
+      <value blom_vcoord="isopyc_bulkml">1.2</value>
     </values>
-    <desc>Critical gradient richardson number for shear driven</desc>
+    <desc>Critical gradient Richardson number for shear driven vertical mixing</desc>
   </entry>
 
   <entry id="bdmtyp">

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2009-2024 Mats Bentsen, Mehmet Ilicak, Aleksi Nummelin,
+! Copyright (C) 2009-2025 Mats Bentsen, Mehmet Ilicak, Aleksi Nummelin,
 !                         Mariana Vertenstein
 !
 ! This file is part of BLOM.

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -1118,13 +1118,11 @@ contains
           rig_i(kk+1) = rig_i(kk)
           bvfsq_i(kk+1) = bvfsq_i(kk)
 
-          do n_iter = 1, 1 !n_smooth_ri
-            rig_i_prev(:) = rig_i(:)
-            bvfsq_i_prev(:) = bvfsq_i(:)
-            do k = 2, kk
-               rig_i(k) = .5_r8*rig_i_prev(k) + .25*(rig_i_prev(k-1) + rig_i_prev(k+1))
-               bvfsq_i(k) = .5_r8*bvfsq_i_prev(k) + .25*(bvfsq_i_prev(k-1) + bvfsq_i_prev(k+1))
-            enddo
+          rig_i_prev(:) = rig_i(:)
+          bvfsq_i_prev(:) = bvfsq_i(:)
+          do k = 2, kk
+             rig_i(k) = .5_r8*rig_i_prev(k) + .25*(rig_i_prev(k-1) + rig_i_prev(k+1))
+             bvfsq_i(k) = .5_r8*bvfsq_i_prev(k) + .25*(bvfsq_i_prev(k-1) + bvfsq_i_prev(k+1))
           enddo
           bvf_i(:) = sqrt( max( bvfsq_i(:), 0.) )
 
@@ -1288,13 +1286,11 @@ contains
           rig_i(kk+1) = rig_i(kk)
           bvfsq_i(kk+1) = bfsqi(i,j,kk+1)
 
-          do n_iter = 1, 1 !n_smooth_ri
-            rig_i_prev(:) = rig_i(:)
-            bvfsq_i_prev(:) = bvfsq_i(:)
-            do k = 2, kk
-               rig_i(k) = .5_r8*rig_i_prev(k) + .25*(rig_i_prev(k-1) + rig_i_prev(k+1))
-               bvfsq_i(k) = .5_r8*bvfsq_i_prev(k) + .25*(bvfsq_i_prev(k-1) + bvfsq_i_prev(k+1))
-            enddo
+          rig_i_prev(:) = rig_i(:)
+          bvfsq_i_prev(:) = bvfsq_i(:)
+          do k = 2, kk
+             rig_i(k) = .5_r8*rig_i_prev(k) + .25*(rig_i_prev(k-1) + rig_i_prev(k+1))
+             bvfsq_i(k) = .5_r8*bvfsq_i_prev(k) + .25*(bvfsq_i_prev(k-1) + bvfsq_i_prev(k+1))
           enddo
 
           ! gets index of the level and interface above hbl


### PR DESCRIPTION
Filtering of squared buoyancy frequency and Richardson number has been added to reduced noise in vertical diffusivity when using KPP. Along with the filtering, the critical gradient Richardson number for shear driven vertical mixing has also been adjusted.

This modification has been quite extensively tested in OMIP2 simulations and was also used in the simulation https://github.com/NorESMhub/noresm3_dev_simulations/issues/68 based on the noresm2_5_alpha08d tag. There is no change with isopycnic vertical coordinate.