### PR TITLE
Fix N-cycle coupling

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3870,7 +3870,7 @@
     <values>
       <value>.false.</value>
       <value comp_interface="nuopc">.true.</value>
-      <value "hamocc_atmndepc"="yes">.true.</value>
+      <value hamocc_atmndepc="yes">.true.</value>
     </values>
     <desc>if .true., use MCT coupler fields from CAM or NUOPC to obtain NDEP (always imported to model).</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3863,15 +3863,16 @@
    <desc>File name (incl. full path) for atmopheric N-deposition data</desc>
   </entry>
 
-  <entry id="use_nuopc_ndep">
+  <entry id="use_coupler_ndep" modify_via_xml="HAMOCC_ATMNDEPC">
     <type>logical</type>
     <category>config_bgc</category>
     <group>config_bgc</group>
     <values>
       <value>.false.</value>
       <value comp_interface="nuopc">.true.</value>
+      <value "hamocc_atmndepc"="yes">.true.</value>
     </values>
-    <desc>if .true., use NUOPC to obtain NDEP (always imported to model).</desc>
+    <desc>if .true., use MCT coupler fields from CAM or NUOPC to obtain NDEP (always imported to model).</desc>
   </entry>
 
   <entry id="do_n2onh3_coupled" modify_via_xml="HAMOCC_N2OC">

--- a/drivers/mct/import_mct.F90
+++ b/drivers/mct/import_mct.F90
@@ -369,108 +369,108 @@ subroutine import_mct(x2o_o, lsize, perm, jjcpl)
     if (mnproc.eq.1) then
       write (lp,*) 'import_mct: prog. atmospheric nitrous oxide not read'
     endif
+  endif
 
-    if (index_x2o_Sa_nh3prog > 0) then
-      n = 0
-      do j = 1, jjcpl
-        do i = 1, ii
-          n = n + 1
-          if     (ip(i,j) == 0) then
-            atmnh3_da(i,j,l2ci) = mval
-          elseif (cplmsk(i,j) == 0) then
-            atmnh3_da(i,j,l2ci) = fval
-          else
-            ! Atmospheric nitrous oxide concentration [ppt]
-            atmnh3_da(i,j,l2ci) = x2o_o%rAttr(index_x2o_Sa_nh3prog,n)
-          endif
-        enddo
+  if (index_x2o_Sa_nh3prog > 0) then
+    n = 0
+    do j = 1, jjcpl
+      do i = 1, ii
+        n = n + 1
+        if     (ip(i,j) == 0) then
+          atmnh3_da(i,j,l2ci) = mval
+        elseif (cplmsk(i,j) == 0) then
+          atmnh3_da(i,j,l2ci) = fval
+        else
+          ! Atmospheric nitrous oxide concentration [ppt]
+          atmnh3_da(i,j,l2ci) = x2o_o%rAttr(index_x2o_Sa_nh3prog,n)
+        endif
       enddo
-      call fill_global(mval, fval, halo_ps, atmnh3_da(1-nbdy,1-nbdy,l2ci))
-      if (mnproc.eq.1) then
-        write (lp,*) 'import_mct: prog. atmospheric ammonia read'
-      end if
-    else
-      do j = 1, jj
-        do i = 1, ii
-          if (ip(i,j) == 0) then
-            atmnh3_da(i,j,l2ci) = mval
-          else
-            atmnh3_da(i,j,l2ci) = -1
-          endif
-        enddo
-      enddo
-      if (mnproc.eq.1) then
-        write (lp,*) 'import_mct: prog. atmospheric ammonia not read'
-      endif
+    enddo
+    call fill_global(mval, fval, halo_ps, atmnh3_da(1-nbdy,1-nbdy,l2ci))
+    if (mnproc.eq.1) then
+      write (lp,*) 'import_mct: prog. atmospheric ammonia read'
     end if
+  else
+    do j = 1, jj
+      do i = 1, ii
+        if (ip(i,j) == 0) then
+          atmnh3_da(i,j,l2ci) = mval
+        else
+          atmnh3_da(i,j,l2ci) = -1
+        endif
+      enddo
+    enddo
+    if (mnproc.eq.1) then
+      write (lp,*) 'import_mct: prog. atmospheric ammonia not read'
+    endif
+  end if
 
