### PR TITLE
Added alternative pressure gradient force formulation

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -363,7 +363,17 @@
     <values>
       <value>enscon</value>
     </values>
-    <desc>Momentum equation discretization method. Valid methods:</desc>
+    <desc>Momentum equation discretization method. Valid methods: 'enscon', 'enecon', 'enedis'</desc>
+  </entry>
+
+  <entry id="pgfmth">
+    <type>char</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>geopotential</value>
+    </values>
+    <desc>Pressure gradient force method. Valid options: 'geopotential', 'dynamic enthalpy'</desc>
   </entry>
 
   <entry id="bmcmth">

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -35,6 +35,8 @@
 !            'enscon' (Sadourny (1975) enstrophy conserving), 'enecon'
 !            (Sadourny (1975) energy conserving), 'enedis' (Sadourny
 !            (1975) energy conserving with some dissipation) (a)
+! PGFMTH   : Pressure gradient force method. Valid options:
+!            'geopotential', 'dynamic enthalpy' (a)
 ! BMCMTH   : Baroclinic mass flux correction method. Valid methods:
 !            'uc' (upstream column), 'dluc' (depth limited upstream
 !            column) (a)

--- a/phy/mod_eos.F90
+++ b/phy/mod_eos.F90
@@ -97,7 +97,8 @@ module mod_eos
              atf, btf, ctf, &
              inieos, rho, alp, sig, sig0, &
              drhodt, dsigdt, dsigdt0, drhods, dsigds, dsigds0, &
-             tofsig, sofsig, p_alpha, p_p_alpha, delphi
+             tofsig, sofsig, p_alpha, p_p_alpha, delphi, &
+             dalpdt, dalpds, dynh_derivatives
 
 contains
 
@@ -428,7 +429,7 @@ contains
       b2 = b21 + b22*th + b23*s
 
       ! The analytic solution of the integral is
