### PR TITLE
Fix output volume settings

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -6,8 +6,8 @@
 
   <entry id="BLOM_OUTPUT_SIZE">
     <type>char</type>
-    <valid_values>spinup</valid_values>
-    <default_value>spinup</default_value>
+    <valid_values>spinup,default</valid_values>
+    <default_value>default</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Namelist option to set BLOM output option.</desc>
@@ -212,8 +212,8 @@
 
   <entry id="HAMOCC_OUTPUT_SIZE">
     <type>char</type>
-    <valid_values>spinup</valid_values>
-    <default_value>spinup</default_value>
+    <valid_values>spinup,default</valid_values>
+    <default_value>default</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Namelist option to set iHAMOCC output option. Requires module ecosys</desc>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5643,6 +5643,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>


### PR DESCRIPTION
Hi @JorgSchwinger , @matsbn and @TomasTorsvik ,

this PR fixes some issue with the recently introduced output size settings. It now sets a default value (i.e. the value, where no switch is set) and the spinup-output volume, when the usermods are set (as before). This doesn't change the behavior of the spinup settings, but if those are not set explicitly, the previous default values are now set again. Hence, it also doesn't affect the previously tagged version (i.e. spinup size for output was always(!) chosen).