-    if (index_x2o_Faxa_nhx > 0) then
-      n = 0
-      do j = 1, jjcpl
-        do i = 1, ii
-          n = n + 1
-          if     (ip(i,j) == 0) then
-            atmnhxdep_da(i,j,l2ci) = mval
-          elseif (cplmsk(i,j) == 0) then
-            atmnhxdep_da(i,j,l2ci) = fval
-          else
-            ! Atmospheric nhx deposition [kgN/m2/sec]
-            atmnhxdep_da(i,j,l2ci) = x2o_o%rAttr(index_x2o_Faxa_nhx,n)
-          endif
-        enddo
+  if (index_x2o_Faxa_nhx > 0) then
+    n = 0
+    do j = 1, jjcpl
+      do i = 1, ii
+        n = n + 1
+        if     (ip(i,j) == 0) then
+          atmnhxdep_da(i,j,l2ci) = mval
+        elseif (cplmsk(i,j) == 0) then
+          atmnhxdep_da(i,j,l2ci) = fval
+        else
+          ! Atmospheric nhx deposition [kgN/m2/sec]
+          atmnhxdep_da(i,j,l2ci) = x2o_o%rAttr(index_x2o_Faxa_nhx,n)
+        endif
       enddo
-      call fill_global(mval, fval, halo_ps, atmnhxdep_da(1-nbdy,1-nbdy,l2ci))
-      if (mnproc.eq.1) then
-        write (lp,*) 'import_mct: atmospheric nhx deposition read'
-      end if
-    else
-      do j = 1, jj
-        do i = 1, ii
-          if (ip(i,j) == 0) then
-            atmnhxdep_da(i,j,l2ci) = mval
-          else
-            atmnhxdep_da(i,j,l2ci) = -1
-          endif
-        enddo
-      enddo
-      if (mnproc.eq.1) then
-        write (lp,*) 'import_mct: atmospheric nhx deposition not read'
-      endif
+    enddo
+    call fill_global(mval, fval, halo_ps, atmnhxdep_da(1-nbdy,1-nbdy,l2ci))
+    if (mnproc.eq.1) then
+      write (lp,*) 'import_mct: atmospheric nhx deposition read'
     end if
+  else
+    do j = 1, jj
+      do i = 1, ii
+        if (ip(i,j) == 0) then
+          atmnhxdep_da(i,j,l2ci) = mval
+        else
+          atmnhxdep_da(i,j,l2ci) = -1
+        endif
+      enddo
+    enddo
+    if (mnproc.eq.1) then
+      write (lp,*) 'import_mct: atmospheric nhx deposition not read'
+    endif
+  end if
 
-    if (index_x2o_Faxa_noy > 0) then
-      n = 0
-      do j = 1, jjcpl
-        do i = 1, ii
-          n = n + 1
-          if     (ip(i,j) == 0) then
-            atmnoydep_da(i,j,l2ci) = mval
-          elseif (cplmsk(i,j) == 0) then
-            atmnoydep_da(i,j,l2ci) = fval
-          else
-            ! Atmospheric noy deposition [kgN/m2/sec]
-            atmnoydep_da(i,j,l2ci) = x2o_o%rAttr(index_x2o_Faxa_noy,n)
-          endif
-        enddo
+  if (index_x2o_Faxa_noy > 0) then
+    n = 0
+    do j = 1, jjcpl
+      do i = 1, ii
+        n = n + 1
+        if     (ip(i,j) == 0) then
+          atmnoydep_da(i,j,l2ci) = mval
+        elseif (cplmsk(i,j) == 0) then
+          atmnoydep_da(i,j,l2ci) = fval
+        else
+          ! Atmospheric noy deposition [kgN/m2/sec]
+          atmnoydep_da(i,j,l2ci) = x2o_o%rAttr(index_x2o_Faxa_noy,n)
+        endif
       enddo
-      call fill_global(mval, fval, halo_ps, atmnoydep_da(1-nbdy,1-nbdy,l2ci))
-      if (mnproc.eq.1) then
-        write (lp,*) 'import_mct: atmospheric noy deposition read'
-      end if
-    else
-      do j = 1, jj
-        do i = 1, ii
-          if (ip(i,j) == 0) then
-            atmnoydep_da(i,j,l2ci) = mval
-          else
-            atmnoydep_da(i,j,l2ci) = -1
-          endif
-        enddo
-      enddo
-      if (mnproc.eq.1) then
-        write (lp,*) 'import_mct: atmospheric noy deposition not read'
-      endif
+    enddo
+    call fill_global(mval, fval, halo_ps, atmnoydep_da(1-nbdy,1-nbdy,l2ci))
+    if (mnproc.eq.1) then
+      write (lp,*) 'import_mct: atmospheric noy deposition read'
     end if
+  else
+    do j = 1, jj
+      do i = 1, ii
+        if (ip(i,j) == 0) then
+          atmnoydep_da(i,j,l2ci) = mval
+        else
+          atmnoydep_da(i,j,l2ci) = -1
+        endif
+      enddo
+    enddo
+    if (mnproc.eq.1) then
+      write (lp,*) 'import_mct: atmospheric noy deposition not read'
+    endif
   end if
 
   if (csdiag) then

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -82,7 +82,7 @@ module mo_control_bgc
   logical           :: use_BOXATM             = .false.
   logical           :: use_sedbypass          = .false.
   logical           :: use_extNcycle          = .false.
