### PR TITLE
Fluxes, surface Alk, PO4, NO3 and ODZ volume to i-monitoring files 

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5428,7 +5428,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,1,0</value>
+      <value>0,1,2</value>
     </values>
     <desc>Writing the BGC inventory files at BGC frequencies</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4911,7 +4911,7 @@
     </values>
     <desc>Sediment: remineralization rate (at reference temperature) (1/(kmol O2/m3 s))</desc>
   </entry>
-  
+
   <entry id="sed_O2thresh_hypoxic">
     <type>real</type>
     <category>bgcparams</category>

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -92,6 +92,7 @@ contains
     !--- additional ocean tracer
     real :: zhito                    ! Total hydrogen ion tracer
     real :: zco3to                   ! Total dissolved carbonate (CO3) tracer
+    real :: ODZvol                   ! ODZ volume (O2threshold: 20 mumol)
     !--- alkalinity of the first layer
     real :: zvoltop                  ! Total volume of top ocean layer
     real :: zalkali                  ! Total alkalinity of top ocean layer
@@ -278,21 +279,12 @@ contains
     ztmp2(:,:)=0.0
     do j=1,kpje
       do i=1,kpie
-        ztmp1(i,j) = omask(i,j)*dlxp(i,j)*dlyp(i,j)*ddpo(i,j,k)
-        ztmp2(i,j) = ocetra(i,j,k,iphosph)*ztmp1(i,j)
+        vol        = omask(i,j)*dlxp(i,j)*dlyp(i,j)*ddpo(i,j,k)
+        ztmp1(i,j) = ocetra(i,j,k,iphosph)*vol
+        ztmp2(i,j) = ocetra(i,j,k,iano3)*vol
       enddo
     enddo
-    call xcsum(zphosph,ztmp2,ips)
-
-    k=1
-    ztmp1(:,:)=0.0
-    ztmp2(:,:)=0.0
-    do j=1,kpje
-      do i=1,kpie
-        ztmp1(i,j) = omask(i,j)*dlxp(i,j)*dlyp(i,j)*ddpo(i,j,k)
-        ztmp2(i,j) = ocetra(i,j,k,iano3)*ztmp1(i,j)
-      enddo
-    enddo
+    call xcsum(zphosph,ztmp1,ips)
     call xcsum(zano3,ztmp2,ips)
 
     !=== atmosphere flux and atmospheric CO2

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -842,6 +842,7 @@ contains
       ! atmosphere-ocean fluxes
       integer :: co2flux_varid,so2flux_varid,sn2flux_varid,sn2oflux_varid,snh3flux_varid
       integer :: sdmsflux_varid
+      integer :: sndepnoyflux_varid,sndepnhxflux_varid
 
       ! ODZ volume
       integer :: ODZvol_varid
@@ -1653,12 +1654,25 @@ contains
              &    'Global flux of DMS into atmosphere') )
         call nccheck( NF90_PUT_ATT(ncid, sdmsflux_varid, 'units', 'kmol/s') )
 
