### PR TITLE
Deallocate arrays in mo_netcdf_bgcrw

### DIFF
--- a/hamocc/mo_netcdf_bgcrw.F90
+++ b/hamocc/mo_netcdf_bgcrw.F90
@@ -316,8 +316,11 @@ contains
       allocate(istart(ndims))
       allocate(icount(ndims))
       allocate(arr_l(ii,jj,klev))
+      allocate(arr_g1(itdm,jj,klev))
 
       arr_l=0.0
+      arr_g1=0.0
+
       if (klev.gt.1.or.time.gt.0) then
         if (klev.gt.1.and.time.gt.0) then
           istart(3)=1
@@ -353,8 +356,6 @@ contains
         enddo
       enddo
 
-      allocate(arr_g1(itdm,jj,klev))
-      arr_g1=0.0
       call xcgetrow(arr_g1, arr_l, klev)
 
       ncstat=nfmpi_inq_varid(ncid,desc,ncvarid)

--- a/hamocc/mo_netcdf_bgcrw.F90
+++ b/hamocc/mo_netcdf_bgcrw.F90
@@ -233,9 +233,9 @@ contains
     integer                       :: ncstat
     integer                       :: ncvarid
     integer, allocatable          :: start(:),count(:)
-    real,    allocatable          :: arr_g1(:,:,:)
     real,    allocatable          :: arr_l(:,:,:)
 #ifdef PNETCDF
+    real,    allocatable          :: arr_g1(:,:,:)
     integer (kind=MPI_OFFSET_KIND), allocatable :: istart(:),icount(:)
 #endif
 
@@ -308,7 +308,7 @@ contains
           ! endif
         endif
       enddo
-      deallocate(start,count)
+      deallocate(start,count,arr_l)
 
     else if (IOTYPE==1) then
 
@@ -378,7 +378,7 @@ contains
       !   stop '(write_pnetcdf_var)'
       ! endif
 
-      deallocate(istart,icount,arr_g1)
+      deallocate(istart,icount,arr_l,arr_g1)
 #endif
 
     end if
@@ -525,6 +525,8 @@ contains
     else
       call xchalt('(read_pnetcdf_var) WRONG IOTYPE')
     endif
+
+    deallocate(arr_l)
 
   end subroutine read_netcdf_var
  


### PR DESCRIPTION
This PR will not make any difference, but maybe it is still good practice to explicitly deallocate variables? At least, I find it confusing  when only some of the temporary arrays are deallocated.