### PR TITLE
Ensure non-negative tracer values and conservation by virtual flux correction

### DIFF
--- a/ben02/mod_thermf_ben02.F90
+++ b/ben02/mod_thermf_ben02.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2002-2024 Mats Bentsen, Mehmet Ilicak
+! Copyright (C) 2002-2025 Mats Bentsen, Mehmet Ilicak
 !
 ! This file is part of BLOM.
 !
@@ -36,7 +36,7 @@ module mod_thermf_ben02
                            swa, nsf, hmltfz, lip, sop, eva, rnf, rfi, &
                            fmltfz, sfl, ustarw, surflx, surrlx, &
                            sswflx, salflx, brnflx, salrlx, ustar, &
-                           t_rs_nonloc, s_rs_nonloc
+                           salt_corr, trc_corr, t_rs_nonloc, s_rs_nonloc
   use mod_swabs,     only: swbgal, swbgfc
   use mod_ben02,     only: tsi_tda, tml_tda, sml_tda, alb_tda, fice_tda, &
                            tsi, ntda, dfl, albw, alb, &
@@ -46,13 +46,12 @@ module mod_thermf_ben02
                            fuss, fice_max, tice_m, tsnw_m, hice_nhmn, &
                            hice_shmn, sagets, sice, cwi, cuc
   use mod_seaice,    only: ficem, hicem, hsnwm, ustari, iagem
-  use mod_utility,   only: util1, util2, util3, util4
+  use mod_utility,   only: util1, util2, util3
   use mod_checksum,  only: csdiag, chksummsk
   use mod_intp1d,    only: intp1d
   use mod_tracers,   only: ntr, itrtke, itrgls, trc, trflx
   use mod_diffusion, only: difdia
   use mod_tke,       only: gls_cmu0, Zos, gls_p, gls_m, gls_n, vonKar
-  use mod_tracers,   only: ntr, trc, trflx
   use mod_ifdefs,    only: use_TRC, use_TKE, use_GLS
 
   implicit none
@@ -65,30 +64,26 @@ contains
 
   subroutine thermf_ben02(m,n,mm,nn,k1m,k1n)
 
-    ! --- NERSC version of thermf.
+    ! NERSC version of thermf.
 
     ! Arguments
     integer, intent(in) :: m,n,mm,nn,k1m,k1n
 
     ! Local variables
     real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: vrtsfl
-    integer :: i,j,k,l,m1,m2,m3,m4,m5,ntld,kn,kl
+    real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,ntr) :: trflxc_aw
+    integer :: i,j,k,l,m1,m2,m3,m4,m5,ntld,kn,kl,nt
     real :: dt,cpsw,rnf_fac,sag_fac,y
     real :: dpotl,hotl,totl,sotl,tice_f,hice_min,fice,hice,hsnw,tsrf
     real :: fice0,hice0,hsnw0,qsww,qnsw,tice,albi,tsmlt,albi_h,qswi,dh
     real :: qsnwf,fcond,qdamp,qsmlt,qo2i,qbot,swfac,dtml,q,volice,df,dvi
     real :: dvs,fwflx,sstc,rice,dpmxl,hmxl,tmxl,trxflx,pbot,dprsi,sssc