-      !    p_alpha = ( b2*(p2 - p1)
+      !    p_alpha = ( b2*(p2 - p1) &
       !              + (a2 - a1*b2/b1)*log((a1 + b1*p2)/(a1 + b1*p1)))/b1
       ! A truncated series expansion of the integral is used that provides
       ! better computational efficiency and accuarcy for most relevant
@@ -547,5 +548,172 @@ contains
       alp2 = (a2 + b2*p2)/(a1 + b1*p2)
 
    end subroutine delphi
+
+   pure real(r8) function dalpdt(p, th, s)
+   ! ---------------------------------------------------------------------------
+   ! Derivative of specific volume with respect to potential temperature
+   ! [cm3 g-1 K-1].
+   ! ---------------------------------------------------------------------------
+
+      real(r8), intent(in) :: &
+         p,    & ! Pressure [g cm-1 s-2].
+         th,   & ! Potental temperature [deg C].
+         s       ! Salinity [g kg-1].
+
+      real(r8) :: r1, r2i
+
+      r1 = a21 + (a22 + a24*th + a25*s)*th + (a23 + a26*s)*s &
+         + (b21 + b22*th + b23*s)*p
+      r2i = 1._r8/( a11 + (a12 + a14*th + a15*s)*th + (a13 + a16*s)*s &
+                  + (b11 + b12*th + b13*s)*p)
+
+      dalpdt = ( a22 + 2._r8*a24*th + a25*s + b22*p &
+               - (a12 + 2._r8*a14*th + a15*s + b12*p)*r1*r2i)*r2i
+
+   end function dalpdt
+
+   pure real(r8) function dalpds(p, th, s)
+   ! ---------------------------------------------------------------------------
+   ! Derivative of specific volume with respect to potential temperature
+   ! [cm3 g-1 K-1].
+   ! ---------------------------------------------------------------------------
+
+      real(r8), intent(in) :: &
+         p,    & ! Pressure [g cm-1 s-2].
+         th,   & ! Potental temperature [deg C].
+         s       ! Salinity [g kg-1].
+
+      real(r8) :: r1, r2i
+
+      r1 = a21 + (a22 + a24*th + a25*s)*th + (a23 + a26*s)*s &
+         + (b21 + b22*th + b23*s)*p
+      r2i = 1._r8/( a11 + (a12 + a14*th + a15*s)*th + (a13 + a16*s)*s &
+                  + (b11 + b12*th + b13*s)*p)
+
+      dalpds = ( a23 + a25*th + 2._r8*a26*s + b23*p &
+               - (a13 + a15*th + 2._r8*a16*s + b13*p)*r1*r2i)*r2i
+
+   end function dalpds
+
+   subroutine dynh_derivatives(p0, p1, p2, th, s, dynh_th, dynh_s)
+   ! ---------------------------------------------------------------------------
+   ! Derivatives with respect to potential temperature and salinity of dynamic
+   ! enthalphy. The derivatives are the average between pressures p1 and p2,
+   ! with potential temperature and salinity held constant.
+   ! ---------------------------------------------------------------------------
+
+      real(r8), intent(in) :: &
+         p0,   & ! Dynamic enthalphy reference pressure [g cm-1 s-2].
+         p1,   & ! Lower pressure bound [g cm-1 s-2].
+         p2,   & ! Upper pressure bound [g cm-1 s-2].
+         th,   & ! Potential temperature [deg C].
+         s       ! Salinity [g kg-1].
+
+      real(r8), intent(out) :: &
+         dynh_th, & ! Derivative of dynamic enthalpy with respect to potential
+                    ! temperature.
+         dynh_s     ! Derivative of dynamic enthalpy with respect to salinity.
+
+      real(r8), parameter :: &
+         r1_2   = 1._r8/2._r8,  &
+         r1_3   = 1._r8/3._r8,  &
+         r1_4   = 1._r8/4._r8,  &
+         r1_5   = 1._r8/5._r8,  &
+         r1_6   = 1._r8/6._r8,  &
+         r1_7   = 1._r8/7._r8,  &
+         r1_8   = 1._r8/8._r8,  &
+         r1_9   = 1._r8/9._r8,  &
+         r1_10  = 1._r8/10._r8, &
+         r1_11  = 1._r8/11._r8
+
+      real(r8) :: b1i, a1, a2, b2, a1_th, a2_th, b2_th, a1_s, a2_s, b2_s, &
+                  pm1, pp1, pm0, pp0, t1, t0, q1, q0, qq1, qq0, &
+                  f, c1, c2, c3
+
+      b1i = 1._r8/(b11 + b12*th + b13*s)
+      a1 = (a11 + (a12 + a14*th + a15*s)*th + (a13 + a16*s)*s)*b1i
+      a2 = (a21 + (a22 + a24*th + a25*s)*th + (a23 + a26*s)*s)*b1i
+      b2 = (b21 + b22*th + b23*s)*b1i
+
+      a1_th = (a12 + 2._r8*a14*th + a15*s - a1*b12)*b1i
+      a2_th = (a22 + 2._r8*a24*th + a25*s - a2*b12)*b1i
+      b2_th = (b22 - b2*b12)*b1i
+
+      a1_s = (a13 + a15*th + 2._r8*a16*s - a1*b13)*b1i
+      a2_s = (a23 + a25*th + 2._r8*a26*s - a2*b13)*b1i
+      b2_s = (b23 - b2*b13)*b1i
+
+      ! The analytic solution to the derivatives are:
+      ! 
+      !    dynh_th = &
+      !       ( (a2_th - a1*b2_th - a1_th*b2) &
+      !         *( (a1 + p2)*log((a1 + p2)/(a1 + p0)) &
+      !          - (a1 + p1)*log((a1 + p1)/(a1 + p0))) &
+      !       + a1_th*(b2*a1 - a2)*log((a1 + p1)/(a1 + p2)))/(p2 - p1) &
+      !     + (b2*(2._r8*a1 + p0) - a2)*a1_th/(a1 + p0) &
+      !     + ((a1 + .5_r8*(p1 + p2) - p0)*b2_th - a2_th)
+      !
+      !    dynh_s  = &
+      !       ( (a2_s - a1*b2_s - a1_s*b2) &
+      !         *( (a1 + p2)*log((a1 + p2)/(a1 + p0)) &
+      !          - (a1 + p1)*log((a1 + p1)/(a1 + p0))) &
+      !       + a1_s*(b2*a1 - a2)*log((a1 + p1)/(a1 + p2)))/(p2 - p1) &
+      !     + (b2*(2._r8*a1 + p0) - a2)*a1_s/(a1 + p0) &
+      !     + ((a1 + .5_r8*(p1 + p2) - p0)*b2_s - a2_s)
+      !
+      ! A truncated series expansion of the expressions are used that provides
+      ! better computational efficiency and accuarcy for most relevant
+      ! parameters.
+
+      pm1 = r1_2*(p2 + p1)
+      pp1 = r1_2*(p2 - p1)
+      pm0 = r1_2*(pm1 + p0)
+      pp0 = r1_2*(pm1 - p0)
+
+      t1 = 1._r8/(a1 + pm1)
+      t0 = 1._r8/(a1 + pm0)
+      q1 = pp1*t1
+      q0 = pp0*t0
+      qq1 = q1*q1
+      qq0 = q0*q0
+
+      f = (a2 - a1*b2)*a1_th
+      c1 = a2_th - a1*b2_th - b2*a1_th
+      c2 = f*t1
+      c3 = f*t0
+
+      dynh_th = 2._r8*( pp0*b2_th &
+                      + ((((( (r1_11*c1 - c3) *qq0 &
+                            + (r1_9 *c1 - c3))*qq0 &
+                            + (r1_7 *c1 - c3))*qq0 &
+                            + (r1_5 *c1 - c3))*qq0 &
+                            + (r1_3 *c1 - c3))*qq0 &
+                            + (      c1 - c3))*q0) &
+               - (((( r1_11*(r1_10*c1 - c2) *qq1 &
+                    + r1_9 *(r1_8 *c1 - c2))*qq1 &
+                    + r1_7 *(r1_6 *c1 - c2))*qq1 &
+                    + r1_5 *(r1_4 *c1 - c2))*qq1 &
+                    + r1_3 *(r1_2 *c1 - c2))*qq1
+
+
+      f = (a2 - a1*b2)*a1_s
+      c1 = a2_s - a1*b2_s - b2*a1_s
+      c2 = f*t1
+      c3 = f*t0
+
+      dynh_s  = 2._r8*( pp0*b2_s &
+                      + ((((( (r1_11*c1 - c3) *qq0 &
+                            + (r1_9 *c1 - c3))*qq0 &
+                            + (r1_7 *c1 - c3))*qq0 &
+                            + (r1_5 *c1 - c3))*qq0 &
+                            + (r1_3 *c1 - c3))*qq0 &
+                            + (      c1 - c3))*q0) &
+               - (((( r1_11*(r1_10*c1 - c2) *qq1 &
+                    + r1_9 *(r1_8 *c1 - c2))*qq1 &
+                    + r1_7 *(r1_6 *c1 - c2))*qq1 &
+                    + r1_5 *(r1_4 *c1 - c2))*qq1 &
+                    + r1_3 *(r1_2 *c1 - c2))*qq1
+
+   end subroutine dynh_derivatives
 
 end module mod_eos

--- a/phy/mod_eos.F90
+++ b/phy/mod_eos.F90
@@ -574,8 +574,7 @@ contains
 
    pure real(r8) function dalpds(p, th, s)
    ! ---------------------------------------------------------------------------
-   ! Derivative of specific volume with respect to potential temperature
-   ! [cm3 g-1 K-1].
+   ! Derivative of specific volume with respect to salinity [cm3 kg g-2].
    ! ---------------------------------------------------------------------------
 
       real(r8), intent(in) :: &

--- a/phy/mod_momtum.F90
+++ b/phy/mod_momtum.F90
@@ -37,7 +37,7 @@ module mod_momtum
   use mod_state,     only: u, v, dp, dpu, dpv, p, pu, pv, ub, vb, &
                            pbu, pbv, ubflxs_p, vbflxs_p, &
                            pbu_p, pbv_p, ubcors_p, vbcors_p
-  use mod_pgforc,    only: wpgf, pgfx, pgfy, pgfxo, pgfyo
+  use mod_pgforc,    only: wpgf, pgfx, pgfy, pgfx_o, pgfy_o
   use mod_tmsmt,     only: wuv1, wuv2, dpuold, dpvold
   use mod_diffusion, only: difmxp, difmxq, difwgt, &
                            mu_nonloc, mv_nonloc
@@ -983,7 +983,7 @@ contains
             botstr = -utotn(i,j)*q/(1.+delt1*q)
 
             ! time averaged pressure gradient term
-            pgf = (1.-2.*wpgf)*pgfx(i,j,km) + wpgf*(pgfxo(i,j,k)+pgfx(i,j,kn))
+            pgf = (1.-2.*wpgf)*pgfx(i,j,km) + wpgf*(pgfx_o(i,j,k)+pgfx(i,j,kn))
 
             ! time smoothing of -u- field  (part 1)
             u(i,j,km) = u(i,j,km)*(wuv1*dpu(i,j,km)+onemm) &
@@ -1146,7 +1146,7 @@ contains
             botstr = -vtotn(i,j)*q/(1.+delt1*q)
 
             ! time averaged pressure gradient term
-            pgf = (1.-2.*wpgf)*pgfy(i,j,km) + wpgf*(pgfyo(i,j,k)+pgfy(i,j,kn))
+            pgf = (1.-2.*wpgf)*pgfy(i,j,km) + wpgf*(pgfy_o(i,j,k)+pgfy(i,j,kn))
 
             ! time smoothing of -v- field  (part 1)
             v(i,j,km) = v(i,j,km)*(wuv1*dpv(i,j,km)+onemm) &

--- a/phy/mod_pgforc.F90
+++ b/phy/mod_pgforc.F90
@@ -18,118 +18,422 @@
 ! ------------------------------------------------------------------------------
 
 module mod_pgforc
-
-  ! --- ------------------------------------------------------------------
-  ! --- This module contains variables and procedures related to time
-  ! --- integration of the baroclinic momentum equation.
-  ! --- ------------------------------------------------------------------
+! ------------------------------------------------------------------------------
+! This module contains variables and procedures related to time integration of
+! the baroclinic momentum equation.
+! ------------------------------------------------------------------------------
 
   use dimensions,    only: idm, jdm, kdm
   use mod_xc,        only: xctilr, nbdy, ii, jj, kk, &
                            isp, ifp, ilp, isu, ifu, ilu, isv, ifv, ilv, &
-                           halo_ps, mnproc, lp, ip, iu, iv
+                           halo_ps, mnproc, lp, ip, iu, iv, xcstop
   use mod_types,     only: r8
-  use mod_constants, only: g, epsilp, spval
+  use mod_constants, only: g, epsilp, onemm, spval
   use mod_state,     only: dp, dpu, dpv, temp, saln, p, pu, pv, phi, &
                            pb_p, pbu_p, pbv_p, sealv
-  use mod_eos,       only: delphi
+  use mod_eos,       only: pref, alp, p_alpha, delphi, dalpdt, dalpds, &
+                           dynh_derivatives
   use mod_checksum,  only: csdiag, chksummsk
 
   implicit none
   private
 
-  ! --- Constants.
-  real(r8) :: &
-       wpgf = .25_r8 ! Weight for time averaging of pressure gradient
-                     ! force [].
+  ! Variables to be set in namelist:
+  character(len = 80) :: pgfmth
+
+  ! Parameters.
+  real(r8), parameter :: &
+       wpgf = .25_r8, & ! Weight for time averaging of pressure gradient force
+                        ! [].
+       p0_dynh = 0._r8  ! Reference pressure for dynamic enthalpy [g cm-1 s-2].
 
   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2*kdm) :: &
