### PR TITLE
introduce capability to switch off dynamic sediment POM age

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4076,6 +4076,16 @@
     <desc>Switch for T- and O2-dependent remineralization of POM</desc>
   </entry>
 
+  <entry id="ldyn_sed_age">
+    <type>logical</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>.false.</value>
+    </values>
+    <desc>Switch for dynamic age of POM when using use_sediment_quality</desc>
+  </entry>
+
   <entry id="do_oalk">
     <type>logical</type>
     <category>bgcnml</category>

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -62,6 +62,7 @@ module mo_control_bgc
   logical           :: use_M4AGO              = .false. ! run with M4AGO settling scheme
   logical           :: lkwrbioz_off           = .false. ! if true, allow remin and primary prod throughout full water column
   logical           :: lTO2depremin           = .false. ! Temperature- and O2-dependent remineralization of POM
+  logical           :: ldyn_sed_age           = .false. ! switch for dynamic sediment age in combination with use_sediment_quality
   integer           :: sedspin_yr_s           = -1      ! start year for sediment spin-up
   integer           :: sedspin_yr_e           = -1      ! end   year for sediment spin-up
   integer           :: sedspin_ncyc           = -1      ! sediment spin-up sub-cycles

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -45,7 +45,7 @@ contains
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
                               lkwrbioz_off,do_n2onh3_coupled,                                      &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
-                              use_coupler_ndep,lTO2depremin,use_sediment_quality
+                              use_coupler_ndep,lTO2depremin,use_sediment_quality,ldyn_sed_age
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
     use mo_param_bgc,   only: ini_parambgc,claydens,calcdens,calcwei,opaldens,opalwei,ropal
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
@@ -87,7 +87,8 @@ contains
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,swaclimfile,       &
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
-         &            do_n2onh3_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,sedqualfile
+         &            do_n2onh3_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,sedqualfile,   &
+         &            ldyn_sed_age
     !
     ! --- Set io units and some control parameters
     !

--- a/hamocc/mo_powach.F90
+++ b/hamocc/mo_powach.F90
@@ -32,7 +32,8 @@ contains
     ! Modified: S.Legutke,   *MPI-MaD, HH*    10.04.01
     !***********************************************************************************************
 
-    use mo_control_bgc, only: dtbgc,use_cisonew,use_extNcycle,lTO2depremin,use_sediment_quality
+    use mo_control_bgc, only: dtbgc,use_cisonew,use_extNcycle,lTO2depremin,use_sediment_quality,   &
+                            & ldyn_sed_age
     use mo_param1_bgc,  only: ioxygen,ipowaal,ipowaic,ipowaox,ipowaph,ipowasi,ipown2,ipowno3,      &
                               isilica,isssc12,issso12,issssil,issster,ks,ipowc13,ipowc14,isssc13,  &
                               isssc14,issso13,issso14,safediv,ipownh4,issso12_age
@@ -226,13 +227,16 @@ contains
             ! units of prorca: kmol P/m2/dt -> prorca_mavg in mmol P/m2/d
             prorca_mavg(i,j) = sed_alpha_poc*prorca(i,j)*1e6*dtbgc/86400.                          &
                              & + (1.-sed_alpha_poc)*prorca_mavg(i,j)
-
-            ! update surface age due to fresh POC sedimentation flux
-            sedlay(i,j,1,issso12_age) = sedlay(i,j,1,issso12) * sedlay(i,j,1,issso12_age)          &
+            if (ldyn_sed_age) then
+              ! update surface age due to fresh POC sedimentation flux
+              sedlay(i,j,1,issso12_age) = sedlay(i,j,1,issso12) * sedlay(i,j,1,issso12_age)        &
                           & / ((prorca(i,j)/(porsol(i,j,1)*seddw(1))) + sedlay(i,j,1,issso12) + eps)
+            endif
             do k = 1, ks