-    real :: smxl,srxflx,totsfl,totwfl,sflxc,totsrp,totsrn,A_cgs2mks
-    integer :: nt
-    real, dimension(ntr,1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-         ttrsf,ttrav
-    ! real tottrsf,tottrav,trflxc
-    real :: trflxc
+    real :: smxl,srxflx,sflxc,totsrp,totsrn,qp,qn,trflxc,A_cgs2mks
 
     A_cgs2mks = 1./(L_mks2cgs**2)
 
-    ! --- Due to conservation, the ratio of ice and snow density must be
-    ! --- equal to the ratio of ice and snow heat of fusion
+    ! Due to conservation, the ratio of ice and snow density must be equal to
+    ! the ratio of ice and snow heat of fusion
     if (abs(fuss/fusi-rhosnw/rhoice) > epsilt) then
       if (mnproc == 1) then
         write (lp,*) &
@@ -99,16 +94,16 @@ contains
       end if
     end if
 
-    ! --- Set various constants
+    ! Set various constants
     dt = baclin                         ! Time step
-    cpsw = spcifh*M_mks2cgs                  ! Specific heat of seawater
+    cpsw = spcifh*M_mks2cgs             ! Specific heat of seawater
     rnf_fac = baclin/real(nrfets*86400) ! Runoff reservoar detrainment rate
-    sag_fac = exp(-sagets*dt)            ! Snow aging rate
+    sag_fac = exp(-sagets*dt)           ! Snow aging rate
 
-    ! --- Set parameters for time interpolation when applying diagnosed heat
-    ! --- and salt relaxation fluxes
+    ! Set parameters for time interpolation when applying diagnosed heat and
+    ! salt relaxation fluxes
     y = (nday_of_year-1+mod(nstep,nstep_in_day)/real(nstep_in_day))*48. &
-         /real(nday_in_year)
+        /real(nday_in_year)
     m3 = int(y)+1
     y = y-real(m3-1)
     m1 = mod(m3+45,48)+1
@@ -116,7 +111,7 @@ contains
     m4 = mod(m3   ,48)+1
     m5 = mod(m3+ 1,48)+1
 
-    ! --- Time level for diagnosing heat and salt relaxation fluxes
+    ! Time level for diagnosing heat and salt relaxation fluxes
     ntld = m3
 
     if (ditflx.or.disflx) nflxdi(ntld) = nflxdi(ntld)+1
@@ -132,8 +127,8 @@ contains
       do l = 1,isp(j)
         do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
 
-          ! --- --- Initialize variables describing the state of the ocean top
-          ! --- --- layer, the mixed layer and ice/snow fraction
+          ! Initialize variables describing the state of the ocean top layer,
+          ! the mixed layer and ice/snow fraction
           dpotl = dp(i,j,k1n)
           hotl = dpotl/onem
           totl = temp(i,j,k1n)+t0deg
@@ -148,10 +143,10 @@ contains
           hice0 = hice
           hsnw0 = hsnw
 
-          ! --- --- Freezing point of sea water (in k)
+          ! Freezing point of sea water (in k)
           tice_f = swtfrz(p(i,j,1),sotl)+t0deg
 
-          ! --- --- Minmimum ice thickness
+          ! Minmimum ice thickness
           if (plat(i,j) > 0.) then
             hice_min = hice_nhmn
           else
@@ -160,54 +155,54 @@ contains
 
           if     (fice*hice < 1.e-5) then
 
-            ! --- ------------------------------------------------------------------
-            ! --- ----- At most, a small amount of ice is present in the grid cell.
-            ! --- ----- Melt the remainders of ice and snow.
-            ! --- ------------------------------------------------------------------
+            ! ------------------------------------------------------------------
+            ! At most, a small amount of ice is present in the grid cell. Melt
+            ! the remainders of ice and snow.
+            ! ------------------------------------------------------------------
 
             hice = 0.
             hsnw = 0.
             fice = 0.
 
-            ! --- ----- Mean albedo of grid cell
+            ! Mean albedo of grid cell
             alb(i,j) = albw(i,j)
 
-            ! --- ----- Solar heat flux that enters the ocean
+            ! Solar heat flux that enters the ocean
             qsww = swa(i,j)
 
-            ! --- ----- Non solar heat flux that enters the ocean
+            ! Non solar heat flux that enters the ocean
             qnsw = nsf(i,j)
 
-            ! --- ----- Set surface temperature and ice surface temperature
+            ! Set surface temperature and ice surface temperature
             tsrf = totl
             tice = totl
 
           else
 
-            ! --- ------------------------------------------------------------------
-            ! --- ----- Do thermodynamics for an ice slab
-            ! --- ------------------------------------------------------------------
+            ! ------------------------------------------------------------------
+            ! Do thermodynamics for an ice slab
+            ! ------------------------------------------------------------------
 
             if (fice*hsnw > 1.e-3) then
 
-              ! --- ------- Set various variables in the case of a snow layer
+              ! Set various variables in the case of a snow layer
 
-              ! --- ------- Albedo
+              ! Albedo
               if (tsrf > tsnw_m-.1) then
                 albi = albs_m
               else
                 albi = albs_f
               end if
 
-              ! --- ------- Surface melting temperature
+              ! Surface melting temperature
               tsmlt = tsnw_m
 
             else
 
-              ! --- ------- Set various variables in the case a thin or non existent
-              ! --- ------- snow layer
+              ! Set various variables in the case a thin or non existent snow
+              ! layer
 
-              ! --- ------- Albedo
+              ! Albedo
               albi_h = .065+.44*hice**.28
               if (tsrf > tice_m-.1) then
                 albi = min(albi_m,albi_h)
@@ -215,33 +210,32 @@ contains
                 albi = min(albi_f,albi_h)
               end if
 
-              ! --- ------- Surface melting temperature
+              ! Surface melting temperature
               tsmlt = tice_m
 
             end if
 
-            ! --- ----- Mean albedo of the grid cell
+            ! Mean albedo of the grid cell
             alb(i,j) = albi*fice+albw(i,j)*(1.-fice)
 
-            ! --- ----- Short wave radiation trough the ice covered fraction
+            ! Short wave radiation trough the ice covered fraction
             qswi = swa(i,j)*(1.-albi)/(1.-alb(i,j))
 
-            ! --- ----- Solar heat flux trough the open water fraction
+            ! Solar heat flux trough the open water fraction
             qsww = swa(i,j)*(1.-albw(i,j))/(1.-alb(i,j))
 
-            ! --- ----- Update snow thickness due to precipitation
+            ! Update snow thickness due to precipitation
             dh = sop(i,j)*dt/rhosnw
             hsnw = hsnw+dh
 
-            ! --- ----- Heat flux from snow to ice to balance the latent heat of
-            ! --- ----- snow fall
+            ! Heat flux from snow to ice to balance the latent heat of snow fall
             qsnwf = dh*fuss/dt
 
-            ! --- ----- Conductive factor in snow and ice layer
+            ! Conductive factor in snow and ice layer
             fcond = rkice*rksnw/(rksnw*hice+rkice*hsnw)
 
-            ! --- ----- Find the snow surface temperature and the non solar heat
-            ! --- ----- flux that enters the open water fraction
+            ! Find the snow surface temperature and the non solar heat flux that
+            ! enters the open water fraction
             if (abs(fcond-dfl(i,j)*(2.-fice)) < 1.e-3) then
               tsrf = tice_f+(qswi+nsf(i,j))/fcond
               qnsw = nsf(i,j)
@@ -254,9 +248,9 @@ contains
               qdamp = dfl(i,j)*(min(tsrf,tsmlt)-tsi(i,j))
             end if
 
-            ! --- ----- If the new surface temperature is above the snow melting
-            ! --- ----- temperature, determine the heat that goes to melting at the
-            ! --- ----- surface
+            ! If the new surface temperature is above the snow melting
+            ! temperature, determine the heat that goes to melting at the
+            ! surface
             if (tsrf > tsmlt) then
               tsrf = tsmlt
               qsmlt = qswi+nsf(i,j) &
@@ -266,17 +260,17 @@ contains
               qsmlt = 0.
             end if
 
-            ! --- ----- Set ice surface temperature
+            ! Set ice surface temperature
             tice = tice_f-fcond*(tice_f-tsrf)*hice/rkice
 
-            ! --- ----- Heat flux from ocean to ice (Maykut and McPhee 1995)
-            qo2i = rhowat*cpsw*cwi*max(ustari(i,j),.2e-2) &
-                 *min(tice_f-totl,0.)+cuc*max(tice_f-totl,0.)
+            ! Heat flux from ocean to ice (Maykut and McPhee 1995)
+            qo2i = rhowat*cpsw*cwi*max(ustari(i,j),.2e-2)*min(tice_f-totl,0.) &
+                 + cuc*max(tice_f-totl,0.)
 
-            ! --- ----- Heat budget at bottom of ice
+            ! Heat budget at bottom of ice
             qbot = -fcond*(tice_f-tsrf)-qo2i-qdamp+qsnwf
 
-            ! --- ----- Update snow thickness due to melting
+            ! Update snow thickness due to melting
             dh = -qsmlt*dt/fuss
             if (hsnw+dh < 0.) then
               qsmlt = qsmlt-hsnw*fuss/dt
@@ -286,15 +280,14 @@ contains
               hsnw = hsnw+dh
             end if
 
-            ! --- ----- Update ice thickness due to melting/freezing
+            ! Update ice thickness due to melting/freezing
             hice = max(0.,hice-(qbot+qsmlt)*dt/fusi)
 
-            ! --- ----- Convert snow to ice due to aging
+            ! Convert snow to ice due to aging
             hice = hice+hsnw*(1.-sag_fac)*rhosnw/rhoice
             hsnw = hsnw*sag_fac
 
-            ! --- ----- Convert snow to ice if snow load is larger than the updrift
-            ! --- ----- of ice
+            ! Convert snow to ice if snow load is larger than the updrift of ice
             dh = (hsnw*rhosnw-hice*(rhowat-rhoice))/rhowat
             if (dh > 0.) then
               hice = hice+dh
@@ -303,31 +296,31 @@ contains
 
           end if
 
-          ! --- ------------------------------------------------------------------
-          ! --- --- Do thermodynamics for open water fraction of the grid cell
-          ! --- ------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Do thermodynamics for open water fraction of the grid cell
+          ! --------------------------------------------------------------------
 
-          ! --- --- Predict temperature change in mixed layer after a leapfrog
-          ! --- --- time step due to heat fluxes
+          ! Predict temperature change in mixed layer after a leapfrog time step
+          ! due to heat fluxes
           swfac = 1.-swbgfc(i,j)*exp(-hotl/swbgal(i,j))
           dtml = (swfac*qsww+qnsw)*2.*dt/(cpsw*rhowat*hotl)
 
           if     (totl+dtml < tice_f) then
 
-            ! --- ----- Heat flux required to change the mixed layer temperature
-            ! --- ----- to the freezing point after a leapfrog time step
+            ! Heat flux required to change the mixed layer temperature to the
+            ! freezing point after a leapfrog time step
             q = .5*(tice_f-totl)*cpsw*rhowat*hotl/dt
 
-            ! --- ----- Ice volume that has to freeze to balance the heat budget
+            ! Ice volume that has to freeze to balance the heat budget
             volice = -(qsww+qnsw-q)*(1.-fice)*dt/fusi
 
             if (volice > epsilt) then
 
-              ! --- ------- New ice in the lead is formed with a specified thickness.
-              ! --- ------- Estimate the change in ice fraction
+              ! New ice in the lead is formed with a specified thickness.
+              ! Estimate the change in ice fraction
               df = volice/hice_min
 
-              ! --- ------- Redistribute ice and snow over an updated ice fraction
+              ! Redistribute ice and snow over an updated ice fraction
               hice = (hice*fice+volice)/min(fice_max,fice+df)
               hsnw = hsnw*fice/min(fice_max,fice+df)
               fice = min(fice_max,fice+df)
@@ -336,10 +329,10 @@ contains
 
           else if (swfac*qsww+qnsw > 0.) then
 
-            ! --- ----- If the lead is warming, let the fraction  (1 - fice)  go to
-            ! --- ----- warm the lead, and the fraction  fice  to melt ice laterally
+            ! If the lead is warming, let the fraction  (1 - fice)  go to warm
+            ! the lead, and the fraction  fice  to melt ice laterally
             fice = fice-(swfac*qsww+qnsw)*fice*dt &
-                 /max(hice*fusi+hsnw*fuss,epsilt)
+                        /max(hice*fusi+hsnw*fuss,epsilt)
             if (fice < 0.) then
               fice = 0.
               hice = 0.
@@ -348,9 +341,9 @@ contains
 
           end if
 
-          ! --- ------------------------------------------------------------------
-          ! --- --- Store the updated ice/snow state variables
-          ! --- ------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Store the updated ice/snow state variables
+          ! --------------------------------------------------------------------
 
           ficem(i,j) = fice
           hicem(i,j) = hice
@@ -358,9 +351,9 @@ contains
           tsrfm(i,j) = tsrf
           ticem(i,j) = tice
 
-          ! --- ------------------------------------------------------------------
-          ! --- --- Accumutate variables to produce averages in flux calculations
-          ! --- ------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Accumutate variables to produce averages in flux calculations
+          ! --------------------------------------------------------------------
 
           alb_tda(i,j) = alb_tda(i,j)+alb(i,j)
           tml_tda(i,j) = tml_tda(i,j)+totl
@@ -368,65 +361,72 @@ contains
           fice_tda(i,j) = fice_tda(i,j)+fice
           tsi_tda(i,j) = tsi_tda(i,j)+tsrf
 
-          ! --- ------------------------------------------------------------------
-          ! --- --- Compute fluxes of heat and salt to the ocean
-          ! --- ------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Compute fluxes of heat and salt to the ocean
+          ! --------------------------------------------------------------------
 
-          ! --- --- Ice volume change
+          ! Ice volume change
           dvi = hice*fice-hice0*fice0
 
-          ! --- --- Snow volume change
+          ! Snow volume change
           dvs = hsnw*fice-hsnw0*fice0
 
-          ! --- --- Accumulate the runoff in a reservoar to delay the discharge
-          ! --- --- into the ocean (by nrfets days approximately 1/e of runoff
-          ! --- --- added will by discharged).
+          ! Accumulate the runoff in a reservoar to delay the discharge into the
+          ! ocean (by nrfets days approximately 1/e of runoff added will by
+          ! discharged).
           rnfres(i,j) = rnfres(i,j)+rnfins(i,j)
           rnf(i,j) = rnfres(i,j)*rnf_fac
           rnfres(i,j) = rnfres(i,j)*(1.-rnf_fac)
 
-          ! --- --- Fresh water flux due to melting/freezing [kg m-2 s-1]
-          ! --- --- (positive downwards)
+          ! Fresh water flux due to melting/freezing [kg m-2 s-1] (positive
+          ! downwards)
           fmltfz(i,j) = -(dvi*rhoice+dvs*rhosnw)/dt
 
-          ! --- --- Fresh water flux [kg m-2 s-1] (positive downwards)
+          ! Fresh water flux [kg m-2 s-1] (positive downwards)
           fwflx = eva(i,j)+lip(i,j)+sop(i,j)+rnf(i,j)+rfi(i,j)+fmltfz(i,j)
 
-          ! --- --- Salt flux [kg m-2 s-1] (positive downwards)
+          ! Salt flux [kg m-2 s-1] (positive downwards)
           sfl(i,j) = -sice*dvi*rhoice/dt*g2kg
 
-          ! --- --- Salt flux due to brine rejection of freezing sea
-          ! --- --- ice [kg m-2 m-1] (positive downwards)
+          ! Salt flux due to brine rejection of freezing sea ice [kg m-2 m-1]
+          ! (positive downwards)
           brnflx(i,j) = max(0.,-sotl*fmltfz(i,j)*g2kg+sfl(i,j))
 
-          ! --- --- Virtual salt flux [kg m-2 s-1] (positive downwards)
+          ! Virtual salt flux [kg m-2 s-1] (positive downwards)
           vrtsfl(i,j) = -sotl*fwflx*g2kg
 
-          ! --- --- Store area weighted virtual salt flux and fresh water flux
-          util1(i,j) = vrtsfl(i,j)*scp2(i,j)
-          util2(i,j) = fwflx*scp2(i,j)
+          ! Store area weighted correction to the virtual salt flux. When the
+          ! global average correction is applied, the virtual salt flux is
+          ! globally consistent with a salt flux based on some reference
+          ! salinity and any salinity limiting compensated for.
+          util1(i,j) = -(sref*fwflx*g2kg &
+                        +vrtsfl(i,j) &
+                        +salt_corr(i,j)*g2kg/(2.*dt)*(L_mks2cgs**2/M_mks2cgs)) &
+                        *scp2(i,j)
 
-          ! --- --- Heat flux due to melting/freezing [W m-2] (positive downwards)
+          ! Reset salt correction
+          salt_corr(i,j) = 0.
+
+          ! Heat flux due to melting/freezing [W m-2] (positive downwards)
           hmltfz(i,j) = (dvi*fusi+dvs*fuss)/dt
 
-          ! --- --- Total heat flux in BLOM units [W cm-2] (positive upwards)
+          ! Total heat flux in BLOM units [W cm-2] (positive upwards)
           surflx(i,j) = -(swa(i,j)+nsf(i,j)+hmltfz(i,j))*A_cgs2mks
 
-          ! --- --- Short-wave heat flux in BLOM units [W cm-2] (positive
-          ! --- --- upwards)
+          ! Short-wave heat flux in BLOM units [W cm-2] (positive
+          ! upwards)
           sswflx(i,j) = -qsww*(1.-fice0)*A_cgs2mks
 
           if (use_TRC) then
-            ! --- ------------------------------------------------------------------
-            ! --- --- Tracer fluxes (positive downwards)
-            ! --- ------------------------------------------------------------------
+            ! ------------------------------------------------------------------
+            ! Tracer fluxes (positive downwards)
+            ! ------------------------------------------------------------------
 
             do nt = 1,ntr
               if (use_TKE) then
                 if (nt == itrtke) then
                   trflx(nt,i,j) = 0.
-                  ttrsf(nt,i,j) = 0.
-                  ttrav(nt,i,j) = 0.
+                  trflxc_aw(i,j,nt) = 0.
                   cycle
                 end if
                 if (use_GLS) then
@@ -434,47 +434,47 @@ contains
                     trflx(nt,i,j) = -gls_n*difdia(i,j,1)*(gls_cmu0**gls_p) &
                          *(trc(i,j,k1n,itrtke)**gls_m) &
                          *(vonKar**gls_n)*Zos**(gls_n-1.)
-                    ttrsf(nt,i,j) = 0.
-                    ttrav(nt,i,j) = 0.
+                    trflxc_aw(i,j,nt) = 0.
                     cycle
                   end if
                 else
                   if (nt == itrgls) then
                     trflx(nt,i,j) = 0.
-                    ttrsf(nt,i,j) = 0.
-                    ttrav(nt,i,j) = 0.
+                    trflxc_aw(i,j,nt) = 0.
                     cycle
                   end if
                 end if
               end if
-              trflx(nt,i,j) = -trc(i,j,k1n,nt)*fwflx*g2kg
-              ttrsf(nt,i,j) = trflx(nt,i,j)*scp2(i,j)
-              ttrav(nt,i,j) = trc(i,j,k1n,nt)*scp2(i,j)
+              trflx(nt,i,j) = -trc(i,j,k1n,nt)*fwflx
+              trflxc_aw(i,j,nt) = -(trflx(nt,i,j) &
+                                   +trc_corr(i,j,nt)/(2.*dt)*(L_mks2cgs**2/M_mks2cgs)) &
+                                   *scp2(i,j)
+              trc_corr(i,j,nt) = 0.
             end do
           end if
 
-          ! --- ------------------------------------------------------------------
-          ! --- --- Relaxation fluxes
-          ! --- ------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Relaxation fluxes
+          ! --------------------------------------------------------------------
 
           surrlx(i,j) = 0.
 
-          ! --- --- If  trxday>0 , apply relaxation towards observed sst
+          ! If  trxday>0 , apply relaxation towards observed sst
           if (trxday > epsilt) then
             sstc = intp1d(sstclm(i,j,l1mi),sstclm(i,j,l2mi), &
-                 sstclm(i,j,l3mi),sstclm(i,j,l4mi), &
-                 sstclm(i,j,l5mi),xmi)
+                          sstclm(i,j,l3mi),sstclm(i,j,l4mi), &
+                          sstclm(i,j,l5mi),xmi)
             rice = intp1d(ricclm(i,j,l1mi),ricclm(i,j,l2mi), &
-                 ricclm(i,j,l3mi),ricclm(i,j,l4mi), &
-                 ricclm(i,j,l5mi),xmi)
+                          ricclm(i,j,l3mi),ricclm(i,j,l4mi), &
+                          ricclm(i,j,l5mi),xmi)
             sstc = (1.-rice)*max(sstc,tice_f)+rice*tice_f
             if (vcoord_tag == vcoord_isopyc_bulkml) then
               dpmxl = dp(i,j,1+nn)+dp(i,j,2+nn)
               hmxl = dpmxl/onem
               tmxl = (temp(i,j,1+nn)*dp(i,j,1+nn) &
-                   +temp(i,j,2+nn)*dp(i,j,2+nn))/dpmxl+t0deg
+                     +temp(i,j,2+nn)*dp(i,j,2+nn))/dpmxl+t0deg
               trxflx = spcifh*L_mks2cgs*min(hmxl,trxdpt)/(trxday*86400.) &
