### PR TITLE
Include additional tests with GNU compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ permanent release branches. The structure of the branches and naming conventions
 `v#.#.#` correspond to a relase version of BLOM, whereas tags on the format `dev#.#.#.#` correspond to 
 development tags. Currently the following branches are actively maintained:
 
-| branch      | note                          |
-|-------------|-------------------------------|
-| master      | main development branch       |
-| release-1.6 | release version for NorESM2.3 |
-| release-1.5 | release version for NorESM2.1 |
-| release-1.4 | release version for NorESM2.0 |
+| branch      | note                                            |
+|-------------|-------------------------------------------------|
+| master      | main development branch                         |
+| release-1.7 | release version for NorESM2.3.1/NorESM2.5_alpha |
+| release-1.6 | release version for NorESM2.3                   |
+| release-1.5 | release version for NorESM2.1                   |
+| release-1.4 | release version for NorESM2.0                   |
+
+The release-1.7 and current master maintains support for both MCT and NUOPC coupler systems.
+We aim to maintian this dual support also for the upcoming release-1.8 version.
+Further development beyond v1.8.X is likely to be NUOPC only.
 
 
 ## BLOM documentation

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -358,7 +358,7 @@
 
   <!-- Configurations for the 1/2 degree tripolar (tnx0.5) grid  !-->
 
-  <!-- GRID: TL319_tn14 : start !-->
+  <!-- GRID: TL319_tn05 : start !-->
   <grid name="a%TL319.+oi%tnx0.5v1">
     <mach name="any">
       <pes pesize="M" compset="any">
@@ -434,6 +434,7 @@
       </pes>
     </mach>
   </grid>
+  <!-- GRID: TL319_tn05 : end !-->
 
   <!-- Configurations for the 1/4 degree tripolar (tnx0.25) grid  !-->
 

--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -7,16 +7,16 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">test debug mode with hybrid coordinates, hamocc and core forcing</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; hamocc; core forcing</option>
     </options>
   </test>
-  <test name="ERS_Ld3" grid="T62_tn14" compset="NOINYOC">
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">test restart with isopycnic layers, hamocc and core forcing</option>
+      <option name="comment">gnu debug mode; 1 degree; hybrid coordinates; hamocc; core forcing</option>
     </options>
   </test>
   <test name="ERS_Ld3" grid="T62_tn21" compset="NOINY">
@@ -25,16 +25,25 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">test restart with 2 degree, isopycnic layers and core forcing</option>
+      <option name="comment">intel restart test; 2 degree; hybrid coordinates; core forcing</option>
     </options>
   </test>
-  <test name="ERR_Ld3" grid="TL319_tn14" compset="NOIIAJRAOC">
+  <test name="ERS_Ld3" grid="T62_tn14" compset="NOINYOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">test restart/resubmit with hybrid coordinates and JRA forcing</option>
+      <option name="comment">intel restart test; 1 degree; hybrid coordinates; hamocc; core forcing</option>
+    </options>
+  </test>
+  <test name="ERS_Ld3" grid="T62_tn14" compset="N2NOINYOC">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel restart test; 1 degree; isopycnic layers; hamocc; core forcing</option>
     </options>
   </test>
   <test name="ERS_Ld3" grid="TL319_tn05" compset="NOIIAJRA">
@@ -43,7 +52,43 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">test restart/resubmit with hybrid coordinates and JRA forcing</option>
+      <option name="comment">intel restart test; 0.5 degree; hybrid coordinates; JRA forcing</option>
+    </options>
+  </test>
+  <test name="ERR_Ld3" grid="TL319_tn14" compset="NOIIAJRAOC">
+    <machines>
+      <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">gnu restart/resubmit test; 1 degree; hybrid coordinates; hamocc; JRA forcing</option>
+    </options>
+  </test>
+  <test name="ERR_Ld3" grid="TL319_tn14" compset="NOIIAJRAOC">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel restart/resubmit test; 1 degree; hybrid coordinates; hamocc; JRA forcing</option>
+    </options>
+  </test>
+  <test name="ERI" grid="TL319_tn14" compset="NOIIAJRAOC">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment">intel hybrid/branch/restart test; 1 degree; hybrid coordinates; hamocc; JRA forcing</option>
+    </options>
+  </test>
+  <test name="ERI" grid="TL319_tn14" compset="NOIIAJRAOC">
+    <machines>
+      <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment">gnu hybrid/branch/restart test; 1 degree; hybrid coordinates; hamocc; JRA forcing</option>
     </options>
   </test>
   <test name="ERP_Ld3_P256" grid="T62_tn14" compset="NOINYOC">
