### PR TITLE
Sediment sulfate reduction and denitrification thresholds - tuning

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4753,6 +4753,36 @@
     <desc>Sediment: remineralization rate (at reference temperature) (1/(kmol O2/m3 s))</desc>
   </entry>
 
+  <entry id="sed_O2thresh_hypoxic">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>Sediment: O2 threshold below which denitrification takes place </desc>
+  </entry>
+
+  <entry id="sed_O2thresh_sulf">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>Sediment: O2 threshold below which sulfate reduction takes place </desc>
+  </entry>
+
+  <entry id="sed_NO3thresh_sulf">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>Sediment: NO3 threshold below which sulfate reduction takes place </desc>
+  </entry>
+
   <entry id="sed_denit">
     <type>real</type>
     <category>bgcparams</category>
@@ -4760,7 +4790,7 @@
     <values>
       <value>None</value>
     </values>
-    <desc>Sediment: denitrification reduction rate (1/s))</desc>
+    <desc>Sediment: denitrification reduction rate (1/s)</desc>
   </entry>
 
   <entry id="sed_sulf">
@@ -4770,7 +4800,7 @@
     <values>
       <value>None</value>
     </values>
-    <desc>Sediment: sulfate reduction rate (1/s))</desc>
+    <desc>Sediment: sulfate reduction rate (1/s)</desc>
   </entry>
 
   <entry id="disso_sil">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4752,7 +4752,7 @@
     </values>
     <desc>Sediment: remineralization rate (at reference temperature) (1/(kmol O2/m3 s))</desc>
   </entry>
-  
+
   <entry id="sed_denit">
     <type>real</type>
     <category>bgcparams</category>
@@ -4760,7 +4760,17 @@
     <values>
       <value>None</value>
     </values>
-    <desc>Sediment: denitrification/sulfate reduction rate (1/s))</desc>
+    <desc>Sediment: denitrification reduction rate (1/s))</desc>
+  </entry>
+
+  <entry id="sed_sulf">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>Sediment: sulfate reduction rate (1/s))</desc>
   </entry>
 
   <entry id="disso_sil">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4790,7 +4790,7 @@
     <values>
       <value>None</value>
     </values>
-    <desc>Sediment: denitrification reduction rate (1/s)</desc>
+    <desc>Sediment: denitrification rate (1/s)</desc>
   </entry>
 
   <entry id="sed_sulf">

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -95,7 +95,7 @@ module mo_param_bgc
   public :: vsmall,safe,pupper,plower,zdis,nmldmin
   public :: beta13,alpha14,atm_c13,atm_c14,c14fac,c14dec
   public :: sedict,silsat,disso_poc,disso_sil,disso_caco3
-  public :: sed_denit,calcwei,opalwei,orgwei
+  public :: sed_denit,sed_sulf,calcwei,opalwei,orgwei
   public :: calcdens,opaldens,orgdens,claydens
   public :: dmsp1,dmsp2,dmsp3,dmsp4,dmsp5,dmsp6,dms_gamma
   public :: POM_remin_q10,opal_remin_q10,POM_remin_Tref,opal_remin_Tref
@@ -489,6 +489,7 @@ module mo_param_bgc
   real, protected :: disso_sil   = 3.e-8          ! 1/(kmol Si(OH)4/m3 s) Dissolution rate constant of opal
   real, protected :: disso_caco3 = 1.e-7          ! 1/(kmol CO3--/m3 s) Dissolution rate constant of CaCO3
   real, protected :: sed_denit   = 0.01/86400.    ! 1/s Denitrification rate constant of POP
+  real, protected :: sed_sulf    = 0.01/86400.    ! 1/s "Sulfate reduction" rate constant of POP
   real, protected :: sed_alpha_poc = 1./90.       ! 1/d 1/decay time for sediment moving average - assuming ~3 month memory here
   real, protected :: sed_qual_sc = 1.             ! scaling factor for sediment quality-based remineralization
   !********************************************************************
@@ -631,7 +632,7 @@ contains
                          bkoxdnra_sed,bkdnra_sed,q10anh4nitr_sed,                &
                          bkoxamox_sed,bkanh4nitr_sed,q10ano2nitr_sed,            &
                          bkoxnitr_sed,bkano2nitr_sed,sed_alpha_poc,sed_qual_sc,  &