-  logical           :: use_nuopc_ndep         = .false.
+  logical           :: use_coupler_ndep       = .false.
   logical           :: use_pref_tracers       = .true.
   logical           :: use_shelfsea_res_time  = .false.
   logical           :: use_sediment_quality   = .false.

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -45,7 +45,7 @@ contains
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
                               lkwrbioz_off,do_n2onh3_coupled,                                      &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
-                              use_nuopc_ndep,lTO2depremin,use_sediment_quality
+                              use_coupler_ndep,lTO2depremin,use_sediment_quality
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
     use mo_param_bgc,   only: ini_parambgc,claydens,calcdens,calcwei,opaldens,opalwei,ropal
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
@@ -207,7 +207,7 @@ contains
     ! --- Initialise reading of input data (dust, n-deposition, river, etc.)
     !
     call ini_read_fedep(idm,jdm,omask)
-    if (.not. use_nuopc_ndep) then
+    if (.not. use_coupler_ndep) then
        call ini_read_ndep(idm,jdm)
     end if
     call ini_read_rivin(idm,jdm,omask)

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -252,14 +252,14 @@ contains
     use mo_control_bgc, only: use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,           &
                               use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,           &
                               use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers,           &
-                              use_nuopc_ndep,use_shelfsea_res_time
+                              use_coupler_ndep,use_shelfsea_res_time
 
     integer :: iounit
 
     namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &
                             use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers,              &
-                            use_nuopc_ndep,use_shelfsea_res_time,use_sediment_quality
+                            use_coupler_ndep,use_shelfsea_res_time,use_sediment_quality
 
     io_stdo_bgc = lp              !  standard out.
 

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -38,7 +38,8 @@ module mo_param_bgc
                             use_BOXATM,use_CFC,use_PBGC_CK_TIMESTEP,                               &
                             use_sedbypass,with_dmsph,use_PBGC_OCNP_TIMESTEP,ocn_co2_type,use_M4AGO,&
                             do_n2onh3_coupled,use_extNcycle,                                       &
-                            lkwrbioz_off,lTO2depremin,use_shelfsea_res_time,use_sediment_quality
+                            lkwrbioz_off,lTO2depremin,use_shelfsea_res_time,use_sediment_quality,  &
+                            use_pref_tracers,use_coupler_ndep
   use mod_xc,         only: mnproc
 
   implicit none
@@ -857,6 +858,8 @@ contains
       call cinfo_add_entry('use_shelfsea_res_time',  use_shelfsea_res_time)
       call cinfo_add_entry('use_sediment_quality',   use_sediment_quality)
       call cinfo_add_entry('use_M4AGO',              use_M4AGO)
+      call cinfo_add_entry('use_pref_tracers',       use_pref_tracers)
+      call cinfo_add_entry('use_coupler_ndep',       use_coupler_ndep)
       if (use_extNcycle) then
         call cinfo_add_entry('do_n2onh3_coupled',       do_n2onh3_coupled)
       endif

--- a/hamocc/mo_read_ndep.F90
+++ b/hamocc/mo_read_ndep.F90
@@ -162,7 +162,7 @@ contains
 
     use mod_xc,             only: mnproc
     use netcdf,             only: nf90_open,nf90_close,nf90_nowrite
-    use mo_control_bgc,     only: io_stdo_bgc, do_ndep, use_extNcycle, use_nuopc_ndep
+    use mo_control_bgc,     only: io_stdo_bgc, do_ndep, use_extNcycle, use_coupler_ndep
     use mo_netcdf_bgcrw,    only: read_netcdf_var
     use mo_param1_bgc,      only: nndep,idepnoy,idepnhx
     use mo_chemcon,         only: mw_nitrogen
@@ -191,9 +191,9 @@ contains
       return
     endif
 
-    if (use_nuopc_ndep) then
-      ! If  use_nuopc_ndep, nitrogen deposition is ALWAYS obtained from the
-      ! nuopc mediator
+    if (use_coupler_ndep) then
+      ! If  use_coupler_ndep, nitrogen deposition is ALWAYS obtained from the
+      ! mct coupler or nuopc mediator (CAM or CDEPS)
       if (mnproc == 1 .and. first_call) then
         write (io_stdo_bgc,*) 'iHAMOCC: getting NOy and NHx deposition from atm'
       endif


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik , cc @DirkOlivie ,

with this PR, a bugfix is introduced to the mct-coupling of NH3, NOy and NHx fields (likely introduced during the BLOM code restructuring - code to transfer the fields wasn't reached any more). Further, I renamed the switch for providing the coupler fields for nitrogen deposition to iHAMOCC, since it can be used by both couplers (MCT and NUOPC) as being currently under testing. Hence, with this PR, iHAMOCC `master` is again fully capable to handle NH3,N2O, NHx and NOy gas and deposition fluxes. 
The setup allows to be used in current test/N-cycling coupling setups (not yet fully supported in NorESM(X), while we are working on this issue as well). 