-                   *min(trxlim,max(-trxlim,sstc-tmxl))/alpha0
+                       *min(trxlim,max(-trxlim,sstc-tmxl))/alpha0
             else
               pbot = p(i,j,1)
               do k = 1,kk
@@ -492,47 +492,47 @@ contains
                   exit
                 else
                   tmxl = tmxl+temp(i,j,kn)*(t_rs_nonloc(i,j,k  ) &
-                       -t_rs_nonloc(i,j,k+1))
+                                           -t_rs_nonloc(i,j,k+1))
                 end if
               end do
               do kl = k,kk
                 t_rs_nonloc(i,j,kl+1) = 0.
               end do
               trxflx = spcifh*L_mks2cgs*trxdpt/(trxday*86400.) &
-                   *min(trxlim,max(-trxlim,sstc-tmxl))/alpha0
+                       *min(trxlim,max(-trxlim,sstc-tmxl))/alpha0
             end if
             surrlx(i,j) = -trxflx
           else
             trxflx = 0.
           end if
 
-          ! --- --- If aptflx=.true., apply diagnosed relaxation flux
+          ! If aptflx=.true., apply diagnosed relaxation flux
           if (aptflx) then
             surrlx(i,j) = surrlx(i,j) &
-                 -intp1d(tflxap(i,j,m1),tflxap(i,j,m2),tflxap(i,j,m3), &
-                 tflxap(i,j,m4),tflxap(i,j,m5),y)
+                        - intp1d(tflxap(i,j,m1),tflxap(i,j,m2),tflxap(i,j,m3), &
+                                 tflxap(i,j,m4),tflxap(i,j,m5),y)
           end if
 