-                         sed_denit
+                         sed_denit,sed_sulf
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)
@@ -754,6 +755,7 @@ contains
     disso_poc   = disso_poc   * dtbgc ! 1/(kmol O2/m3 time step)      Degradation rate constant of POP
     disso_caco3 = disso_caco3 * dtbgc ! 1/(kmol CO3--/m3 time step)   Dissolution rate constant of CaCO3
     sed_denit   = sed_denit   * dtbgc ! 1/time step                   Denitrification rate constant of POP
+    sed_sulf    = sed_sulf    * dtbgc ! 1/time step                   "Sulfate reduction" rate constant of POP
 
     if (use_extNcycle) then
       rano3denit = rano3denit *dtb ! Maximum growth rate denitrification on NO3 at reference T (1/d -> 1/dt)
@@ -1007,6 +1009,7 @@ contains
       call pinfo_add_entry('disso_sil',   disso_sil   * dtbgcinv)
       call pinfo_add_entry('disso_caco3', disso_caco3 * dtbgcinv)
       call pinfo_add_entry('sed_denit',   sed_denit   * dtbgcinv)
+      call pinfo_add_entry('sed_sulf',    sed_sulf   * dtbgcinv)
       call pinfo_add_entry('silsat',      silsat)
       call pinfo_add_entry('orgwei',      orgwei)
       call pinfo_add_entry('opalwei',     opalwei)

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -284,17 +284,17 @@ module mo_param_bgc
   !********************************************************************
   ! Remineralization and dissolution parameters
   !********************************************************************
-  real, parameter :: O2thresh_aerob   = 5.e-8    ! Above O2thresh_aerob aerob remineralization takes place
-  real, parameter :: O2thresh_hypoxic = 5.e-7    ! Below O2thresh_hypoxic denitrification and sulfate reduction takes place (default model version)
-  real, parameter :: NO3thresh_sulf   = 3.e-6    ! Below NO3thresh_sulf 'sufate reduction' takes place
-  real, protected :: remido     = 0.004           ! 1/d - remineralization rate (of DOM)
+  real, parameter :: O2thresh_aerob   = 5.e-8  ! Above O2thresh_aerob aerob remineralization takes place
+  real, parameter :: O2thresh_hypoxic = 5.e-7  ! Below O2thresh_hypoxic denitrification and sulfate reduction takes place (default model version)
+  real, parameter :: NO3thresh_sulf   = 3.e-6  ! Below NO3thresh_sulf 'sufate reduction' takes place
+  real, protected :: remido     = 0.004        ! 1/d - remineralization rate (of DOM)
   ! deep sea remineralisation constants
-  real, protected :: drempoc    = 0.025           ! 1/d Aerob remineralization rate detritus
+  real, protected :: drempoc    = 0.025        ! 1/d Aerob remineralization rate detritus
   real, protected :: drempoc_anaerob = 1.25e-3 ! =0.05*drempoc - remin in sub-/anoxic environm. - not be overwritten by M4AGO
   real, protected :: bkox_drempoc    = 1e-7    ! half-saturation constant for oxygen for ammonification (aerobic remin via drempoc)
-  real, protected :: dremopal   = 0.003           ! 1/d Dissolution rate for opal
-  real, protected :: dremn2o    = 0.01            ! 1/d Remineralization rate of detritus on N2O
-  real, protected :: dremsul    = 0.005           ! 1/d Remineralization rate for sulphate reduction
+  real, protected :: dremopal   = 0.003        ! 1/d Dissolution rate for opal
+  real, protected :: dremn2o    = 0.01         ! 1/d Remineralization rate of detritus on N2O
+  real, protected :: dremsul    = 0.005        ! 1/d Remineralization rate for sulphate reduction
   real, protected :: POM_remin_q10   = 2.1     ! Bidle et al. 2002: Regulation of Oceanic Silicon...
   real, protected :: opal_remin_q10  = 2.6     ! Bidle et al. 2002: Regulation of Oceanic Silicon...
   real, protected :: POM_remin_Tref  = 10.     ! [deg C] reference temperatue for Q10-dep. POC remin