+        call nccheck( NF90_DEF_VAR(ncid, 'sndepnoyflux', NF90_DOUBLE,             &
+               &    time_dimid, sndepnoyflux_varid) )
+        call nccheck( NF90_PUT_ATT(ncid, sndepnoyflux_varid, 'long_name',         &
+               &    'Global deposition of NOy from atmosphere') )
+        call nccheck( NF90_PUT_ATT(ncid, sndepnoyflux_varid, 'units', 'kmol') )
+
         if (use_extNcycle) then
           call nccheck( NF90_DEF_VAR(ncid, 'snh3flux', NF90_DOUBLE,               &
                &    time_dimid, snh3flux_varid) )
           call nccheck( NF90_PUT_ATT(ncid, snh3flux_varid, 'long_name',           &
                &    'Global flux of NH3 into atmosphere') )
           call nccheck( NF90_PUT_ATT(ncid, snh3flux_varid, 'units', 'kmol') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'sndepnhxflux', NF90_DOUBLE,           &
+               &    time_dimid, sndepnhxflux_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, sndepnhxflux_varid, 'long_name',       &
+               &    'Global deposition of NHx from atmosphere') )
+          call nccheck( NF90_PUT_ATT(ncid, sndepnhxflux_varid, 'units', 'kmol') )
+
         endif
 
         call nccheck( NF90_DEF_VAR(ncid, 'ODZvol', NF90_DOUBLE,                   &
@@ -1828,8 +1842,10 @@ contains
         call nccheck( NF90_INQ_VARID(ncid, "sn2flux",  sn2flux_varid) )
         call nccheck( NF90_INQ_VARID(ncid, "sn2oflux", sn2oflux_varid) )
         call nccheck( NF90_INQ_VARID(ncid, "sdmsflux", sdmsflux_varid) )
+        call nccheck( NF90_INQ_VARID(ncid, "sndepnoyflux",  sndepnoyflux_varid) )
         if (use_extNcycle) then
           call nccheck( NF90_INQ_VARID(ncid, "snh3flux",  snh3flux_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, "sndepnhxflux",  sndepnhxflux_varid) )
         endif
         call nccheck( NF90_INQ_VARID(ncid, "ODZvol", ODZvol_varid) )
       endif
@@ -2103,8 +2119,10 @@ contains
       call nccheck( NF90_PUT_VAR(ncid, sn2flux_varid, sn2flux,start = wrstart) )
       call nccheck( NF90_PUT_VAR(ncid, sn2oflux_varid,sn2oflux,start = wrstart) )
       call nccheck( NF90_PUT_VAR(ncid, sdmsflux_varid,sdmsflux/dtbgc,start = wrstart) )
+      call nccheck( NF90_PUT_VAR(ncid, sndepnoyflux_varid, sndepnoyflux,start = wrstart) )
       if (use_extNcycle) then
         call nccheck( NF90_PUT_VAR(ncid, snh3flux_varid, snh3flux,start = wrstart) )
+        call nccheck( NF90_PUT_VAR(ncid, sndepnhxflux_varid, sndepnhxflux,start = wrstart) )
       endif
       call nccheck( NF90_PUT_VAR(ncid, ODZvol_varid,ODZvol, start = wrstart) )
 

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -902,8 +902,8 @@ contains
           call nccheck( NF90_DEF_VAR(ncid, 'zsedtotvol', NF90_DOUBLE, time_dimid,   &
                &    zsedtotvol_varid) )
           call nccheck( NF90_PUT_ATT(ncid, zsedtotvol_varid, 'long_name',           &
-               &    'Total sediment volume') )
-          call nccheck( NF90_PUT_ATT(ncid, zsedtotvol_varid, 'units', 'L') )
+               &    'Total sediment pore water volume') )
+          call nccheck( NF90_PUT_ATT(ncid, zsedtotvol_varid, 'units', 'm^3') )
 
           call nccheck( NF90_DEF_VAR(ncid, 'zpowtratot', NF90_DOUBLE,               &
                &    zpowtra_dimids, zpowtratot_varid) )
@@ -915,7 +915,13 @@ contains
                &    zpowtra_dimids, zpowtratoc_varid) )
           call nccheck( NF90_PUT_ATT(ncid, zpowtratoc_varid, 'long_name',           &
                &    'Aqueous sediment concentration') )
-          call nccheck( NF90_PUT_ATT(ncid, zpowtratoc_varid, 'units', 'kmol/L') )
+          call nccheck( NF90_PUT_ATT(ncid, zpowtratoc_varid, 'units', 'kmol/m^3') )
+
+          call nccheck( NF90_DEF_VAR(ncid, 'sedfluxo', NF90_DOUBLE,                 &
+               &    zpowtra_dimids, sum_sedfluxo_varid) )
+          call nccheck( NF90_PUT_ATT(ncid, sum_sedfluxo_varid, 'long_name',         &
+               &    'Aqueous sediment tracer diffusive fluxes') )
+          call nccheck( NF90_PUT_ATT(ncid, sum_sedfluxo_varid, 'units', 'kmol/s') )
 
           !--- non-aqueous sediment tracers
           call nccheck( NF90_DEF_VAR(ncid, 'zsedlayto', NF90_DOUBLE,                &
@@ -1682,6 +1688,7 @@ contains
           call nccheck( NF90_INQ_VARID(ncid, 'zsedtotvol', zsedtotvol_varid) )
           call nccheck( NF90_INQ_VARID(ncid, 'zpowtratot', zpowtratot_varid) )
           call nccheck( NF90_INQ_VARID(ncid, 'zpowtratoc', zpowtratoc_varid) )
+          call nccheck( NF90_INQ_VARID(ncid, 'sedfluxo',   sum_sedfluxo_varid) )
           !--- non-aqueous sediment tracers
           call nccheck( NF90_INQ_VARID(ncid, 'zsedlayto', zsedlayto_varid) )
           call nccheck( NF90_INQ_VARID(ncid, 'zburial', zburial_varid) )
@@ -1849,6 +1856,8 @@ contains
              &     start = zpowtra_wrstart, count = zpowtra_count) )
         call nccheck( NF90_PUT_VAR(ncid, zpowtratoc_varid, zpowtratoc,                &
              &     start = zpowtra_wrstart, count = zpowtra_count) )
+        call nccheck( NF90_PUT_VAR(ncid, sum_sedfluxo_varid, sum_sedfluxo/dtbgc,      &
+             &     start = zpowtra_wrstart,count = zpowtra_count) )
         !--- non-aqueous sediment tracers
         call nccheck( NF90_PUT_VAR(ncid, zsedlayto_varid, zsedlayto,                  &
              &     start = zsedtra_wrstart, count = zsedtra_count) )

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -50,7 +50,7 @@ contains
                               igasnit,iopal,ioxygen,iphosph,iphy,ipowaic,ipowaox,ipowaph,ipowasi,  &
                               ipown2,ipowno3,isco212,isilica,isssc12,issso12,issssil,izoo,         &
                               irdin,irdip,irsi,iralk,irdoc,irdet,nocetra,npowtra,nsedtra,nriv,     &