-          ! --- --- If ditflx=.true., diagnose relaxation flux by accumulating the
-          ! --- --- relaxation flux
+          ! If ditflx=.true., diagnose relaxation flux by accumulating the
+          ! relaxation flux
           if (ditflx) then
             tflxdi(i,j,ntld) = tflxdi(i,j,ntld)+trxflx
           end if
 
           salrlx(i,j) = 0.
 
-          ! --- --- if  srxday>0 , apply relaxation towards observed sss
+          ! If  srxday>0 , apply relaxation towards observed sss
           if (srxday > epsilt) then
             sssc = intp1d(sssclm(i,j,l1mi),sssclm(i,j,l2mi), &
-                 sssclm(i,j,l3mi),sssclm(i,j,l4mi), &
-                 sssclm(i,j,l5mi),xmi)
+                          sssclm(i,j,l3mi),sssclm(i,j,l4mi), &
+                          sssclm(i,j,l5mi),xmi)
             if (vcoord_tag == vcoord_isopyc_bulkml) then
               dpmxl = dp(i,j,1+nn)+dp(i,j,2+nn)
               hmxl = dpmxl/onem
               smxl = (saln(i,j,1+nn)*dp(i,j,1+nn) &
-                   +saln(i,j,2+nn)*dp(i,j,2+nn))/dpmxl
+                     +saln(i,j,2+nn)*dp(i,j,2+nn))/dpmxl
               srxflx = L_mks2cgs*min(hmxl,srxdpt)/(srxday*86400.) &
-                   *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
+                       *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
             else
               pbot = p(i,j,1)
               do k = 1,kk
@@ -550,7 +550,7 @@ contains
                   exit
                 else
                   smxl = smxl+saln(i,j,kn)*(s_rs_nonloc(i,j,k  ) &
-                       -s_rs_nonloc(i,j,k+1))
+                                           -s_rs_nonloc(i,j,k+1))
                 end if
               end do
               do kl = k,kk
@@ -560,106 +560,86 @@ contains
                    *min(srxlim,max(-srxlim,sssc-smxl))/alpha0
             end if
             salrlx(i,j) = -srxflx
-            util3(i,j) = max(0.,salrlx(i,j))*scp2(i,j)
-            util4(i,j) = min(0.,salrlx(i,j))*scp2(i,j)
+            util2(i,j) = max(0.,salrlx(i,j))*scp2(i,j)
+            util3(i,j) = min(0.,salrlx(i,j))*scp2(i,j)
           else
             srxflx = 0.
           end if
 
-          ! --- --- If apsflx=.true., apply diagnosed relaxation flux
+          ! If apsflx=.true., apply diagnosed relaxation flux
           if (apsflx) then
             salrlx(i,j) = salrlx(i,j) &
-                 -intp1d(sflxap(i,j,m1),sflxap(i,j,m2),sflxap(i,j,m3), &
-                 sflxap(i,j,m4),sflxap(i,j,m5),y)
+                        - intp1d(sflxap(i,j,m1),sflxap(i,j,m2),sflxap(i,j,m3), &
+                                 sflxap(i,j,m4),sflxap(i,j,m5),y)
           end if
 
-          ! --- --- If disflx=.true., diagnose relaxation flux by accumulating the
-          ! --- --- relaxation flux
+          ! If disflx=.true., diagnose relaxation flux by accumulating the
+          ! relaxation flux
           if (disflx) then
             sflxdi(i,j,ntld) = sflxdi(i,j,ntld)+srxflx
           end if
 
-          ! --- ------------------------------------------------------------------
-          ! --- --- Update age of ice
-          ! --- ------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Update age of ice
+          ! --------------------------------------------------------------------
 
           if (fice*hice < 1.e-5) then
             iagem(i,j) = 0.
           else