-       pgfx  ! x-component of baroclinic pressure gradient
-             ! force [cm2 s-2]. &
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2*kdm) :: &
-       pgfy  ! y-component of baroclinic pressure gradient
-             ! force [cm2 s-2].
+       pgfx, &    ! x-component of baroclinic pressure gradient force [cm2 s-2].
+       pgfy       ! y-component of baroclinic pressure gradient force [cm2 s-2].
 
   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm) :: &
-       pgfxo         ! 'pgfx' at old time level [cm2 s-2]. &
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm) :: &
-       pgfyo         ! 'pgfy' at old time level [cm2 s-2].
+       pgfx_o, &  ! 'pgfx' at old time level [cm2 s-2]. &
+       pgfy_o     ! 'pgfy' at old time level [cm2 s-2].
 
   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2) :: &
-       pgfxm  ! x-component of barotropic pressure gradient
-              ! force, not dependent on bottom pressure
-              ! [cm2 s-2]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2) :: &
-       pgfym  ! y-component of barotropic pressure gradient
-              ! force, not dependent on bottom pressure
-              ! [cm2 s-2]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2) :: &
-       xixp   ! Dependeny of x-component of barotropic pressure
-              ! gradient force on bottom pressure at (i, j)
-              ! [cm3 g-1].
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2) :: &
-       xixm   ! Dependeny of x-component of barotropic pressure
-              ! gradient force on bottom pressure at (i - 1, j)
-              ! [cm3 g-1].
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2) :: &
-       xiyp   ! Dependeny of y-component of barotropic pressure
-              ! gradient force on bottom pressure at (i, j)
-              ! [cm3 g-1].
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,2) :: &
-       xiym   ! Dependeny of y-component of barotropic pressure
-              ! gradient force on bottom pressure at (i, j - 1)
-              ! [cm3 g-1].
+       pgfxm, &   ! x-component of barotropic pressure gradient force, not
+                  ! dependent on bottom pressure [cm2 s-2]
+       pgfym, &   ! y-component of barotropic pressure gradient force, not
+                  ! dependent on bottom pressure [cm2 s-2]
+       xixp, &    ! Dependeny of x-component of barotropic pressure gradient
+                  ! force on bottom pressure at (i, j) [cm3 g-1].
+       xixm, &    ! Dependeny of x-component of barotropic pressure gradient
+                  ! force on bottom pressure at (i - 1, j) [cm3 g-1].
+       xiyp, &    ! Dependeny of y-component of barotropic pressure gradient
+                  ! force on bottom pressure at (i, j) [cm3 g-1].
+       xiym       ! Dependeny of y-component of barotropic pressure gradient
+                  ! force on bottom pressure at (i, j - 1) [cm3 g-1].
 
   real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-       pgfxm_o       ! 'pgfxm' at old time level [cm2 s-2]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-       pgfym_o       ! 'pgfym' at old time level [cm2 s-2]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-       xixp_o        ! 'xixp' at old time level [cm3 g-1]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-       xixm_o        ! 'xixm' at old time level [cm3 g-1]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-       xiyp_o        ! 'xiyp' at old time level [cm3 g-1]
-  real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-       xiym_o        ! 'xiym' at old time level [cm3 g-1].
+       pgfxm_o, & ! 'pgfxm' at old time level [cm2 s-2]
+       pgfym_o, & ! 'pgfym' at old time level [cm2 s-2]
+       xixp_o, &  ! 'xixp' at old time level [cm3 g-1]
+       xixm_o, &  ! 'xixm' at old time level [cm3 g-1]
+       xiyp_o, &  ! 'xiyp' at old time level [cm3 g-1]
+       xiym_o         ! 'xiym' at old time level [cm3 g-1].
 
-  ! Public variables
-  public :: wpgf, pgfx, pgfy, pgfxo, pgfyo, pgfxm, pgfym
-  public :: xixp, xixm, xiyp, xiym, pgfxm_o, pgfym_o
-  public :: xixp_o, xixm_o, xiyp_o, xiym_o
+  ! Public variables.
+  public :: pgfmth, wpgf, pgfx, pgfy, pgfx_o, pgfy_o, pgfxm, pgfym, &
+            xixp, xixm, xiyp, xiym, pgfxm_o, pgfym_o, &
+            xixp_o, xixm_o, xiyp_o, xiym_o
 
-  ! Public routines
+  ! Public routines.
   public :: inivar_pgforc, pgforc
 
 contains
 