-                              ianh4,iano2,iatmnh3,ipownh4,ipown2o,ipowno2
+                              ianh4,iano2,iatmnh3,ipownh4,ipown2o,ipowno2,iatmdms
     use mo_vgrid,       only: dp_min
 
     ! NOT sedbypass
@@ -333,6 +333,7 @@ contains
       co2flux = sum2d(atmflx(:,:,iatmco2))
       so2flux = sum2d(atmflx(:,:,iatmo2))
       sn2flux = sum2d(atmflx(:,:,iatmn2))
+      sdmsflux = sum2d(atmflx(:,:,iatmdms))
       sn2oflux = sum2d(atmflx(:,:,iatmn2o))
       if (use_extNcycle) then
         snh3flux = sum2d(atmflx(:,:,iatmnh3))
@@ -355,6 +356,7 @@ contains
       co2flux = sum2d(bgct2d(:,:,jco2flux))
       so2flux = sum2d(bgct2d(:,:,jo2flux))
       sn2flux = sum2d(bgct2d(:,:,jn2flux))
+      sdmsflux = sum2d(atmflx(:,:,iatmdms))
       sn2oflux = sum2d(bgct2d(:,:,jn2oflux))
       if (use_extNcycle) then
         snh3flux = sum2d(bgct2d(:,:,jnh3flux))

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -356,7 +356,7 @@ contains
       co2flux = sum2d(bgct2d(:,:,jco2flux))
       so2flux = sum2d(bgct2d(:,:,jo2flux))
       sn2flux = sum2d(bgct2d(:,:,jn2flux))
-      sdmsflux = sum2d(atmflx(:,:,iatmdms))
+      sdmsflux = sum2d(atmflx(:,:,iatmdms)) ! exception: DMS is instantanious flux (no accumulation)
       sn2oflux = sum2d(bgct2d(:,:,jn2oflux))
       if (use_extNcycle) then
         snh3flux = sum2d(bgct2d(:,:,jnh3flux))
@@ -722,7 +722,7 @@ contains
                                idet14,idoc13,idoc14,iphy13,iphy14,isco213,isco214,izoo13,izoo14,   &
                                inatalkali,inatcalc,inatsco212,ianh4,iano2,iprefsilica
       use mo_control_bgc,only: use_PBGC_CK_TIMESTEP,use_BOXATM,use_sedbypass,use_cisonew,use_AGG,  &
-                               use_CFC,use_natDIC,use_BROMO,use_pref_tracers
+                               use_CFC,use_natDIC,use_BROMO,use_pref_tracers,dtbgc
 
       implicit none
 
@@ -1645,7 +1645,7 @@ contains
              &    time_dimid, sdmsflux_varid) )
         call nccheck( NF90_PUT_ATT(ncid, sdmsflux_varid, 'long_name',             &
              &    'Global flux of DMS into atmosphere') )
-        call nccheck( NF90_PUT_ATT(ncid, sdmsflux_varid, 'units', 'kmol') )
+        call nccheck( NF90_PUT_ATT(ncid, sdmsflux_varid, 'units', 'kmol/s') )
 
         if (use_extNcycle) then
           call nccheck( NF90_DEF_VAR(ncid, 'snh3flux', NF90_DOUBLE,               &
@@ -2093,7 +2093,7 @@ contains
       call nccheck( NF90_PUT_VAR(ncid, so2flux_varid, so2flux,start = wrstart) )
       call nccheck( NF90_PUT_VAR(ncid, sn2flux_varid, sn2flux,start = wrstart) )
       call nccheck( NF90_PUT_VAR(ncid, sn2oflux_varid,sn2oflux,start = wrstart) )
-      call nccheck( NF90_PUT_VAR(ncid, sdmsflux_varid,sdmsflux,start = wrstart) )
+      call nccheck( NF90_PUT_VAR(ncid, sdmsflux_varid,sdmsflux/dtbgc,start = wrstart) )
       if (use_extNcycle) then
         call nccheck( NF90_PUT_VAR(ncid, snh3flux_varid, snh3flux,start = wrstart) )
       endif


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik , I added a number of further -useful- global monitoring fields to the monitoring files output. This includes:
- Surface alkalinity, PO4 and NO3
- Various gaseous surface fluxes
- ODZ volume (ODZ volume for oxygen concentrations < 20mumol/L) 
- diffusive sediment pore water tracer fluxes
- riverine input fluxes
- N-deposition fluxes

**Yearly i-monitoring file writing is now default.** 