### PR TITLE
fix remin diag - in case of kwrbioz_off=True remin was formerly under…

### DIFF
--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -727,7 +727,7 @@ contains
               ocetra(i,j,k,ianh4) = ocetra(i,j,k,ianh4) + remin*rnit
               ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali) + (rnit-1.)*remin
               ocetra(i,j,k,ioxygen) = ocetra(i,j,k,ioxygen) - ro2utammo*remin
-              remin_aerob(i,j,k)  = remin*rnit ! kmol/NH4/dtb - remin to NH4 from various sources
+              remin_aerob(i,j,k)  = remin_aerob(i,j,k)+remin*rnit ! kmol/NH4/dtb - remin to NH4 from various sources
             endif
             ocetra(i,j,k,isco212) = ocetra(i,j,k,isco212)+rcar*remin
             ocetra(i,j,k,iiron) = ocetra(i,j,k,iiron)+remin*riron           &


### PR DESCRIPTION
…estimated

@JorgSchwinger and @TomasTorsvik , this PR should fix N-cycle diagnostics in the acse of kwrbioz_off=True (remin_aerob is set to zero at the beginning of ocprod, while it sums up any remin/excretion/exudation in the MLD and deep ocean loop - hence it was thus far underestimated, when breaking up the MLD-deep ocean separation)