### PR TITLE
Add sed_denit to namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4752,6 +4752,16 @@
     </values>
     <desc>Sediment: remineralization rate (at reference temperature) (1/(kmol O2/m3 s))</desc>
   </entry>
+  
+  <entry id="sed_denit">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>Sediment: denitrification/sulfate reduction rate (1/s))</desc>
+  </entry>
 
   <entry id="disso_sil">
     <type>real</type>

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -630,7 +630,8 @@ contains
                          bkoxan2odenit_sed,bkan2odenit_sed,q10dnra_sed,          &
                          bkoxdnra_sed,bkdnra_sed,q10anh4nitr_sed,                &
                          bkoxamox_sed,bkanh4nitr_sed,q10ano2nitr_sed,            &
-                         bkoxnitr_sed,bkano2nitr_sed,sed_alpha_poc,sed_qual_sc
+                         bkoxnitr_sed,bkano2nitr_sed,sed_alpha_poc,sed_qual_sc,  &
+                         sed_denit
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger ,

this PR just adds the `sed_denit` rate to the namelist - making it tunable. It would be great, if we could merge this before the cgs and pointer PR (#513, #515)