-  ! ------------------------------------------------------------------
+  ! ----------------------------------------------------------------------------
+  ! Private procedures.
+  ! ----------------------------------------------------------------------------
+
+  subroutine pgforc_geopotential(m, n, mm, nn, k1m, k1n)
+  ! ----------------------------------------------------------------------------
+  ! Compute the pressure gradient force (PGF) as the gradient of the
+  ! geopotential on pressure surfaces.
+  ! ----------------------------------------------------------------------------
+
+    ! Arguments.
+    integer, intent(in) :: m, n, mm, nn, k1m, k1n
+
+    ! Local variables.
+    real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm+1) :: phip
+    real :: dphi, alpl, alpu, prs, dphip, dphim, alplp, alpup, alplm, alpum, &
+            cp, cm, phi_p, phi_m, q
+    integer, dimension(idm) :: kup, kum, kvp, kvm
+    integer :: i, j, k, l, kn
+
+    !$omp parallel do private(l,i,k,kn,dphi,alpu,alpl)
+    do j = 0, jj
+      do l = 1, isp(j)
+        do i = max(0, ifp(j,l)), min(ii, ilp(j,l))
+          phip(i,j,kk+1) = 0._r8
+        end do
+      end do
+      do k = kk, 1, -1
+        kn = k + nn
+        do l = 1, isp(j)
+          do i = max(0, ifp(j,l)), min(ii, ilp(j,l))
+            if (dp(i,j,kn) < epsilp) then
+              phi (i,j,k) = phi (i,j,k+1)
+              phip(i,j,k) = phip(i,j,k+1)
+            else
+              call delphi(p(i,j,k), p(i,j,k+1), temp(i,j,kn), saln(i,j,kn), &
+                          dphi, alpu, alpl)
+              phi (i,j,k) = phi (i,j,k+1) - dphi
+              phip(i,j,k) = phip(i,j,k+1) + p(i,j,k+1)*alpl - p(i,j,k)*alpu
+            end if
+          end do
+        end do
+      end do
+    end do
+    !$omp end parallel do
+
+    !$omp parallel do private( &
+    !$omp l,i,kup,kum,kvp,kvm,k,kn,prs,dphip,alpup,alplp,dphim,alpum,alplm, &
+    !$omp cp,cm,q,phi_p,phi_m)
+    do j = 1, jj
+
+      do l = 1, isu(j)
+        do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+          kup(i) = kk
+          kum(i) = kk
+          xixp(i,j,n) = 0._r8
+          xixm(i,j,n) = 0._r8
+          pgfxm(i,j,n) = 0._r8
+        end do
+      end do
+
+      do l = 1, isv(j)
+        do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+          kvp(i) = kk
+          kvm(i) = kk
+          xiyp(i,j,n) = 0._r8
+          xiym(i,j,n) = 0._r8
+          pgfym(i,j,n) = 0._r8
+        end do
+      end do
+
+      do k = kk, 1, -1
+        kn = k + nn
+
+        do l = 1, isu(j)
+          do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+
+            prs = pu(i,j,k+1) - .5_r8*dpu(i,j,kn)
+
+            do while (p(i  ,j,kup(i)) > prs)
+              kup(i) = kup(i) - 1
+            end do
+
+            do while (p(i-1,j,kum(i)) > prs)
+              kum(i) = kum(i) - 1
+            end do
+
+            call delphi(prs, p(i,j,kup(i)+1), &
+                        temp(i,j,kup(i)+nn), saln(i,j,kup(i)+nn), &
+                        dphip, alpup, alplp)
+
+            call delphi(prs, p(i-1,j,kum(i)+1), &
+                        temp(i-1,j,kum(i)+nn), saln(i-1,j,kum(i)+nn), &
+                        dphim, alpum, alplm)
+
+            cp = .25_r8*(p(i  ,j,k+1) + p(i  ,j,k))
+            cm = .25_r8*(p(i-1,j,k+1) + p(i-1,j,k))
+            q = prs/(cp + cm)
+            cp = q*cp
+            cm = q*cm
+
+            phi_p = phi(i  ,j,kup(i)+1) - dphip
+            xixp(i,j,n) = xixp(i,j,n) &
+                        + ( phip(i  ,j,kup(i)+1) &
+                          + p(i  ,j,kup(i)+1)*alplp - cp*(alpup-alpum)) &
+                          *dpu(i,j,kn)
+
+            phi_m = phi(i-1,j,kum(i)+1) - dphim
+            xixm(i,j,n) = xixm(i,j,n) &
+                        + ( phip(i-1,j,kum(i)+1) &
+                          + p(i-1,j,kum(i)+1)*alplm - cm*(alpum-alpup)) &
+                          *dpu(i,j,kn)
+
+            pgfx(i,j,kn) = - (phi_p - phi_m)
+            pgfxm(i,j,n) = pgfxm(i,j,n) + pgfx(i,j,kn)*dpu(i,j,kn)
+
+          end do
+        end do
+
+        do l = 1, isv(j)
+          do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+
+            prs = pv(i,j,k+1) - .5_r8*dpv(i,j,kn)
+
+            do while (p(i,j  ,kvp(i)) > prs)
+              kvp(i) = kvp(i)-1
+            end do
+
+            do while (p(i,j-1,kvm(i)) > prs)
+              kvm(i) = kvm(i)-1
+            end do
+
+            call delphi(prs, p(i,j  ,kvp(i)+1), &
+                        temp(i,j  ,kvp(i)+nn), saln(i,j  ,kvp(i)+nn), &
+                        dphip, alpup, alplp)
+
+            call delphi(prs, p(i,j-1,kvm(i)+1), &
+                        temp(i,j-1,kvm(i)+nn), saln(i,j-1,kvm(i)+nn), &
+                        dphim, alpum, alplm)
+
+            cp = .25_r8*(p(i,j  ,k+1) + p(i,j  ,k))
+            cm = .25_r8*(p(i,j-1,k+1) + p(i,j-1,k))
+            q = prs/(cp + cm)
+            cp = q*cp
+            cm = q*cm
+
+            phi_p = phi(i,j  ,kvp(i)+1) - dphip
+            xiyp(i,j,n) = xiyp(i,j,n) &
+                        + ( phip(i,j  ,kvp(i)+1) &
+                          + p(i,j  ,kvp(i)+1)*alplp - cp*(alpup-alpum)) &
+                          *dpv(i,j,kn)
+
+            phi_m = phi(i,j-1,kvm(i)+1) - dphim
+            xiym(i,j,n) = xiym(i,j,n) &
+                        + ( phip(i,j-1,kvm(i)+1) &
+                          + p(i,j-1,kvm(i)+1)*alplm - cm*(alpum-alpup)) &
+                          *dpv(i,j,kn)
+
+            pgfy(i,j,kn) = - (phi_p - phi_m)
+            pgfym(i,j,n) = pgfym(i,j,n) + pgfy(i,j,kn)*dpv(i,j,kn)
+
+          end do
+        end do
+
+      end do
+
+    end do
+    !$omp end parallel do
+
+  end subroutine pgforc_geopotential
+
+  subroutine pgforc_dynamic_enthalpy(m, n, mm, nn, k1m, k1n)
+  ! ----------------------------------------------------------------------------
+  ! Compute the pressure gradient force (PGF) using layer-wise gradients.
+  ! ----------------------------------------------------------------------------
+
+    ! Arguments.
+    integer, intent(in) :: m, n, mm, nn, k1m, k1n
+
+    ! Local variables.
+    real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm) :: &
+      pot_dynh, pot_dynh_pb, dynh_a, dynh_t, alpha_r
+    real :: dynh_ts_t, dynh_ts_s
+    integer :: i, j, k, l, kn
+
+    !$omp parallel do private(kn, l, i, k, dynh_ts_t, dynh_ts_s)
+    do j = 0, jj
+
+      ! For each layer, obtain the potential, pot_dynh, which is the sum of
+      ! dynamic enthalpy and the geopotential. Also get the linearized response
+      ! of this potential to barotropic pressure excursions, pot_dynh_pb, and
+      ! the geopotential, phi, at layer interfaces.
+
+      kn = kk + nn
+      do l = 1, isp(j)
+        do i = max(0, ifp(j,l)), min(ii, ilp(j,l))
+          pot_dynh(i,j,kk) = phi(i,j,kk+1) &
+           + p_alpha(p0_dynh, p(i,j,kk+1), temp(i,j,kn), saln(i,j,kn))
+          pot_dynh_pb(i,j,kk) = &
+             alp(p(i,j,kk+1), temp(i,j,kn),saln(i,j,kn))*p(i,j,kk+1)
+          phi(i,j,kk) = phi(i,j,kk+1) &
+           + p_alpha(p(i,j,kk), p(i,j,kk+1), temp(i,j,kn), saln(i,j,kn))
+        end do
+      end do
+      do k = kk-1, 1, -1
+        kn = k + nn
+        do l = 1, isp(j)
+          do i = max(0, ifp(j,l)), min(ii, ilp(j,l))
+            pot_dynh(i,j,k) = pot_dynh(i,j,k+1) &
+             + p_alpha(p0_dynh, p(i,j,k+1), temp(i,j,kn  ),saln(i,j,kn  )) &
+             - p_alpha(p0_dynh, p(i,j,k+1), temp(i,j,kn+1),saln(i,j,kn+1))
+            pot_dynh_pb(i,j,k) = pot_dynh_pb(i,j,k+1) &
+             + ( alp(p(i,j,k+1), temp(i,j,kn  ),saln(i,j,kn  )) &
+               - alp(p(i,j,k+1), temp(i,j,kn+1),saln(i,j,kn+1)))*p(i  ,j,k+1)
+            phi(i,j,k) = phi(i,j,k+1) &
+             + p_alpha(p(i,j,k), p(i,j,k+1), temp(i,j,kn), saln(i,j,kn))
+          end do
+        end do
+      end do
+
+      ! For each layer, find the derivatives of dynamic enthalpy with respect to
+      ! potential temperature and specific volume with a reference pressure
+      ! (reciprocal of potential density).
+
+      do k = 1, kk
+        kn = k + nn
+        do l = 1, isp(j)
+          do i = max(0, ifp(j,l)), min(ii, ilp(j,l))
+            if (dp(i,j,kn) < onemm) then
+              dynh_a(i,j,k) = 0._r8
+              dynh_t(i,j,k) = 0._r8
+            else
+              call dynh_derivatives(p0_dynh, p(i,j,k), p(i,j,k+1), &
+                                    temp(i,j,kn), saln(i,j,kn), &
+                                    dynh_ts_t, dynh_ts_s)
+              dynh_a(i,j,k) = &
+                 dynh_ts_s/dalpds(pref, temp(i,j,kn), saln(i,j,kn))
+              dynh_t(i,j,k) = &
+                 dynh_ts_t &
+               - dynh_a(i,j,k)*dalpdt(pref, temp(i,j,kn), saln(i,j,kn))
+            end if
+            alpha_r(i,j,k) = alp(pref, temp(i,j,kn), saln(i,j,kn))
+          end do
+        end do
+      end do
+    end do
+
+    ! Compute the pressure gradient force as the gradient on vertical coordinate
+    ! surfaces of pot_dynh with additional contributions by potential
+    ! temperature and specific volume gradients. Also accumulate layer pressure
+    ! thickness weighted PGF and linearized response of PGF to barotropic
+    ! pressure excursions.
+
+    !$omp parallel do private(l, i, k, kn)
+    do j = 1, jj
+
+      do l = 1, isu(j)
+        do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+          xixp(i,j,n) = 0._r8
+          xixm(i,j,n) = 0._r8
+          pgfxm(i,j,n) = 0._r8
+        end do
+      end do
+
+      do l = 1, isv(j)
+        do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+          xiyp(i,j,n) = 0._r8
+          xiym(i,j,n) = 0._r8
+          pgfym(i,j,n) = 0._r8
+        end do
+      end do
+
+      do k = kk, 1, -1
+        kn = k + nn
+
+        do l = 1, isu(j)
+          do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+
+            pgfx(i,j,kn) = - (pot_dynh(i,j,k) - pot_dynh(i-1,j,k))
+            if (dp(i-1,j,kn) >= onemm .and. dp(i,j,kn) >= onemm) then
+              pgfx(i,j,kn) = pgfx(i,j,kn) &
+                           + .5_r8*( (dynh_t(i-1,j,k) + dynh_t(i,j,k)) &
+                                     *(temp   (i,j,k) - temp   (i-1,j,k)) &
+                                   + (dynh_a(i-1,j,k) + dynh_a(i,j,k)) &
+                                     *(alpha_r(i,j,k) - alpha_r(i-1,j,k)))
+            endif
+
+            pgfxm(i,j,n) = pgfxm(i,j,n) + pgfx(i,j,kn)*dpu(i,j,kn)
+            xixm(i,j,n) = xixm(i,j,n) + pot_dynh_pb(i-1,j,k)*dpu(i,j,kn)
+            xixp(i,j,n) = xixp(i,j,n) + pot_dynh_pb(i  ,j,k)*dpu(i,j,kn)
+
+          end do
+        end do
+
+        do l = 1, isv(j)
+          do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+
+            pgfy(i,j,kn) = - (pot_dynh(i,j,k) - pot_dynh(i,j-1,k))
+            if (dp(i,j-1,kn) >= onemm .and. dp(i,j,kn) >= onemm) then
+              pgfy(i,j,kn) = pgfy(i,j,kn) &
+                           + .5_r8*( (dynh_t(i,j-1,k) + dynh_t(i,j,k)) &
+                                     *(temp   (i,j,k) - temp   (i,j-1,k)) &
+                                   + (dynh_a(i,j-1,k) + dynh_a(i,j,k)) &
+                                     *(alpha_r(i,j,k) - alpha_r(i,j-1,k)))
+            endif
+
+            pgfym(i,j,n) = pgfym(i,j,n) + pgfy(i,j,kn)*dpv(i,j,kn)
+            xiym(i,j,n) = xiym(i,j,n) + pot_dynh_pb(i,j-1,k)*dpv(i,j,kn)
+            xiyp(i,j,n) = xiyp(i,j,n) + pot_dynh_pb(i,j  ,k)*dpv(i,j,kn)
+
+          end do
+        end do
+
+      end do
+
+    end do
+
+  end subroutine pgforc_dynamic_enthalpy
+
+  ! ----------------------------------------------------------------------------
+  ! Public procedures.
+  ! ----------------------------------------------------------------------------
 
   subroutine inivar_pgforc()
