### PR TITLE
Fix Ncycle

### DIFF
--- a/hamocc/mo_extNsediment.F90
+++ b/hamocc/mo_extNsediment.F90
@@ -171,7 +171,7 @@ contains
           fdetamox = 1. - (fn2o + fno2)
 
           ! NO2 oxidizing step of nitrification
-          Tdepano2    = q10ano2nitr_sed**((temp-Trefano2nitr_sed)/10.) 
+          Tdepano2    = q10ano2nitr_sed**((temp-Trefano2nitr_sed)/10.)
           O2limano2   = powtra(i,j,k,ipowaox)/(powtra(i,j,k,ipowaox) + bkoxnitr_sed)
           nut2lim     = powtra(i,j,k,ipowno2)/(powtra(i,j,k,ipowno2) + bkano2nitr_sed)
           ano2new     = powtra(i,j,k,ipowno2)/(1. + rano2nitr_sed*Tdepano2*O2limano2*nut2lim)
@@ -186,7 +186,7 @@ contains
           no2fdetamox = NOB2AOAy_sed*n2omaxy_sed*2.*(1. + n2oybeta_sed)*powtra(i,j,k,ipowaox)*bkyamox_sed  &
                       & /(powtra(i,j,k,ipowaox)**2 + 2.*powtra(i,j,k,ipowaox)*bkyamox_sed + bkyamox_sed**2)
 
-          fdetnitr = no2fdetamox/(no2fno2 + no2fn2o)   ! yield to energy usage ratio for NO2 -> ratio equals 16:x
+          fdetnitr = no2fdetamox/(no2fno2 + no2fn2o + eps)   ! yield to energy usage ratio for NO2 -> ratio equals 16:x
 
           ! limitation of the two processes through available nutrients, etc.
           totd     = potdnh4amox + potdno2nitr

--- a/hamocc/mo_extNwatercol.F90
+++ b/hamocc/mo_extNwatercol.F90
@@ -152,7 +152,7 @@ contains
             no2fdetamox = NOB2AOAy*n2omaxy*2.*(1. + n2oybeta)*ocetra(i,j,k,ioxygen)*bkyamox        &
                         & /(ocetra(i,j,k,ioxygen)**2 + 2.*ocetra(i,j,k,ioxygen)*bkyamox + bkyamox**2)
 
-            fdetnitr = no2fdetamox/(no2fno2 + no2fn2o)   ! yield to energy usage ratio for NO2 -> ratio equals 16:x
+            fdetnitr = no2fdetamox/(no2fno2 + no2fn2o + eps)   ! yield to energy usage ratio for NO2 -> ratio equals 16:x
 
 
           ! limitation of the two processes through available nutrients, etc.
@@ -217,7 +217,7 @@ contains
     integer :: i,j,k
     real    :: Tdep,O2inhib,nutlim,ano3new,ano3denit,temp
 
-    ! Sett output-related field to zero
+    ! Set output-related field to zero
     denit_NO3  = 0.
 
     !$OMP PARALLEL DO PRIVATE(i,k,Tdep,O2inhib,nutlim,ano3new,ano3denit,temp)


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik ,
this PR is an immediate fix for #479. Noticeably, at least in my simulations, the issue was only indirectly related to `lkwrbioz_off=.true.` - it somehow led to zero oxygen values in the sediment that then led to division by zero, which I fixed now (also for the water column for safety). I ran a previously crashing simulation for one month in DEBUG mode on `tnx2` and it ran through with this fix. Maybe @JorgSchwinger , you could do a short run with your setup to see, if it this fixes the `lkwrbioz_off=.true.` issue reported in #479? 

I will investigate one more thing that I stumbled upon (which may or may not lead to changes), but I think an incremental PR approach is better in this case.

Closes #479