-            iagem(i,j) = (iagem(i,j)+dt/86400.) &
-                 *(1.-max(0.,dvi)/(fice*hice))
+            iagem(i,j) = (iagem(i,j)+dt/86400.)*(1.-max(0.,dvi)/(fice*hice))
           end if
 
-          ! --- -------------------------------------------------------------------
-          ! --- --- Compute friction velocity (cm/s)
-          ! --- -------------------------------------------------------------------
+          ! --------------------------------------------------------------------
+          ! Compute friction velocity (cm/s)
+          ! --------------------------------------------------------------------
 
-          ustar(i,j) = (min(ustari(i,j),.8e-2)*fice0 &
-               +ustarw(i,j)*(1.-fice0))*L_mks2cgs
+          ustar(i,j) = (min(ustari(i,j),.8e-2)*fice0+ustarw(i,j)*(1.-fice0))*L_mks2cgs
 
         end do
       end do
     end do
     !$omp end parallel do
 
-    ! --- ------------------------------------------------------------------
-    ! --- Compute correction to the virtual salt flux so it is globally
-    ! --- consistent with a salt flux based on some reference salinity.
-    ! --- Also combine virtual and true salt flux and convert salt fluxes
-    ! --- used later to unit [10e-3 g cm-2 s-1] and positive upwards.
-    ! --- ------------------------------------------------------------------
+    ! ------------------------------------------------------------------
+    ! Apply the virtual salt flux correction and the compute the total
+    ! salt flux by combining the virtual and true salt flux. Also
+    ! convert salt fluxes used later to unit [10e-3 g cm-2 s-1] and
+    ! positive upwards.
+    ! ------------------------------------------------------------------
 
-    call xcsum(totsfl,util1,ips)
-    call xcsum(totwfl,util2,ips)
-
-    ! --- Correction for the virtual salt flux [kg m-2 s-1]
-    sflxc = (-sref*totwfl*g2kg-totsfl)/area
+    call xcsum(sflxc,util1,ips)
+    sflxc = sflxc/area
     if (mnproc == 1) then
-      write (lp,*) 'thermf: totsfl/area,sflxc',totsfl/area,sflxc
+      write (lp,'(a,e15.7)') ' thermf: sflxc', sflxc
     end if
 
-    ! --- Apply the virtual salt flux correction and the compute the total
-    ! --- salt flux by combining the virtual and true salt flux
     !$omp parallel do private(l,i)
     do j = 1,jj
       do l = 1,isp(j)
         do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
           salflx(i,j) = -(vrtsfl(i,j)+sflxc+sfl(i,j)) &
-               *(kg2g*(M_mks2cgs/L_mks2cgs**2))
-          brnflx(i,j) = -brnflx(i,j) &
-               *(kg2g*(M_mks2cgs/L_mks2cgs**2))
+                         *(kg2g*(M_mks2cgs/L_mks2cgs**2))
+          brnflx(i,j) = -brnflx(i,j)*(kg2g*(M_mks2cgs/L_mks2cgs**2))
         end do
       end do
     end do
     !$omp end parallel do
 
-    ! --- if  srxday>0  and  srxbal=.true. , balance the sss relaxation flux
-    ! --- so the net input of salt in grid cells connected to the world
-    ! --- ocean is zero
+    ! If  srxday>0  and  srxbal=.true. , balance the sss relaxation flux
+    ! so the net input of salt in grid cells connected to the world
+    ! ocean is zero
     if (srxday > epsilt.and.srxbal) then
-      call xcsum(totsrp,util3,ipwocn)
-      call xcsum(totsrn,util4,ipwocn)
-      if (abs(totsrp) > abs(totsrn)) then
-        q = -totsrn/totsrp
+      call xcsum(totsrp,util2,ipwocn)
+      call xcsum(totsrn,util3,ipwocn)
+      if (abs(totsrp-totsrn) > 0.) then
+        qp = 2.*totsrn/(totsrn-totsrp)
+        qn = 2.*totsrp/(totsrp-totsrn)
         !$omp parallel do private(l,i)
         do j = 1,jj
           do l = 1,isp(j)
             do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              if (salrlx(i,j) > 0..and.ipwocn(i,j) == 1) then
-                salrlx(i,j) = q*salrlx(i,j)
-              end if
-            end do
-          end do
-        end do
-        !$omp end parallel do
-      else
-        q = -totsrp/totsrn
-        !$omp parallel do private(l,i)
-        do j = 1,jj
-          do l = 1,isp(j)
-            do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              if (salrlx(i,j) < 0..and.ipwocn(i,j) == 1) then
-                salrlx(i,j) = q*salrlx(i,j)
+              if (ipwocn(i,j) == 1) then
+                salrlx(i,j) = qp*max(0.,salrlx(i,j)) + qn*min(0.,salrlx(i,j))
               end if
             end do
           end do
@@ -670,46 +650,26 @@ contains
 
     if (use_TRC) then
       do nt = 1,ntr
-
         if (use_TKE) then
           if (nt == itrtke.or.nt == itrgls) cycle
         end if
-        !!$omp parallel do private(l,i)
-        !        do j=1,jj
-        !          do l=1,isp(j)
-        !          do i=max(1,ifp(j,l)),min(ii,ilp(j,l))
-        !            util1(i,j)=ttrsf(nt,i,j)
-        !            util2(i,j)=ttrav(nt,i,j)
-        !          enddo
-        !          enddo
-        !        enddo
-        !!$omp end parallel do
-        !
-        !        call xcsum(tottrsf,util1,ips)
-        !        call xcsum(tottrav,util2,ips)
-        !
-        !        tottrav=tottrav/area
-        !
-        !        trflxc=(-tottrsf)/area
-        !        trflxc=(-tottrav*totwfl*g2kg-tottrsf)/area
-        trflxc = 0.
-
+        call xcsum(trflxc,trflxc_aw(1-nbdy,1-nbdy,nt),ips)
+        trflxc = trflxc/area
         !$omp parallel do private(l,i)
         do j = 1,jj
           do l = 1,isp(j)
             do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              trflx(nt,i,j) = -(trflx(nt,i,j)+trflxc)*L_mks2cgs
+              trflx(nt,i,j) = -(trflx(nt,i,j)+trflxc)*(M_mks2cgs/L_mks2cgs**2)
             end do
           end do
         end do
         !$omp end parallel do
-
       end do
     end if
 
-    ! --- ------------------------------------------------------------------
-    ! --- number of accumulated fields for flux calculations
-    ! --- ------------------------------------------------------------------
+    ! --------------------------------------------------------------------------
+    ! Number of accumulated fields for flux calculations
+    ! --------------------------------------------------------------------------
 
     ntda = ntda+1
 

--- a/phy/mod_ale_vdiff.F90
+++ b/phy/mod_ale_vdiff.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2021-2024 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
+! Copyright (C) 2021-2025 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !
@@ -20,7 +20,7 @@
 module mod_ale_vdiff
 ! ------------------------------------------------------------------------------
 ! This module contains procedures for solving vertical diffusion equations with
-! the ALE method.
+! the ALE method, combined with updating state variables with surface fluxes.
 ! ------------------------------------------------------------------------------
 
   use mod_types,     only: r8
@@ -32,9 +32,15 @@ module mod_ale_vdiff
   use mod_checksum,  only: csdiag, chksummsk
   use mod_diffusion, only: Kvisc_m, Kdiff_t, Kdiff_s, t_ns_nonloc, s_nb_nonloc
   use mod_forcing,   only: surflx, sswflx, surrlx, salflx, brnflx, salrlx, &