-
-    ! ------------------------------------------------------------------
-    ! Initialize arrays.
-    ! ------------------------------------------------------------------
+  ! ----------------------------------------------------------------------------
+  ! Initialize arrays.
+  ! ----------------------------------------------------------------------------
 
     ! Local variables
     integer :: i,j,k
 
     !$omp parallel do private(i,k)
-    do j = 1-nbdy,jj+nbdy
-      do k = 1,2*kk
-        do i = 1-nbdy,ii+nbdy
+    do j = 1-nbdy, jj+nbdy
+      do k = 1, 2*kk
+        do i = 1-nbdy, ii+nbdy
           pgfx(i,j,k) = spval
           pgfy(i,j,k) = spval
         end do
       end do
-      do k = 1,kk
-        do i = 1-nbdy,ii+nbdy
-          pgfxo(i,j,k) = spval
-          pgfyo(i,j,k) = spval
+      do k = 1, kk
+        do i = 1-nbdy, ii+nbdy
+          pgfx_o(i,j,k) = spval
+          pgfy_o(i,j,k) = spval
         end do
       end do
-      do k = 1,2
-        do i = 1-nbdy,ii+nbdy
+      do k = 1, 2
+        do i = 1-nbdy, ii+nbdy
           pgfxm(i,j,k) = spval
           pgfym(i,j,k) = spval
           xixp(i,j,k) = spval