-              ! Update sediment POC age [yrs]
-              sedlay(i,j,k,issso12_age) = sedlay(i,j,k,issso12_age) + dtbgc/31536000.
+              if (ldyn_sed_age) then
+                ! Update sediment POC age [yrs]
+                sedlay(i,j,k,issso12_age) = sedlay(i,j,k,issso12_age) + dtbgc/31536000.
+              endif
               ! Mean DOU flux [mmol O2/m2/d]
               ! Since reactivity is based on total sediment DOU (incl. nitrification),
               ! we here assume the full oxydation steo and use ro2ut

--- a/hamocc/mo_sedshi.F90
+++ b/hamocc/mo_sedshi.F90
@@ -46,7 +46,7 @@ contains
                               issso13,issso14,issso12_age,nsedtra_woage
     use mo_carbch,      only: sedfluxb
     use mo_control_bgc, only: use_cisonew,use_sediment_quality,dtbgc,                              &
-                            & do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc
+                            & do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,ldyn_sed_age
 
     ! Arguments
     integer, intent(in) :: kpie
@@ -103,7 +103,7 @@ contains
             if(omask(i,j) > 0.5) then
               !ka          if(bolay(i,j).gt.0.) then
               uebers=wsed(i,j)*sedlay(i,j,k,iv)
-              if (use_sediment_quality .and. iv == issso12) then
+              if (use_sediment_quality .and. iv == issso12 .and. ldyn_sed_age) then
                 sedlay(i,j,k+1,issso12_age) = ( uebers                                             &
                  & *(seddw(k)*porsol(i,j,k))/(seddw(k+1)*porsol(i,j,k+1))*sedlay(i,j,k,issso12_age)&
                  &     + sedlay(i,j,k,issso12)*sedlay(i,j,k,issso12_age))                          &
@@ -150,7 +150,7 @@ contains
           if(omask(i,j) > 0.5) then
             !ka          if(bolay(i,j).gt.0.) then
             uebers=wsed(i,j)*sedlay(i,j,ks,iv)
-            if (use_sediment_quality .and. iv == issso12) then
+            if (use_sediment_quality .and. iv == issso12  .and. ldyn_sed_age) then
               burial(i,j,issso12_age) = (uebers*seddw(ks)*porsol(i,j,ks)*sedlay(i,j,ks,issso12_age)&
                                       &   + burial(i,j,issso12)*burial(i,j,issso12_age))           &
                                       & /(uebers*seddw(ks)*porsol(i,j,ks) + burial(i,j,issso12)+eps)
@@ -237,7 +237,7 @@ contains
           refill=seddef/(buried+1.e-10)
           frac = porsol(i,j,ks)*seddw(ks)
 
-          if (use_sediment_quality) then
+          if (use_sediment_quality  .and. ldyn_sed_age) then
             ! Update burial POC age [yrs] - NOTE that sedshi is called once per day!
             burial(i,j,issso12_age)    = burial(i,j,issso12_age) + 86400./31536000. + acc_time
             sedlay(i,j,ks,issso12_age) = (refill*burial(i,j,issso12)/frac * burial(i,j,issso12_age)&
@@ -304,7 +304,7 @@ contains
               !ka        if(bolay(i,j).gt.0.) then
               uebers=sedlay(i,j,k,iv)*wsed(i,j)
               frac=porsol(i,j,k)*seddw(k)/(porsol(i,j,k-1)*seddw(k-1))
-              if (use_sediment_quality .and. iv == issso12) then
+              if (use_sediment_quality .and. iv == issso12 .and. ldyn_sed_age) then
                 sedlay(i,j,k-1,issso12_age) = (uebers*frac*sedlay(i,j,k,issso12_age)               &
                                             &+ sedlay(i,j,k-1,issso12)*sedlay(i,j,k-1,issso12_age))&
                                             & / (uebers*frac + sedlay(i,j,k-1,issso12)+eps)


### PR DESCRIPTION
With this PR, I introduce the option to switch off the dynamic evolution of the sediment age, which facilitates the testing of the sediment_quality further - also due to a seemingly diffusive sedshi routine.  