### PR TITLE
Update testdefs, BLOM hybrid is now default

### DIFF
--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
   <!-- aux_blom_noresm : Declarations for BLOM/iHAMOCC tests -->
-  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hybrid">
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
@@ -28,7 +28,7 @@
       <option name="comment">test restart with 2 degree, isopycnic layers and core forcing</option>
     </options>
   </test>
-  <test name="ERR_Ld3" grid="TL319_tn14" compset="NOIIAJRAOC" testmods="blom/hybrid">
+  <test name="ERR_Ld3" grid="TL319_tn14" compset="NOIIAJRAOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
@@ -37,7 +37,7 @@
       <option name="comment">test restart/resubmit with hybrid coordinates and JRA forcing</option>
     </options>
   </test>
-  <test name="ERS_Ld3" grid="TL319_tn05" compset="NOIIAJRA" testmods="blom/hybrid">
+  <test name="ERS_Ld3" grid="TL319_tn05" compset="NOIIAJRA">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>


### PR DESCRIPTION
BLOM hybrid is now default in the `master` branch. Using `testmods="blom/hybrid"` results in error at SETUP stage:

```
ERROR: BLOM_VCOORD == cntiso_hybrid and BLOM_TURBULENT_CLOSURE ==  is not a valid combination'
```

This PR removes the "blom/hybrid" testmods.