@@ -138,7 +442,7 @@ contains
           xiym(i,j,k) = spval
         end do
       end do
-      do i = 1-nbdy,ii+nbdy
+      do i = 1-nbdy, ii+nbdy
         pgfxm_o(i,j) = spval
         pgfym_o(i,j) = spval
         xixp_o(i,j) = spval
@@ -151,102 +455,67 @@ contains
 
   end subroutine inivar_pgforc
 
-  ! ------------------------------------------------------------------
+  subroutine pgforc(m, n, mm, nn, k1m, k1n)
+  ! ----------------------------------------------------------------------------
+  ! Compute the pressure gradient force (PGF).
+  ! ----------------------------------------------------------------------------
 
-  subroutine pgforc(m,n,mm,nn,k1m,k1n)
+    ! Arguments.
+    integer, intent(in) :: m, n, mm, nn, k1m, k1n
 
-    ! ------------------------------------------------------------------
-    ! compute the pressure gradient force
-    ! ------------------------------------------------------------------
+    ! Local variables.
+    real :: q
+    integer :: i, j, k, l, kn
 
-    ! Arguments
-    integer, intent(in) :: m,n,mm,nn,k1m,k1n
-
-    ! Local variables
-    real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,kdm+1) :: phip
-    real :: dphi,alpl,alpu,prs,dphip,dphim,alplp,alpup,alplm,alpum,cp,cm, &
-         phi_p,phi_m,q
-    integer :: kup(idm),kum(idm),kvp(idm),kvm(idm)
-    integer :: i,j,k,l,kn
-
-    ! compute new -dpu,dpv- field.
-
+    ! Compute new -dpu,dpv- fields.
     !$omp parallel do private(k,kn,l,i)
-    do j = -2,jj+2
-      do k = 1,kk
-        kn = k+nn
-        do l = 1,isp(j)
-          do i = max(-2,ifp(j,l)),min(ii+2,ilp(j,l))
-            p(i,j,k+1) = p(i,j,k)+dp(i,j,kn)
+    do j = -2, jj+2
+      do k = 1, kk
+        kn = k + nn
+        do l = 1, isp(j)
+          do i = max(-2, ifp(j,l)), min(ii+2, ilp(j,l))
+            p(i,j,k+1) = p(i,j,k) + dp(i,j,kn)
           end do
         end do
       end do
     end do
     !$omp end parallel do
-
     !$omp parallel do private(k,kn,l,i,q)
-    do j = -1,jj+2
-      do k = 1,kk
-        kn = k+nn
-        do l = 1,isu(j)
-          do i = max(-1,ifu(j,l)),min(ii+2,ilu(j,l))
-            q = min(p(i,j,kk+1),p(i-1,j,kk+1))
-            dpu(i,j,kn)= &
-                 .5*((min(q,p(i-1,j,k+1))-min(q,p(i-1,j,k))) &
-                    +(min(q,p(i  ,j,k+1))-min(q,p(i  ,j,k))))
-            pu(i,j,k+1) = pu(i,j,k)+dpu(i,j,kn)
+    do j = -1, jj+2
+      do k = 1, kk
+        kn = k + nn
+        do l = 1, isu(j)
+          do i = max(-1, ifu(j,l)), min(ii+2, ilu(j,l))
+            q = min(p(i,j,kk+1), p(i-1,j,kk+1))
+            dpu(i,j,kn) = .5_r8*( (min(q, p(i-1,j,k+1)) - min(q, p(i-1,j,k))) &
+                                + (min(q, p(i  ,j,k+1)) - min(q, p(i  ,j,k))))
+            pu(i,j,k+1) = pu(i,j,k) + dpu(i,j,kn)
           end do
         end do
-        do l = 1,isv(j)
-          do i = max(-1,ifv(j,l)),min(ii+2,ilv(j,l))
-            q = min(p(i,j,kk+1),p(i,j-1,kk+1))
-            dpv(i,j,kn)= &
-                 .5*((min(q,p(i,j-1,k+1))-min(q,p(i,j-1,k))) &
-                    +(min(q,p(i,j  ,k+1))-min(q,p(i,j  ,k))))
-            pv(i,j,k+1) = pv(i,j,k)+dpv(i,j,kn)
-          end do
-        end do
-      end do
-    end do
-    !$omp end parallel do
-
-    !$omp parallel do private(l,i,k,kn,dphi,alpu,alpl)
-    do j = 0,jj
-      do l = 1,isp(j)
-        do i = max(0,ifp(j,l)),min(ii,ilp(j,l))
-          phip(i,j,kk+1) = 0.
-        end do
-      end do
-      do k = kk,1,-1
-        kn = k+nn
-        do l = 1,isp(j)
-          do i = max(0,ifp(j,l)),min(ii,ilp(j,l))
-            if (dp(i,j,kn) < epsilp) then
-              phi (i,j,k) = phi (i,j,k+1)
-              phip(i,j,k) = phip(i,j,k+1)
-            else
-              call delphi(p(i,j,k),p(i,j,k+1),temp(i,j,kn),saln(i,j,kn), &
-                   dphi,alpu,alpl)
-              phi (i,j,k) = phi (i,j,k+1)-dphi
-              phip(i,j,k) = phip(i,j,k+1)+p(i,j,k+1)*alpl-p(i,j,k)*alpu
-            end if
+        do l = 1, isv(j)
+          do i = max(-1, ifv(j,l)), min(ii+2, ilv(j,l))
+            q = min(p(i,j,kk+1), p(i,j-1,kk+1))
+            dpv(i,j,kn) = .5_r8*( (min(q, p(i,j-1,k+1)) - min(q, p(i,j-1,k))) &
+                                + (min(q, p(i,j  ,k+1)) - min(q, p(i,j  ,k))))
+            pv(i,j,k+1) = pv(i,j,k) + dpv(i,j,kn)
           end do
         end do
       end do
     end do
     !$omp end parallel do
 
+    ! Copy old PGF fields.
     !$omp parallel do private(l,i)
-    do j = -1,jj+2
-      do l = 1,isu(j)
-        do i = max(0,ifu(j,l)),min(ii+1,ilu(j,l))
+    do j = -1, jj+2
+      do l = 1, isu(j)
+        do i = max(0, ifu(j,l)), min(ii+1, ilu(j,l))
           xixp_o(i,j) = xixp(i,j,n)
           xixm_o(i,j) = xixm(i,j,n)
           pgfxm_o(i,j) = pgfxm(i,j,n)
         end do
       end do
-      do l = 1,isv(j)
-        do i = max(0,ifv(j,l)),min(ii+1,ilv(j,l))
+      do l = 1, isv(j)
+        do i = max(0, ifv(j,l)), min(ii+1, ilv(j,l))
           xiyp_o(i,j) = xiyp(i,j,n)
           xiym_o(i,j) = xiym(i,j,n)
           pgfym_o(i,j) = pgfym(i,j,n)
@@ -254,187 +523,93 @@ contains
       end do
     end do
     !$omp end parallel do