@@ -338,7 +338,7 @@ module mo_param_bgc
   real, protected :: q10an2odenit  = 3.       ! Q10 factor for denitrificationj on N2O (-)
   real, protected :: Trefan2odenit = 10.      ! Reference temperature for denitrification on N2O (degr C)
   real, protected :: bkoxan2odenit = 10e-6    ! Half-saturation constant for (quadratic) oxygen inhibition function of denitrification on N2O (kmol/m3)
-  real, protected :: bkan2odenit   = 0.1e-6    ! Half-saturation constant for denitrification on N2O (kmol/m3)
+  real, protected :: bkan2odenit   = 0.1e-6   ! Half-saturation constant for denitrification on N2O (kmol/m3)
 
   ! === DNRA NO2 -> NH4
   real, protected :: rdnra         = 0.0003   ! Maximum growth rate DNRA on NO2 at reference T (1/d -> 1/dt)
@@ -484,9 +484,9 @@ module mo_param_bgc
   !********************************************************************
   ! Note that the rates in the sediment are given in per second here!
   !
-  real, protected :: sed_O2thresh_hypoxic = 1.e-6    ! Below sed_O2thresh_hypoxic denitrification takes place (default model version)
-  real, protected :: sed_O2thresh_sulf    = 3.e-6    ! Below sed_O2thresh_sulf 'sulfate reduction' takes place
-  real, protected :: sed_NO3thresh_sulf   = 3.e-6    ! Below sed_NO3thresh_sulf 'sufate reduction' takes place
+  real, protected :: sed_O2thresh_hypoxic = 1.e-6 ! Below sed_O2thresh_hypoxic denitrification takes place (default model version)
+  real, protected :: sed_O2thresh_sulf    = 3.e-6 ! Below sed_O2thresh_sulf 'sulfate reduction' takes place
+  real, protected :: sed_NO3thresh_sulf   = 3.e-6 ! Below sed_NO3thresh_sulf 'sufate reduction' takes place
   real, protected :: sedict      = 1.e-9          ! m2/s Molecular diffusion coefficient
   real, protected :: silsat      = 0.001          ! kmol/m3 Silicate saturation concentration is 1 mol/m3
   real, protected :: disso_poc   = 0.432 / 86400. ! 1/(kmol O2/m3 s)      Degradation rate constant of POP
@@ -1017,7 +1017,7 @@ contains
       call pinfo_add_entry('disso_sil',   disso_sil   * dtbgcinv)
       call pinfo_add_entry('disso_caco3', disso_caco3 * dtbgcinv)
       call pinfo_add_entry('sed_denit',   sed_denit   * dtbgcinv)
-      call pinfo_add_entry('sed_sulf',    sed_sulf   * dtbgcinv)
+      call pinfo_add_entry('sed_sulf',    sed_sulf    * dtbgcinv)
       call pinfo_add_entry('silsat',      silsat)
       call pinfo_add_entry('orgwei',      orgwei)
       call pinfo_add_entry('opalwei',     opalwei)

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -100,7 +100,7 @@ module mo_param_bgc
   public :: dmsp1,dmsp2,dmsp3,dmsp4,dmsp5,dmsp6,dms_gamma
   public :: POM_remin_q10,opal_remin_q10,POM_remin_Tref,opal_remin_Tref
   public :: O2thresh_aerob,O2thresh_hypoxic,NO3thresh_sulf
-  public :: sed_O2thresh_aerob,sed_O2thresh_hypoxic,sed_NO3thresh_sulf
+  public :: sed_O2thresh_sulf,sed_O2thresh_hypoxic,sed_NO3thresh_sulf
   public :: shelfbreak_depth
   public :: sed_alpha_poc,sed_qual_sc
 
@@ -484,9 +484,9 @@ module mo_param_bgc
   !********************************************************************
   ! Note that the rates in the sediment are given in per second here!
   !