+                           salt_corr, trc_corr, &
                            t_sw_nonloc, t_rs_nonloc, s_br_nonloc, s_rs_nonloc
   use mod_tracers,   only: ntr, trc, trflx ! TRC
   use mod_ifdefs,    only: use_TRC
+
+!TODO
+  use mod_grid, only: scp2
+  use mod_constants, only: M_mks2cgs
+!TODO
 
   implicit none
   private
@@ -57,27 +63,31 @@ contains
     integer :: i, j, k, l, kn, nt
     real(r8), dimension(kdm, ntr) :: trc_1d ! TRC
 
+    real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
+         util5
+    real(r8) :: totscr
+
     cpi = 1._r8/spcifh    ! Multiplicative inverse of specific heat capacity.
     dtg = delt1*g
     c = g*g*delt1/(alpha0*alpha0)
 
     do j = 1, jj
       do l = 1, isp(j)
-        do i = max(1, ifp(j, l)), min(ii, ilp(j, l))
+        do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
 
           ! Copy variables into 1D arrays.
           do k = 1, kk
             kn = k + nn
-            dp_1d(k) = dp(i, j, kn)
-            temp_1d(k) = temp(i, j, kn)
-            saln_1d(k) = saln(i, j, kn)
-            nut_1d(k) = Kdiff_t(i, j, k)
-            nus_1d(k) = Kdiff_s(i, j, k)
+            dp_1d(k) = dp(i,j,kn)
+            temp_1d(k) = temp(i,j,kn)
+            saln_1d(k) = saln(i,j,kn)
+            nut_1d(k) = Kdiff_t(i,j,k)
+            nus_1d(k) = Kdiff_s(i,j,k)
             if (use_TRC) then
               do nt = 1, ntr
-                trc_1d(k, nt) = trc(i, j, kn, nt)
+                trc_1d(k,nt) = trc(i,j,kn,nt)
               enddo
-              nutrc_1d(k) = Kdiff_t(i, j, k)
+              nutrc_1d(k) = Kdiff_t(i,j,k)
             end if
           enddo
 
@@ -103,10 +113,10 @@ contains
 
           ! Diffusive interface fluxes, before multiplying with diffusivity.
           do k = 2, kk
-            fpbase(k) = c/max(dpmin_vdiff, .5_r8*(dp_1d(k - 1) + dp_1d(k)))
+            fpbase(k) = c/max(dpmin_vdiff, .5_r8*(dp_1d(k-1) + dp_1d(k)))
           enddo
 
-          ! Diffusion of potential temperature.
+          ! Diffusion and change due to surface flux of potential temperature.
           do k = 2, kk
             fp(k) = nut_1d(k)*fpbase(k)
           enddo
@@ -118,12 +128,12 @@ contains
           temp_1d(1) = rhs*bei
           do k = 2, kk - 1
             gam(k) = - fp(k)*bei
-            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k + 1))
+            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k+1))
             rhs = dp_1d(k)*temp_1d(k) &
                  - ( (t_ns_nonloc(i,j,k) - t_ns_nonloc(i,j,k+1))*hfns &
                    + (t_sw_nonloc(i,j,k) - t_sw_nonloc(i,j,k+1))*hfsw &
                    + (t_rs_nonloc(i,j,k) - t_rs_nonloc(i,j,k+1))*hfrs)*dtg*cpi
-            temp_1d(k) = (rhs + fp(k)*temp_1d(k - 1))*bei
+            temp_1d(k) = (rhs + fp(k)*temp_1d(k-1))*bei
           enddo
           gam(kk) = - fp(kk)*bei
           bei = 1._r8/(dp_1d(kk) + fp(kk)*(1._r8 + gam(kk)))
@@ -131,12 +141,12 @@ contains
                - ( (t_ns_nonloc(i,j,kk) - t_ns_nonloc(i,j,kk+1))*hfns &
                  + (t_sw_nonloc(i,j,kk) - t_sw_nonloc(i,j,kk+1))*hfsw &
                  + (t_rs_nonloc(i,j,kk) - t_rs_nonloc(i,j,kk+1))*hfrs)*dtg*cpi
-          temp_1d(kk) = (rhs + fp(kk)*temp_1d(kk - 1))*bei
+          temp_1d(kk) = (rhs + fp(kk)*temp_1d(kk-1))*bei
           do k = kk - 1, 1, - 1
-            temp_1d(k) = temp_1d(k) - gam(k + 1)*temp_1d(k + 1)
+            temp_1d(k) = temp_1d(k) - gam(k+1)*temp_1d(k+1)
           enddo
 
-          ! Diffusion of salinity.
+          ! Diffusion and change due to surface flux of salinity.
           do k = 2, kk
             fp(k) = nus_1d(k)*fpbase(k)
           enddo
@@ -148,12 +158,12 @@ contains
           saln_1d(1) = rhs*bei
           do k = 2, kk - 1
             gam(k) = - fp(k)*bei
-            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k + 1))
+            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k+1))
             rhs = dp_1d(k)*saln_1d(k) &
                  - ( (s_nb_nonloc(i,j,k) - s_nb_nonloc(i,j,k+1))*sfnb &
                    + (s_br_nonloc(i,j,k) - s_br_nonloc(i,j,k+1))*sfbr &
                    + (s_rs_nonloc(i,j,k) - s_rs_nonloc(i,j,k+1))*sfrs)*dtg
-            saln_1d(k) = (rhs + fp(k)*saln_1d(k - 1))*bei
+            saln_1d(k) = (rhs + fp(k)*saln_1d(k-1))*bei
           enddo
           gam(kk) = - fp(kk)*bei
           bei = 1._r8/(dp_1d(kk) + fp(kk)*(1._r8 + gam(kk)))
@@ -161,13 +171,13 @@ contains
                - ( (s_nb_nonloc(i,j,kk) - s_nb_nonloc(i,j,kk+1))*sfnb &
                  + (s_br_nonloc(i,j,kk) - s_br_nonloc(i,j,kk+1))*sfbr &
                  + (s_rs_nonloc(i,j,kk) - s_rs_nonloc(i,j,kk+1))*sfrs)*dtg
-          saln_1d(kk) = (rhs + fp(kk)*saln_1d(kk - 1))*bei
+          saln_1d(kk) = (rhs + fp(kk)*saln_1d(kk-1))*bei
           do k = kk - 1, 1, - 1
-            saln_1d(k) = saln_1d(k) - gam(k + 1)*saln_1d(k + 1)
+            saln_1d(k) = saln_1d(k) - gam(k+1)*saln_1d(k+1)
           enddo
 
           if (use_TRC) then
-            ! Diffusion of tracers.
+            ! Diffusion and change due to surface flux of tracers.
             do k = 2, kk
               fp(k) = nutrc_1d(k)*fpbase(k)
             enddo
@@ -175,16 +185,16 @@ contains
             do nt = 1, ntr
               rhs = dp_1d(1)*trc_1d(1,nt) &
                    - (1._r8 - s_nb_nonloc(i,j,2))*trflx(nt,i,j)*dtg
-              trc_1d(1, nt) = rhs*bei
+              trc_1d(1,nt) = rhs*bei
             enddo
             do k = 2, kk - 1
               gam(k) = - fp(k)*bei
-              bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k + 1))
+              bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k+1))
               do nt = 1, ntr
                 rhs = dp_1d(k)*trc_1d(k,nt) &
                      - (s_nb_nonloc(i,j,k) - s_nb_nonloc(i,j,k+1)) &
                        *trflx(nt,i,j)*dtg