-
-    !$omp parallel do private( &
-    !$omp l,i,kup,kum,kvp,kvm,k,kn,prs,dphip,alpup,alplp,dphim,alpum,alplm, &
-    !$omp cp,cm,q,phi_p,phi_m)
-    do j = 1,jj
-
-      do l = 1,isu(j)
-        do i = max(1,ifu(j,l)),min(ii,ilu(j,l))
-          kup(i) = kk
-          kum(i) = kk
-          xixp(i,j,n) = 0.
-          xixm(i,j,n) = 0.
-          pgfxm(i,j,n) = 0.
-        end do
-      end do
-
-      do l = 1,isv(j)
-        do i = max(1,ifv(j,l)),min(ii,ilv(j,l))
-          kvp(i) = kk
-          kvm(i) = kk
-          xiyp(i,j,n) = 0.
-          xiym(i,j,n) = 0.
-          pgfym(i,j,n) = 0.
-        end do
-      end do
-
-      do k = kk,1,-1
-        kn = k+nn
-
-        do l = 1,isu(j)
-          do i = max(1,ifu(j,l)),min(ii,ilu(j,l))
-
-            prs = pu(i,j,k+1)-.5*dpu(i,j,kn)
-
-            do while (p(i,j,kup(i)) > prs)
-              kup(i) = kup(i)-1
-            end do
-
-            do while (p(i-1,j,kum(i)) > prs)
-              kum(i) = kum(i)-1
-            end do
-
-            call delphi(prs,p(i,j,kup(i)+1), &
-                 temp(i,j,kup(i)+nn),saln(i,j,kup(i)+nn), &
-                 dphip,alpup,alplp)
-
-            call delphi(prs,p(i-1,j,kum(i)+1), &
-                 temp(i-1,j,kum(i)+nn),saln(i-1,j,kum(i)+nn), &
-                 dphim,alpum,alplm)
-
-            cp = .25*(p(i  ,j,k+1)+p(i  ,j,k))
-            cm = .25*(p(i-1,j,k+1)+p(i-1,j,k))
-            q = prs/(cp+cm)
-            !           if (i.eq.itest.and.j.eq.jtest) write (lp,*) 'u',k,q
-            cp = q*cp
-            cm = q*cm
-
-            phi_p = phi(i,j,kup(i)+1)-dphip
-            xixp(i,j,n) = xixp(i,j,n) &
-                 +(phip(i,j,kup(i)+1) &
-                 +p(i,j,kup(i)+1)*alplp-cp*(alpup-alpum)) &
-                 *dpu(i,j,kn)
-
-            phi_m = phi(i-1,j,kum(i)+1)-dphim
-            xixm(i,j,n) = xixm(i,j,n) &
-                 +(phip(i-1,j,kum(i)+1) &
-                 +p(i-1,j,kum(i)+1)*alplm-cm*(alpum-alpup)) &
-                 *dpu(i,j,kn)
-
-            pgfxo(i,j,k) = pgfx(i,j,kn)
-            pgfx(i,j,kn) = -(phi_p-phi_m)
-            pgfxm(i,j,n) = pgfxm(i,j,n)+pgfx(i,j,kn)*dpu(i,j,kn)
-
+    !$omp parallel do private(k, kn, l, i)
+    do j = 1, jj
+      do k = kk, 1, -1
+        kn = k + nn
+        do l = 1, isu(j)
+          do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+            pgfx_o(i,j,k) = pgfx(i,j,kn)
           end do
         end do
-
-        do l = 1,isv(j)
-          do i = max(1,ifv(j,l)),min(ii,ilv(j,l))
-
-            prs = pv(i,j,k+1)-.5*dpv(i,j,kn)
-
-            do while (p(i,j  ,kvp(i)) > prs)
-              kvp(i) = kvp(i)-1
-            end do
-
-            do while (p(i,j-1,kvm(i)) > prs)
-              kvm(i) = kvm(i)-1
-            end do
-
-            call delphi(prs,p(i,j  ,kvp(i)+1), &
-                 temp(i,j  ,kvp(i)+nn),saln(i,j  ,kvp(i)+nn), &
-                 dphip,alpup,alplp)
-
-            call delphi(prs,p(i,j-1,kvm(i)+1), &
-                 temp(i,j-1,kvm(i)+nn),saln(i,j-1,kvm(i)+nn), &
-                 dphim,alpum,alplm)
-
-            cp = .25*(p(i,j  ,k+1)+p(i,j  ,k))
-            cm = .25*(p(i,j-1,k+1)+p(i,j-1,k))
-            q = prs/(cp+cm)
-            !           if (i.eq.itest.and.j.eq.jtest) write (lp,*) 'v',k,q
-            cp = q*cp
-            cm = q*cm
-
-            phi_p = phi(i,j  ,kvp(i)+1)-dphip
-            xiyp(i,j,n) = xiyp(i,j,n) &
-                 +(phip(i,j  ,kvp(i)+1) &
-                 +p(i,j  ,kvp(i)+1)*alplp-cp*(alpup-alpum)) &
-                 *dpv(i,j,kn)
-
-            phi_m = phi(i,j-1,kvm(i)+1)-dphim
-            xiym(i,j,n) = xiym(i,j,n) &
-                 +(phip(i,j-1,kvm(i)+1) &
-                 +p(i,j-1,kvm(i)+1)*alplm-cm*(alpum-alpup)) &
-                 *dpv(i,j,kn)
-
-            pgfyo(i,j,k) = pgfy(i,j,kn)
-            pgfy(i,j,kn) = -(phi_p-phi_m)
-            pgfym(i,j,n) = pgfym(i,j,n)+pgfy(i,j,kn)*dpv(i,j,kn)
-
+        do l = 1, isv(j)
+          do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+            pgfy_o(i,j,k) = pgfy(i,j,kn)
           end do
         end do
-
       end do
-
     end do
     !$omp end parallel do
 
-    call xctilr(pb_p, 1,1, 1,1, halo_ps)
+    ! Compute new PGF fields.
+    if (pgfmth == 'geopotential') then
+      call pgforc_geopotential(m, n, mm, nn, k1m, k1n)
+    elseif (pgfmth == 'dynamic enthalpy') then
+      call pgforc_dynamic_enthalpy(m, n, mm, nn, k1m, k1n)
+    else
+      if (mnproc == 1) then
+        write (lp,'(3a)') ' pgfmth = ',trim(pgfmth),' is unsupported!'
+      end if
+      call xcstop('(pgforc)')
+      stop '(pgforc)'
+    endif
+
+    ! Finalise vertical average PGF fields and the dependency fields of
+    ! barotropic PGF on bottom pressure.
+
+    call xctilr(pb_p, 1, 1, 1, 1, halo_ps)
 
     !$omp parallel do private(l,i,q,k,kn)
     do j = 1,jj
 
-      do l = 1,isu(j)
-        do i = max(1,ifu(j,l)),min(ii,ilu(j,l))
-          q = 1./pbu_p(i,j)
+      do l = 1, isu(j)
+        do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+          q = 1._r8/pbu_p(i,j)
           pgfxm(i,j,n) = pgfxm(i,j,n)*q
           xixp(i,j,n) = xixp(i,j,n)*q
           xixm(i,j,n) = xixm(i,j,n)*q
         end do
       end do