-  real, parameter :: sed_O2thresh_hypoxic = 1.e-6    ! Below sed_O2thresh_hypoxic denitrification takes place (default model version)
-  real, parameter :: sed_O2thresh_sulf    = 3.e-6    ! Below sed_O2thresh_sulf 'sulfate reduction' takes place
-  real, parameter :: sed_NO3thresh_sulf   = 3.e-6    ! Below sed_NO3thresh_sulf 'sufate reduction' takes place
+  real, protected :: sed_O2thresh_hypoxic = 1.e-6    ! Below sed_O2thresh_hypoxic denitrification takes place (default model version)
+  real, protected :: sed_O2thresh_sulf    = 3.e-6    ! Below sed_O2thresh_sulf 'sulfate reduction' takes place
+  real, protected :: sed_NO3thresh_sulf   = 3.e-6    ! Below sed_NO3thresh_sulf 'sufate reduction' takes place
   real, protected :: sedict      = 1.e-9          ! m2/s Molecular diffusion coefficient
   real, protected :: silsat      = 0.001          ! kmol/m3 Silicate saturation concentration is 1 mol/m3
   real, protected :: disso_poc   = 0.432 / 86400. ! 1/(kmol O2/m3 s)      Degradation rate constant of POP
@@ -636,7 +636,8 @@ contains
                          bkoxdnra_sed,bkdnra_sed,q10anh4nitr_sed,                &
                          bkoxamox_sed,bkanh4nitr_sed,q10ano2nitr_sed,            &
                          bkoxnitr_sed,bkano2nitr_sed,sed_alpha_poc,sed_qual_sc,  &
-                         sed_denit,sed_sulf
+                         sed_denit,sed_sulf,                                     &
+                         sed_O2thresh_hypoxic,sed_O2thresh_sulf,sed_NO3thresh_sulf
 
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -100,6 +100,7 @@ module mo_param_bgc
   public :: dmsp1,dmsp2,dmsp3,dmsp4,dmsp5,dmsp6,dms_gamma
   public :: POM_remin_q10,opal_remin_q10,POM_remin_Tref,opal_remin_Tref
   public :: O2thresh_aerob,O2thresh_hypoxic,NO3thresh_sulf
+  public :: sed_O2thresh_aerob,sed_O2thresh_hypoxic,sed_NO3thresh_sulf
   public :: shelfbreak_depth
   public :: sed_alpha_poc,sed_qual_sc
 
@@ -483,6 +484,9 @@ module mo_param_bgc
   !********************************************************************
   ! Note that the rates in the sediment are given in per second here!
   !
+  real, parameter :: sed_O2thresh_hypoxic = 1.e-6    ! Below sed_O2thresh_hypoxic denitrification takes place (default model version)
+  real, parameter :: sed_O2thresh_sulf    = 3.e-6    ! Below sed_O2thresh_sulf 'sulfate reduction' takes place
+  real, parameter :: sed_NO3thresh_sulf   = 3.e-6    ! Below sed_NO3thresh_sulf 'sufate reduction' takes place
   real, protected :: sedict      = 1.e-9          ! m2/s Molecular diffusion coefficient
   real, protected :: silsat      = 0.001          ! kmol/m3 Silicate saturation concentration is 1 mol/m3
   real, protected :: disso_poc   = 0.432 / 86400. ! 1/(kmol O2/m3 s)      Degradation rate constant of POP
@@ -1004,6 +1008,9 @@ contains
       write(io_stdo_bgc,*)
       write(io_stdo_bgc,*) '********************************************'
       write(io_stdo_bgc,*) '* Values of MO_PARAM_BGC sediment variables : '
+      call pinfo_add_entry('sed_O2thresh_hypoxic',sed_O2thresh_hypoxic)
+      call pinfo_add_entry('sed_O2thresh_sulf',   sed_O2thresh_sulf)
+      call pinfo_add_entry('sed_NO3thresh_sulf',  sed_NO3thresh_sulf)
       call pinfo_add_entry('sedict',      sedict      * dtbgcinv)
       call pinfo_add_entry('disso_poc',   disso_poc   * dtbgcinv)
       call pinfo_add_entry('disso_sil',   disso_sil   * dtbgcinv)

--- a/hamocc/mo_powach.F90
+++ b/hamocc/mo_powach.F90
@@ -39,7 +39,7 @@ contains
     use mo_carbch,      only: co3,keqb,ocetra,sedfluxo,sedfluxb
     use mo_chemcon,     only: calcon
     use mo_param_bgc,   only: rnit,rcar,rdnit1,rdnit2,ro2ut,disso_sil,silsat,disso_poc,sed_denit,  &