-                trc_1d(k, nt) = (rhs + fp(k)*trc_1d(k - 1, nt))*bei
+                trc_1d(k,nt) = (rhs + fp(k)*trc_1d(k-1,nt))*bei
               enddo
             enddo
             gam(kk) = - fp(kk)*bei
@@ -193,24 +203,28 @@ contains
               rhs = dp_1d(kk)*trc_1d(kk,nt) &
                    - (s_nb_nonloc(i,j,kk) - s_nb_nonloc(i,j,kk+1)) &
                      *trflx(nt,i,j)*dtg
-              trc_1d(kk, nt) = (rhs + fp(kk)*trc_1d(kk - 1, nt))*bei
+              trc_1d(kk,nt) = (rhs + fp(kk)*trc_1d(kk-1,nt))*bei
             enddo
             do k = kk - 1, 1, - 1
               do nt = 1, ntr
-                trc_1d(k, nt) = trc_1d(k, nt) - gam(k + 1)*trc_1d(k + 1, nt)
+                trc_1d(k,nt) = trc_1d(k,nt) - gam(k+1)*trc_1d(k+1,nt)
               enddo
             enddo
           end if
 
-          ! Update 3D arrays
+          ! Update 3D arrays. Also enforce non-negative tracer values, storing
+          ! the correction in an array.
           do k = 1, kk
             kn = k + nn
-            temp(i, j, kn) = temp_1d(k)
-            saln(i, j, kn) = saln_1d(k)
-            sigma(i, j, kn) = sig(temp_1d(k), saln_1d(k))
+            temp(i,j,kn) = temp_1d(k)
+            salt_corr(i,j) = salt_corr(i,j) - min(0._r8, saln_1d(k))*dp_1d(k)/g
+            saln(i,j,kn) = max(0._r8, saln_1d(k))
+            sigma(i,j,kn) = sig(temp_1d(k), saln(i,j,kn))
             if (use_TRC) then
               do nt = 1,ntr
-                trc(i, j, kn, nt) = trc_1d(k, nt)
+                trc_corr(i,j,nt) = trc_corr(i,j,nt) &
+                                 - min(0._r8, trc_1d(k,nt))*dp_1d(k)/g
+                trc(i,j,kn,nt) = max(0._r8, trc_1d(k,nt))
               enddo
             end if
           enddo
@@ -228,7 +242,7 @@ contains
       call chksummsk(sigma, ip, 2*kk, 'sigma')
       if (use_TRC) then
         do nt = 1, ntr
-          call chksummsk(trc(1-nbdy, 1-nbdy, 1, nt), ip, 2*kk, 'trc')
+          call chksummsk(trc(1-nbdy,1-nbdy,1,nt), ip, 2*kk, 'trc')
         enddo
       end if
     endif
@@ -251,14 +265,14 @@ contains
     do j = 1, jj
 
       do l = 1, isu(j)
-        do i = max(1, ifu(j, l)), min(ii, ilu(j, l))
+        do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
 
           ! Copy variables into 1D arrays.
           do k = 1, kk
             kn = k + nn
-            dp_1d(k) = dpu(i, j, kn)
-            u_1d(k) = u(i, j, kn)
-            nuv_1d(k) = .5_r8*(Kvisc_m(i-1, j, k) + Kvisc_m(i, j, k))
+            dp_1d(k) = dpu(i,j,kn)
+            u_1d(k) = u(i,j,kn)
+            nuv_1d(k) = .5_r8*(Kvisc_m(i-1,j,k) + Kvisc_m(i,j,k))
           enddo
 
           ! Vertical diffusion equations are solved by backward integration
@@ -272,7 +286,7 @@ contains
 
           ! Diffusive interface fluxes, before multiplying with diffusivity.
           do k = 2, kk
-            fpbase(k) = c/max(dpmin_vdiff, .5_r8*(dp_1d(k - 1) + dp_1d(k)))
+            fpbase(k) = c/max(dpmin_vdiff, .5_r8*(dp_1d(k-1) + dp_1d(k)))
           enddo
 
           ! Diffusion of u-component of baroclinic velocity.
@@ -283,34 +297,34 @@ contains
           u_1d(1) = dp_1d(1)*u_1d(1)*bei
           do k = 2, kk - 1
             gam(k) = - fp(k)*bei
-            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k + 1))
-            u_1d(k) = (dp_1d(k)*u_1d(k) + fp(k)*u_1d(k - 1))*bei
+            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k+1))
+            u_1d(k) = (dp_1d(k)*u_1d(k) + fp(k)*u_1d(k-1))*bei
           enddo
           gam(kk) = - fp(kk)*bei
           bei = 1._r8/(dp_1d(kk) + fp(kk)*(1._r8 + gam(kk)))
-          u_1d(kk) = (dp_1d(kk)*u_1d(kk) + fp(kk)*u_1d(kk - 1))*bei
+          u_1d(kk) = (dp_1d(kk)*u_1d(kk) + fp(kk)*u_1d(kk-1))*bei
           do k = kk - 1, 1, - 1
-            u_1d(k) = u_1d(k) - gam(k + 1)*u_1d(k + 1)
+            u_1d(k) = u_1d(k) - gam(k+1)*u_1d(k+1)
           enddo
 
           ! Update 3D arrays
           do k = 1, kk
             kn = k + nn
-            u(i, j, kn) = u_1d(k)
+            u(i,j,kn) = u_1d(k)
           enddo
 
         enddo
       enddo
 
       do l = 1, isv(j)
-        do i = max(1, ifv(j, l)), min(ii, ilv(j, l))
+        do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
 
           ! Copy variables into 1D arrays.
           do k = 1, kk
             kn = k + nn
-            dp_1d(k) = dpv(i, j, kn)
-            v_1d(k) = v(i, j, kn)
-            nuv_1d(k) = .5_r8*(Kvisc_m(i, j-1, k) + Kvisc_m(i, j, k))
+            dp_1d(k) = dpv(i,j,kn)
+            v_1d(k) = v(i,j,kn)
+            nuv_1d(k) = .5_r8*(Kvisc_m(i,j-1,k) + Kvisc_m(i,j,k))
           enddo
 
           ! Vertical diffusion equations are solved by backward integration
@@ -324,7 +338,7 @@ contains
 
           ! Diffusive interface fluxes, before multiplying with diffusivity.
           do k = 2, kk
-            fpbase(k) = c/max(dpmin_vdiff, .5_r8*(dp_1d(k - 1) + dp_1d(k)))
+            fpbase(k) = c/max(dpmin_vdiff, .5_r8*(dp_1d(k-1) + dp_1d(k)))
           enddo
 
           ! Diffusion of v-component of baroclinic velocity.
@@ -335,20 +349,20 @@ contains
           v_1d(1) = dp_1d(1)*v_1d(1)*bei
           do k = 2, kk - 1
             gam(k) = - fp(k)*bei
-            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k + 1))
-            v_1d(k) = (dp_1d(k)*v_1d(k) + fp(k)*v_1d(k - 1))*bei
+            bei = 1._r8/(dp_1d(k) + fp(k)*(1._r8 + gam(k)) + fp(k+1))
+            v_1d(k) = (dp_1d(k)*v_1d(k) + fp(k)*v_1d(k-1))*bei
           enddo
           gam(kk) = - fp(kk)*bei
           bei = 1._r8/(dp_1d(kk) + fp(kk)*(1._r8 + gam(kk)))
-          v_1d(kk) = (dp_1d(kk)*v_1d(kk) + fp(kk)*v_1d(kk - 1))*bei
+          v_1d(kk) = (dp_1d(kk)*v_1d(kk) + fp(kk)*v_1d(kk-1))*bei
           do k = kk - 1, 1, - 1
