### PR TITLE
Enabled parameterized wave forcing of Langmuir mixing.

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -776,7 +776,7 @@
     <category>limits</category>
     <group>limits</group>
     <values>
-      <value>none</value>
+      <value>param</value>
     </values>
     <desc>Source of wave fields. Valid source: 'none', 'param', 'extern' (a)</desc>
   </entry>
@@ -1447,7 +1447,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>none</value>
+      <value>vr12-ma</value>
     </values>
     <desc>Type of CVMix Langmuir turbulence parameterization. Valid</desc>
   </entry>


### PR DESCRIPTION
Enabled parameterized wave forcing to drive Langmuir mixing according to Li et al. (2016) and as implemented in CVMix.

This modification has been quite extensively tested in OMIP2 simulations and was also used in the simulation https://github.com/NorESMhub/noresm3_dev_simulations/issues/68 based on the noresm2_5_alpha08d tag. There is no change with isopycnic vertical coordinate.