-                            & disso_caco3,ro2utammo,sed_alpha_poc,                                 &
+                            & disso_caco3,ro2utammo,sed_alpha_poc,sed_sulf,                        &
                             & POM_remin_q10_sed,POM_remin_Tref_sed,bkox_drempoc_sed,sed_qual_sc
     use mo_sedmnt,      only: porwat,porsol,powtra,produs,prcaca,prorca,seddw,sedhpl,sedlay,       &
                               silpro,pror13,pror14,prca13,prca14,prorca_mavg,sed_reactivity_a,     &
@@ -427,7 +427,7 @@ contains
         do i = 1, kpie
           if(omask(i,j) > 0.5) then
             if(powtra(i,j,k,ipowaox) < 3.e-6 .and. powtra(i,j,k,ipowno3) < 3.e-6) then
-              posol = denit * sedlay(i,j,k,issso12)         ! remineralization of poc
+              posol = sed_sulf * sedlay(i,j,k,issso12)         ! remineralization of poc
               umfa = porsol(i,j,k) / porwat(i,j,k)
               sulf(i,k) = posol*umfa      !this has P units: kmol P/m3 of pore water
               if (use_cisonew) then

--- a/hamocc/mo_powach.F90
+++ b/hamocc/mo_powach.F90
@@ -40,7 +40,8 @@ contains
     use mo_chemcon,     only: calcon
     use mo_param_bgc,   only: rnit,rcar,rdnit1,rdnit2,ro2ut,disso_sil,silsat,disso_poc,sed_denit,  &
                             & disso_caco3,ro2utammo,sed_alpha_poc,sed_sulf,                        &
-                            & POM_remin_q10_sed,POM_remin_Tref_sed,bkox_drempoc_sed,sed_qual_sc
+                            & POM_remin_q10_sed,POM_remin_Tref_sed,bkox_drempoc_sed,sed_qual_sc,   &
+                            & sed_O2thresh_hypoxic,sed_O2thresh_sulf,sed_NO3thresh_sulf
     use mo_sedmnt,      only: porwat,porsol,powtra,produs,prcaca,prorca,seddw,sedhpl,sedlay,       &
                               silpro,pror13,pror14,prca13,prca14,prorca_mavg,sed_reactivity_a,     &
                               sed_reactivity_k,sed_applied_reminrate
@@ -390,7 +391,7 @@ contains
         do k = 1, ks
           do i = 1, kpie
             if(omask(i,j) > 0.5) then
-              if(powtra(i,j,k,ipowaox) < 1.e-6) then
+              if(powtra(i,j,k,ipowaox) < sed_O2thresh_hypoxic) then
                 posol = denit * min(0.25*powtra(i,j,k,ipowno3)/rdnit2, sedlay(i,j,k,issso12))
                 umfa = porsol(i,j,k)/porwat(i,j,k)
                 anaerob(i,k) = posol*umfa     !this has P units: kmol P/m3 of pore water
@@ -426,7 +427,7 @@ contains
       do k = 1, ks
         do i = 1, kpie
           if(omask(i,j) > 0.5) then
-            if(powtra(i,j,k,ipowaox) < 3.e-6 .and. powtra(i,j,k,ipowno3) < 3.e-6) then
+            if(powtra(i,j,k,ipowaox) < sed_O2thresh_sulf .and. powtra(i,j,k,ipowno3) < sed_NO3thresh_sulf) then
               posol = sed_sulf * sedlay(i,j,k,issso12)         ! remineralization of poc
               umfa = porsol(i,j,k) / porwat(i,j,k)
               sulf(i,k) = posol*umfa      !this has P units: kmol P/m3 of pore water


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger ,

with this PR, I make the O2 and NO3 sediment thresholds for denitrification and sulfate reduction as well as the sulfate reduction rate in the default model version accessible through the bgc namelist. It is partially also used in the extended nitrogen cycle and I would like to be able to change it (since particularly the O2 threshold for sulfate reduction is relatively high and could also be changed in the default model - I'll check also the water column and might make those values also tunable).    