-            v_1d(k) = v_1d(k) - gam(k + 1)*v_1d(k + 1)
+            v_1d(k) = v_1d(k) - gam(k+1)*v_1d(k+1)
           enddo
 
           ! Update 3D arrays
           do k = 1, kk
             kn = k + nn
-            v(i, j, kn) = v_1d(k)
+            v(i,j,kn) = v_1d(k)
           enddo
 
         enddo

--- a/phy/mod_budget.F90
+++ b/phy/mod_budget.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2007-2024 Mats Bentsen, Mariana Vertenstein
+! Copyright (C) 2007-2025 Mats Bentsen, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !
@@ -29,7 +29,7 @@ module mod_budget
   use mod_vcoord,    only: vcoord_tag, vcoord_isopyc_bulkml
   use mod_grid,      only: scp2
   use mod_state,     only: pb, dp, temp, saln
-  use mod_forcing,   only: surflx, surrlx, salflx, salrlx
+  use mod_forcing,   only: salt_corr, surflx, surrlx, salflx, salrlx
   use mod_utility,   only: util1, util2, util3, util4
   use mod_tracers,   only: itrtke, itrgls, trc, trflx
   use mod_ifdefs,    only: use_TRC, use_TKE, use_GLS
@@ -55,6 +55,9 @@ module mod_budget
        glsdp            ! Global mass weighted sum of GLS.
   real(r8), dimension(ncalls, 2) :: &
        trdp             ! Global mass weighted sum of 1. tracer.
+
+  real(r8), dimension(2) :: &
+       sc               ! Global area weighted sum of salt correction.
 
   real(r8) :: &
        mass0, &         ! Global sum of mass.
@@ -176,6 +179,20 @@ contains
       call xcsum(trdp(ncall,n), util1, ips)
     end if
 
+    if ((vcoord_tag == vcoord_isopyc_bulkml .and. ncall == 5) .or. &
+        (vcoord_tag /= vcoord_isopyc_bulkml .and. ncall == 4)) then
+      !$omp parallel do private(l, i)
+      do j = 1, jj
+        do l = 1, isp(j)
+          do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
+            util1(i,j) = salt_corr(i,j)*scp2(i,j)
+          enddo
+        enddo
+      enddo
+      !$omp end parallel do
+      call xcsum(sc(n), util1, ips)
+    endif
+
   end subroutine budget_sums
 
   subroutine budget_output(m)
@@ -198,7 +215,7 @@ contains
              (sdp(2, m) - sdp(1, m))/mass0, &
              (sdp(3, m) - sdp(2, m))/mass0, &
              (sdp(4, m) - sdp(3, m))/mass0, &
-             (sdp(5, m) - sdp(4, m) + sf*g)/mass0, &
+             (sdp(5, m) - sdp(4, m) + (sf - sc(m))*g)/mass0, &
              (sdp(6, m) - sdp(5, m))/mass0, &
              (sdp(7, m) - sdp(6, m))/mass0
         close (nfu)
@@ -257,7 +274,7 @@ contains
         write (nfu, '(i8,6e12.4)') nstep - 1, &
              (sdp(2, m) - sdp(1, m))/mass0, &
              (sdp(3, m) - sdp(2, m))/mass0, &
-             (sdp(4, m) - sdp(3, m) + sf*g)/mass0, &
+             (sdp(4, m) - sdp(3, m) + (sf - sc(m))*g)/mass0, &
              (sdp(5, m) - sdp(4, m))/mass0, &
              (sdp(6, m) - sdp(5, m))/mass0, &
              (sdp(7, m) - sdp(6, m))/mass0

--- a/phy/mod_mxlayr.F90
+++ b/phy/mod_mxlayr.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2009-2024 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
+! Copyright (C) 2009-2025 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !
@@ -41,7 +41,7 @@ module mod_mxlayr
                            p, pu, pv, kfpla
   use mod_swabs,     only: swbgal, swbgfc, swamxd
   use mod_forcing,   only: surflx, surrlx, sswflx, &
-                           salflx, brnflx, salrlx, &
+                           salflx, brnflx, salrlx, salt_corr, trc_corr, &
                            ustar, ustar3, buoyfl
   use mod_eddtra,    only: ce, lfmin, tau_mlr
   use mod_niw,       only: niwgf, niwbf, idkedt
@@ -1224,7 +1224,8 @@ contains
           do k = 1,kk
             kn = k+nn
             temp(i,j,kn) = ttem(k)
-            saln(i,j,kn) = ssal(k)
+            salt_corr(i,j) = salt_corr(i,j) - min(0._r8, ssal(k))*delp(k)/g
+            saln(i,j,kn) = max(0._r8, ssal(k))
             sigma(i,j,kn) = dens(k)
             dp(i,j,kn) = delp(k)
             if (use_TRC) then
@@ -1241,7 +1242,9 @@ contains
                     end if
                   end if
                 end if
-                trc(i,j,kn,nt) = ttrc(nt,k)
+                trc_corr(i,j,nt) = trc_corr(i,j,nt) &
+                                 - min(0._r8, ttrc(nt,k))*delp(k)/g
+                trc(i,j,kn,nt) = max(0._r8, ttrc(nt,k))
               end do
             end if
           end do

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -1,6 +1,6 @@
 ! ------------------------------------------------------------------------------
 ! Copyright (C) 2005 HYCOM Consortium and contributors
-! Copyright (C) 2006-2024 Lars Inge Enstad, Mats Bentsen, Alok Kumar Gupta,
+! Copyright (C) 2006-2025 Lars Inge Enstad, Mats Bentsen, Alok Kumar Gupta,
 !                         Mariana Vertenstein
 !
 ! This file is part of BLOM.
@@ -2197,7 +2197,7 @@ contains
   end subroutine xcsync
 
   !-----------------------------------------------------------------------
-  subroutine xctilr(a,l1,ld,mh,nh,itype)
+  recursive subroutine xctilr(a,l1,ld,mh,nh,itype)
      integer, intent(in)    :: l1,ld,mh,nh,itype
      real,    intent(inout) :: a(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,ld)
 


### PR DESCRIPTION
Tracers are enforced to be non-negative and and any tracer quantity added to ensure non-negative values are compensation for by a global virtual flux correction.

The simulation n1850.ne30_tn14.hybrid_wavparam_vfcor_fatessp.20250204 was started as a hybrid simulation from year 29 of https://github.com/NorESMhub/noresm3_dev_simulations/issues/68 to test the impact of this PR. Diagnostics can be found here: https://ns2345k.web.sigma2.no/datalake/diagnostics/noresm/matsbn/n1850.ne30_tn14.hybrid_wavparam_vfcor_fatessp.20250204/

Some erratic biogeochemistry global flux time-series (net downward CO2 flux) and global averages (DIC and alkalinity) seems to be mitigated in the new simulation. It should be noted that recent changes to iHAMOCC included in the code base used for 1850.ne30_tn14.hybrid_wavparam_vfcor_fatessp.20250204 could also contribute to this improvement. Then there are difference to the evolution of global averages of oxygen, phosphate and nitrate that would be useful with comments on.

Global average salinity has a stronger increase in  n1850.ne30_tn14.hybrid_wavparam_vfcor_fatessp.20250204 compared to https://github.com/NorESMhub/noresm3_dev_simulations/issues/68. Apparently and unintentionally, CICE started from the initial condition set in user_nl_cice, and not the year 29 restart of https://github.com/NorESMhub/noresm3_dev_simulations/issues/68. The resulting sea-ice volume build-up might explain the salinity evolution. A new simulation is underway to make sure CICE starts from the year 29 restart of https://github.com/NorESMhub/noresm3_dev_simulations/issues/68.