### PR TITLE
Ocean-atmosphere N coupling - enable to separately couple NH3 and N2O

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -194,11 +194,23 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values>
-       <value compset="_BGC.*%N2OC%NH3C">TRUE</value>
+       <value compset="_BGC.*%N2OC">TRUE</value>
     </values>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
-    <desc>N2O and NH3 fluxes coupled from atmosphere. Requires module ecosys and extncycle</desc>
+    <desc>N2O fluxes coupled from atmosphere. Requires module ecosys and extncycle</desc>
+  </entry>
+  
+  <entry id="HAMOCC_NH3C">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <values>
+       <value compset="_BGC.*%NH3C">TRUE</value>
+    </values>
+    <group>run_component_blom</group>
+    <file>env_run.xml</file>
+    <desc>NH3 fluxes coupled from atmosphere. Requires module ecosys and extncycle</desc>
   </entry>
 
   <entry id="HAMOCC_SINKING_SCHEME">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4044,7 +4044,7 @@
     <desc>if .true., use MCT coupler fields from CAM or NUOPC to obtain NDEP (always imported to model).</desc>
   </entry>
 
-  <entry id="do_n2onh3_coupled" modify_via_xml="HAMOCC_N2OC">
+  <entry id="do_n2o_coupled" modify_via_xml="HAMOCC_N2OC">
     <type>logical</type>
     <category>bgcnml</category>
     <group>bgcnml</group>
@@ -4052,7 +4052,18 @@
       <value>.false.</value>
       <value hamocc_n2oc="yes" hamocc_extncycle="yes">.true.</value>
     </values>
-    <desc>Switch to couple N2O and NH3 fluxes</desc>
+    <desc>Switch to couple N2O fluxes to atmosphere</desc>
+  </entry>
+  
+  <entry id="do_nh3_coupled" modify_via_xml="HAMOCC_NH3C">
+    <type>logical</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>.false.</value>
+      <value hamocc_nh3c="yes" hamocc_extncycle="yes">.true.</value>
+    </values>
+    <desc>Switch to couple NH3 fluxes to atmosphere</desc>
   </entry>
 
   <entry id="use_m4ago">

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -54,7 +54,8 @@ module mo_control_bgc
   ! Variables set via namelist bgcnml
   logical           :: l_3Dvarsedpor          = .false. ! apply spatially variable sediment porosity
   logical           :: do_ndep                = .true.  ! apply n-deposition
-  logical           :: do_n2onh3_coupled      = .false. ! for coupled simulations, use field provided by atmosphere
+  logical           :: do_n2o_coupled         = .false. ! for coupled simulations, use field provided by atmosphere
+  logical           :: do_nh3_coupled         = .false. ! for coupled simulations, use field provided by atmosphere
   logical           :: do_rivinpt             = .true.  ! apply riverine input
   logical           :: do_sedspinup           = .false. ! apply sediment spin-up
   logical           :: do_oalk                = .false. ! apply ocean alkalinization

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -87,8 +87,8 @@ contains
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,swaclimfile,       &
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
-         &            do_n2o_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,sedqualfile,      &
-         &            ldyn_sed_age,do_nh3_coupled
+         &            do_n2o_coupled,do_nh3_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,   &
+         &            sedqualfile,ldyn_sed_age
     !
     ! --- Set io units and some control parameters
     !

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -43,7 +43,7 @@ contains
                               do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                 &
                               dtb,dtbgc,io_stdo_bgc,ldtbgc,                                        &
                               ldtrunbgc,ndtdaybgc,with_dmsph,l_3Dvarsedpor,use_M4AGO,              &
-                              lkwrbioz_off,do_n2onh3_coupled,                                      &
+                              lkwrbioz_off,do_n2o_coupled,do_nh3_coupled,                          &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
                               use_coupler_ndep,lTO2depremin,use_sediment_quality,ldyn_sed_age
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
@@ -87,8 +87,8 @@ contains
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,swaclimfile,       &
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
-         &            do_n2onh3_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,sedqualfile,   &
-         &            ldyn_sed_age
+         &            do_n2o_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,sedqualfile,      &
+         &            ldyn_sed_age,do_nh3_coupled
     !
     ! --- Set io units and some control parameters
     !

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -37,7 +37,7 @@ module mo_param_bgc
                             do_ndep,do_oalk,do_rivinpt,do_sedspinup,l_3Dvarsedpor,                 &
                             use_BOXATM,use_CFC,use_PBGC_CK_TIMESTEP,                               &
                             use_sedbypass,with_dmsph,use_PBGC_OCNP_TIMESTEP,ocn_co2_type,use_M4AGO,&
-                            do_n2onh3_coupled,use_extNcycle,                                       &
+                            do_n2o_coupled,do_nh3_coupled,use_extNcycle,                           &
                             lkwrbioz_off,lTO2depremin,use_shelfsea_res_time,use_sediment_quality,  &
                             use_pref_tracers,use_coupler_ndep
   use mod_xc,         only: mnproc
@@ -869,7 +869,8 @@ contains
       call cinfo_add_entry('use_pref_tracers',       use_pref_tracers)
       call cinfo_add_entry('use_coupler_ndep',       use_coupler_ndep)
       if (use_extNcycle) then
-        call cinfo_add_entry('do_n2onh3_coupled',       do_n2onh3_coupled)
+        call cinfo_add_entry('do_n2o_coupled',       do_n2o_coupled)
+        call cinfo_add_entry('do_nh3_coupled',       do_nh3_coupled)
       endif
       write(io_stdo_bgc,*) '* '
       write(io_stdo_bgc,*) '* Values of MO_PARAM_BGC variables : '


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger , with this PR, the capability to separately switch on/off NH3 and N2O coupled fluxes between ocean and atmosphere is introduced for experiments addressing individual contributions.