@@ -55,13 +100,32 @@
       <option name="comment">test bfb with changing processor count and openmp on</option>
     </options>
   </test>
+  <!-- Declarations for tests with prognostic wave component: testmods="blom/wavice" -->
   <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINY_WW3" testmods="blom/wavice">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">test restart with wave code</option>
+      <option name="comment">intel restart test; 1 degree; hybrid coordinates; wave code; core forcing</option>
+    </options>
+  </test>
+  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINYOC_WW3" testmods="blom/wavice">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment">intel restart test; 1 degree; hybrid coordinates; hamocc; wave code; core forcing</option>
+    </options>
+  </test>
+  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINYOC_WW3" testmods="blom/wavice">
+    <machines>
+      <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment">gnu restart test; 1 degree; hybrid coordinates; hamocc; wave code; core forcing</option>
     </options>
   </test>
   <!-- Declarations for tests with different iHAMOCC settings: aux_hamocc_noresm -->

--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -19,6 +19,51 @@
       <option name="comment">gnu debug mode; 1 degree; hybrid coordinates; hamocc; core forcing</option>
     </options>
   </test>
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIA">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; IAF forcing</option>
+    </options>
+  </test>
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAOC">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; hamocc; IAF forcing</option>
+    </options>
+  </test>
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAOC20TR">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; hamocc; IAF forcing; 20TR historical</option>
+    </options>
+  </test>
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAJRAOC1850">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 1850 clim</option>
+    </options>
+  </test>
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAJRAOC20TR">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 20TR historical</option>
+    </options>
+  </test>
   <test name="ERS_Ld3" grid="T62_tn21" compset="NOINY">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
@@ -101,31 +146,40 @@
     </options>
   </test>
   <!-- Declarations for tests with prognostic wave component: testmods="blom/wavice" -->
-  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINY_WW3" testmods="blom/wavice">
+  <test name="SMS_D_Ld1" grid="T62_tn14_wtn14nw" compset="NOINYOC_WW3" testmods="blom/wavice">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">intel restart test; 1 degree; hybrid coordinates; wave code; core forcing</option>
+      <option name="comment">intel debug mode; 1 degree; hybrid coordinates; hamocc; wave code; core forcing</option>
     </options>
   </test>
-  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINYOC_WW3" testmods="blom/wavice">
+  <test name="SMS_D_Ld1" grid="T62_tn14_wtn14nw" compset="NOINYOC_WW3" testmods="blom/wavice">
+    <machines>
+      <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">gnu debug mode; 1 degree; hybrid coordinates; hamocc; wave code; core forcing</option>
+    </options>
+  </test>
+  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINY_WW3" testmods="blom/wavice">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
-      <option name="comment">intel restart test; 1 degree; hybrid coordinates; hamocc; wave code; core forcing</option>
+      <option name="comment">intel restart test; 1 degree; hybrid coordinates; wave code; core forcing</option>
     </options>
   </test>
-  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINYOC_WW3" testmods="blom/wavice">
+  <test name="ERS_Ld3" grid="T62_tn14_wtn14nw" compset="NOINY_WW3" testmods="blom/wavice">
     <machines>
       <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
-      <option name="comment">gnu restart test; 1 degree; hybrid coordinates; hamocc; wave code; core forcing</option>
+      <option name="comment">gnu restart test; 1 degree; hybrid coordinates; wave code; core forcing</option>
     </options>
   </test>
   <!-- Declarations for tests with different iHAMOCC settings: aux_hamocc_noresm -->


### PR DESCRIPTION
This PR expands the list of default system tests for BLOM, including tests using the GNU compiler.