### PR TITLE
Update buildlib for M4AGO, ecosys dependency

### DIFF
--- a/cime_config/buildlib_2.1
+++ b/cime_config/buildlib_2.1
@@ -66,7 +66,6 @@ def _main_func():
                      os.path.join(comp_root_dir_ocn, "channel"),
                      os.path.join(comp_root_dir_ocn, "single_column"),
                      os.path.join(comp_root_dir_ocn, "pkgs", "CVMix-src", "src", "shared"),
-                     os.path.join(comp_root_dir_ocn, "pkgs", "M4AGO-sinking-scheme", "src"),
                      os.path.join(comp_root_dir_ocn, "phy")]
 
             if turbclo != 0 and tracers != 0:
@@ -78,6 +77,7 @@ def _main_func():
                         paths.append(os.path.join(comp_root_dir_ocn, "idlage"))
                     elif module == "ecosys":
                         paths.append(os.path.join(comp_root_dir_ocn, "hamocc"))
+                        paths.append(os.path.join(comp_root_dir_ocn, "pkgs", "M4AGO-sinking-scheme", "src"))
                     else:
                         expect(False, "tracer module {} is not recognized".format(module))
 

--- a/cime_config/buildlib_2.2
+++ b/cime_config/buildlib_2.2
@@ -67,7 +67,6 @@ def _main_func():
                      os.path.join(comp_root_dir_ocn, "channel"),
                      os.path.join(comp_root_dir_ocn, "single_column"),
                      os.path.join(comp_root_dir_ocn, "pkgs", "CVMix-src", "src", "shared"),
-                     os.path.join(comp_root_dir_ocn, "pkgs", "M4AGO-sinking-scheme", "src"),
                      os.path.join(comp_root_dir_ocn, "phy")]
 
             if turbclo != 0 and tracers != 0:
@@ -79,6 +78,7 @@ def _main_func():
                         paths.append(os.path.join(comp_root_dir_ocn, "idlage"))
                     elif module == "ecosys":
                         paths.append(os.path.join(comp_root_dir_ocn, "hamocc"))
+                        paths.append(os.path.join(comp_root_dir_ocn, "pkgs", "M4AGO-sinking-scheme", "src"))
                     else:
                         expect(False, "tracer module {} is not recognized".format(module))
 


### PR DESCRIPTION
Only include M4AGO source files if building with "ecosys". This fix for `release-1.6` has already been implemented in `master`.