-      do l = 1,isv(j)
-        do i = max(1,ifv(j,l)),min(ii,ilv(j,l))
-          q = 1./pbv_p(i,j)
+      do l = 1, isv(j)
+        do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+          q = 1._r8/pbv_p(i,j)
           pgfym(i,j,n) = pgfym(i,j,n)*q
           xiyp(i,j,n) = xiyp(i,j,n)*q
           xiym(i,j,n) = xiym(i,j,n)*q
         end do
       end do
 
-      do k = 1,kk
-        kn = k+nn
-        do l = 1,isu(j)
-          do i = max(1,ifu(j,l)),min(ii,ilu(j,l))
-            pgfx(i,j,kn) = pgfx(i,j,kn)-pgfxm(i,j,n)
+      do k = 1, kk
+        kn = k + nn
+        do l = 1, isu(j)
+          do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+            pgfx(i,j,kn) = pgfx(i,j,kn) - pgfxm(i,j,n)
           end do
         end do
-        do l = 1,isv(j)
-          do i = max(1,ifv(j,l)),min(ii,ilv(j,l))
-            pgfy(i,j,kn) = pgfy(i,j,kn)-pgfym(i,j,n)
+        do l = 1, isv(j)
+          do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+            pgfy(i,j,kn) = pgfy(i,j,kn) - pgfym(i,j,n)
           end do
         end do
       end do
 
-      do l = 1,isu(j)
-        do i = max(1,ifu(j,l)),min(ii,ilu(j,l))
-          pgfxm(i,j,n) = pgfxm(i,j,n)+xixp(i,j,n)-xixm(i,j,n)
+      do l = 1, isu(j)
+        do i = max(1, ifu(j,l)), min(ii, ilu(j,l))
+          pgfxm(i,j,n) = pgfxm(i,j,n) + xixp(i,j,n) - xixm(i,j,n)
           xixp(i,j,n) = xixp(i,j,n)/pb_p(i  ,j)
           xixm(i,j,n) = xixm(i,j,n)/pb_p(i-1,j)
         end do
       end do
-      do l = 1,isv(j)
-        do i = max(1,ifv(j,l)),min(ii,ilv(j,l))
-          pgfym(i,j,n) = pgfym(i,j,n)+xiyp(i,j,n)-xiym(i,j,n)
+      do l = 1, isv(j)
+        do i = max(1, ifv(j,l)), min(ii, ilv(j,l))
+          pgfym(i,j,n) = pgfym(i,j,n) + xiyp(i,j,n) - xiym(i,j,n)
           xiyp(i,j,n) = xiyp(i,j,n)/pb_p(i,j  )
           xiym(i,j,n) = xiym(i,j,n)/pb_p(i,j-1)
         end do
       end do
 
-      do l = 1,isp(j)
-        do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
+      do l = 1, isp(j)
+        do i = max(1, ifp(j,l)), min(ii, ilp(j,l))
           sealv(i,j) = phi(i,j,1)/g
         end do
       end do
@@ -446,15 +621,15 @@ contains
       if (mnproc == 1) then
         write (lp,*) 'pgforc:'
       end if
-      call chksummsk(phi,ip,kk+1,'phi')
-      call chksummsk(pgfx,iu,2*kk,'pgfx')
-      call chksummsk(pgfy,iv,2*kk,'pgfy')
-      call chksummsk(pgfxm,iu,2,'pgfxm')
-      call chksummsk(pgfym,iv,2,'pgfym')
-      call chksummsk(xixp,iu,2,'xixp')
-      call chksummsk(xixm,iu,2,'xixm')
-      call chksummsk(xiyp,iv,2,'xiyp')
-      call chksummsk(xiym,iv,2,'xiym')
+      call chksummsk(phi   ,ip, kk+1, 'phi')
+      call chksummsk(pgfx  ,iu, 2*kk, 'pgfx')
+      call chksummsk(pgfy  ,iv, 2*kk, 'pgfy')
+      call chksummsk(pgfxm ,iu, 2,    'pgfxm')
+      call chksummsk(pgfym ,iv, 2,    'pgfym')
+      call chksummsk(xixp  ,iu, 2,    'xixp')
+      call chksummsk(xixm  ,iu, 2,    'xixm')
+      call chksummsk(xiyp  ,iv, 2,    'xiyp')
+      call chksummsk(xiym  ,iv, 2,    'xiym')
     end if
 
   end subroutine pgforc

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -37,6 +37,7 @@ module mod_rdlim
   use mod_momtum,      only: mdv2hi, mdv2lo, mdv4hi, mdv4lo, mdc2hi, &
                              mdc2lo, vsc2hi, vsc2lo, vsc4hi, vsc4lo, &
                              cbar, cb, mommth
+  use mod_pgforc,      only: pgfmth
   use mod_barotp,      only: cwbdts, cwbdls
   use mod_forcing,     only: aptflx, apsflx, ditflx, disflx, &
                              scfile, &
@@ -131,7 +132,7 @@ contains
          grfile,icfile,pref,baclin,batrop, &
          mdv2hi,mdv2lo,mdv4hi,mdv4lo,mdc2hi,mdc2lo, &
          vsc2hi,vsc2lo,vsc4hi,vsc4lo,cbar,cb,cwbdts,cwbdls, &
-         mommth,bmcmth,rmpmth, &
+         mommth,pgfmth,bmcmth,rmpmth, &
          mlrmth,ce,cl,tau_mlr,tau_growing_hbl,tau_decaying_hbl, &
          tau_growing_hml,tau_decaying_hml,lfmin,mstar,nstar,wpup_min, &
          mlrttp,rm0,rm5,tdfile,niwgf,niwbf,niwlf, &
@@ -199,6 +200,7 @@ contains
       write (lp,*) 'CWBDTS',CWBDTS
       write (lp,*) 'CWBDLS',CWBDLS
       write (lp,*) 'MOMMTH ',trim(MOMMTH)
+      write (lp,*) 'PGFMTH ',trim(PGFMTH)
       write (lp,*) 'BMCMTH ',trim(BMCMTH)
       write (lp,*) 'RMPMTH ',trim(RMPMTH)
       write (lp,*) 'MLRMTH ',trim(MLRMTH)
@@ -283,6 +285,7 @@ contains
     call xcbcst(cwbdts)
     call xcbcst(cwbdls)
     call xcbcst(mommth)
+    call xcbcst(pgfmth)
     call xcbcst(bmcmth)
     call xcbcst(rmpmth)
     call xcbcst(mlrmth)


### PR DESCRIPTION
An alternative pressure gradient force (PGF) formulation has been added that makes use of a dynamic enthalpy based potential. The choice of PGF method is now a namelist option. The original method is still default and will not change answers.

An OMIP2 simulation covering one forcing cycle has been carried out with the new PGF method. BLOM diagnostics comparing with the original PGF can be found here: https://ns2345k.web.sigma2.no/datalake/diagnostics/noresm/matsbn/NOIIAJRA_TL319_tn14_2.5a8d_lvsmooth_ric_p7_wavparam_pgfnew_20250121/BLOM_DIAG/yrs42to61-NOIIAJRA_TL319_tn14_2.5a7_lvsmooth_ric_p7_wavparam_20241223/indexnew.html. In general rather small differences can be found in this configuration. The most notable difference might be a slightly weaker AMOC strength with the new formulation, but not sure if this is significant.

The new PGF method has only been tested with hybrid vertical coordinate, but there is no known reason it should not work with other vertical coordinate choices.