### PR TITLE
Set character length to 512 for all filenames

### DIFF
--- a/drivers/mct/ocn_comp_mct.F90
+++ b/drivers/mct/ocn_comp_mct.F90
@@ -61,6 +61,7 @@ module ocn_comp_mct
    use mod_grid,         only: scp2, plon, plat, scuy, scvx, scuxi, scvyi
    use mod_state,        only: u, v, temp, saln, pbu, pbv, ubflxs, vbflxs, sealv
    use mod_cesm,         only: frzpot
+   use mod_utility,      only: fnmlen
    use blom_cpl_indices
 
    implicit none
@@ -272,7 +273,7 @@ module ocn_comp_mct
       type(seq_infodata_type), pointer :: infodata   ! Input init object
       integer :: shrlogunit, shrloglev, ymd, tod, ymd_sync, tod_sync
       integer :: nfu
-      character(len = 256) :: restartfn
+      character(len = fnmlen) :: restartfn
 
       ! ----------------------------------------------------------------
       ! Reset shr logging to my log file

--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -58,6 +58,7 @@ module ocn_comp_nuopc
    use mod_restart,       only: restart_write
    use ocn_stream_sss,    only: ocn_stream_sss_init, ocn_stream_sss_interp
    use ocn_stream_sst,    only: ocn_stream_sst_init, ocn_stream_sst_interp
+   use mod_utility,       only: fnmlen
 #ifdef HAMOCC
    use mo_control_bgc,    only: use_BROMO
    use ocn_stream_dust,   only: ocn_stream_dust_init, ocn_stream_dust_interp
@@ -853,8 +854,8 @@ contains
       logical :: first_call = .true., restart_alarm_on, stop_alarm_on, wrtrst
       character(len=cllen) :: msg
       integer :: nfu
-      character(len = 256) :: restartfn
-      character(len = 256) :: rpfile
+      character(len = fnmlen) :: restartfn
+      character(len = fnmlen) :: rpfile
 
       if (dbug > 5) call ESMF_LogWrite(subname//': called', ESMF_LOGMSG_INFO)
 

--- a/hamocc/meson.build
+++ b/hamocc/meson.build
@@ -23,6 +23,7 @@ sources += files(
   'mo_chemcon.F90',
   'mo_clim_swa.F90',
   'mo_control_bgc.F90',
+  'mo_kind.F90',
   'mo_intfcblom.F90',
   'mo_param1_bgc.F90',
   'mo_param_bgc.F90',

--- a/hamocc/mo_Gdata_read.F90
+++ b/hamocc/mo_Gdata_read.F90
@@ -49,6 +49,7 @@ module mo_Gdata_read
                             nf90_inquire_variable,nf90_get_att,nf90_close,nf90_open
   use mod_xc,         only: mnproc,xchalt
   use mo_control_bgc, only: io_stdo_bgc
+  use mo_kind,        only: bgc_fnmlen
 
   implicit none
   private
@@ -89,16 +90,16 @@ module mo_Gdata_read
   real,             parameter :: fillval = -1.e+32
 
   ! Input file names (incl. full path) set through namelist
-  character(len=256) :: inidic  = ''
-  character(len=256) :: inialk  = ''
-  character(len=256) :: inipo4  = ''
-  character(len=256) :: inioxy  = ''
-  character(len=256) :: inino3  = ''
-  character(len=256) :: inisil  = ''
-  character(len=256) :: inid13c = ''
-  character(len=256) :: inid14c = ''
-  character(len=256) :: inic13 = ''   ! currently not used
-  character(len=256) :: inic14 = ''   ! currently not used
+  character(len=bgc_fnmlen) :: inidic  = ''
+  character(len=bgc_fnmlen) :: inialk  = ''
+  character(len=bgc_fnmlen) :: inipo4  = ''
+  character(len=bgc_fnmlen) :: inioxy  = ''
+  character(len=bgc_fnmlen) :: inino3  = ''
+  character(len=bgc_fnmlen) :: inisil  = ''
+  character(len=bgc_fnmlen) :: inid13c = ''
+  character(len=bgc_fnmlen) :: inid14c = ''
+  character(len=bgc_fnmlen) :: inic13 = ''   ! currently not used
+  character(len=bgc_fnmlen) :: inic14 = ''   ! currently not used
 
   ! Variables set by call to Gdata_set
   integer                               :: nz
@@ -108,7 +109,7 @@ module mo_Gdata_read
   real, dimension(:, :, :), allocatable :: rvar,gdata
   character(len=16)                     :: var,ncname
   character(len=3)                      :: dsrc
-  character(len=256)                    :: infile
+  character(len=bgc_fnmlen)             :: infile
 
   logical :: lset  = .false.
 

--- a/hamocc/mo_clim_swa.F90
+++ b/hamocc/mo_clim_swa.F90
@@ -25,6 +25,8 @@ module mo_clim_swa
   !  J.Tjiputra,        *NORCE Climate, Bergen*    2021-04-15
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -34,7 +36,7 @@ module mo_clim_swa
   ! Module variables
 
   ! File name (incl. full path) for input data, set through namelist in hamocc_init.F
-  character(len=512), public :: swaclimfile=''
+  character(len=bgc_fnmlen), public :: swaclimfile=''
 
   ! Array to store swa flux after reading from file
   real, allocatable, public :: swa_clim(:,:,:)

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -723,6 +723,7 @@ contains
                                inatalkali,inatcalc,inatsco212,ianh4,iano2,iprefsilica
       use mo_control_bgc,only: use_PBGC_CK_TIMESTEP,use_BOXATM,use_sedbypass,use_cisonew,use_AGG,  &
                                use_CFC,use_natDIC,use_BROMO,use_pref_tracers,dtbgc
+      use mo_kind,       only: bgc_fnmlen
 
       implicit none
 
@@ -730,7 +731,7 @@ contains
 
       !=== Save filename and counter variables
       !--- netCDF output file names
-      character(len=256), dimension(nbgcmax), save :: fname_inv
+      character(len=bgc_fnmlen), dimension(nbgcmax), save :: fname_inv
       integer, dimension(nbgcmax), save :: ncrec = 0
       logical, dimension(nbgcmax), save :: append2file_inv
       data append2file_inv /nbgcmax*.false./

--- a/hamocc/mo_kind.F90
+++ b/hamocc/mo_kind.F90
@@ -18,8 +18,8 @@
 module mo_kind
 
   use mod_types,   only: blom_i1 => i1, blom_i2 => i2, blom_i4 => i4, blom_i8 => i8, &
-                         blom_r4 => r4, blom_r8 => r8, blom_kind_cs, blom_kind_cm,   &
-                         blom_kind_cl, blom_kind_cx, blom_kind_cxx
+                         blom_r4 => r4, blom_r8 => r8, blom_char_s, blom_char_m,     &
+                         blom_char_l, blom_char_x, blom_char_xx
   use mod_utility, only: fnmlen
 
   implicit none
@@ -28,19 +28,19 @@ module mo_kind
   !----------------------------------------------------------------------------
 
   public
-  integer,parameter :: i1 = blom_i1                     ! 8-bit integer
-  integer,parameter :: i2 = blom_i2                     ! 16-bit integer
-  integer,parameter :: i4 = blom_i4                     ! 32-bit integer
-  integer,parameter :: i8 = blom_i8                     ! 64-bit integer
-  integer,parameter :: r4 = blom_r4                     ! 4 byte real
-  integer,parameter :: r8 = blom_r8                     ! 8 byte real
-  integer,parameter :: HAMOCC_KIND_CS  = blom_kind_cs   ! short char
-  integer,parameter :: HAMOCC_KIND_CM  = blom_kind_cm   ! mid-sized char
-  integer,parameter :: HAMOCC_KIND_CL  = blom_kind_cl   ! long char
-  integer,parameter :: HAMOCC_KIND_CX  = blom_kind_cx   ! extra-long char
-  integer,parameter :: HAMOCC_KIND_CXX = blom_kind_cxx  ! extra-extra-long char
+  integer,parameter :: i1 = blom_i1                   ! 8-bit integer
+  integer,parameter :: i2 = blom_i2                   ! 16-bit integer
+  integer,parameter :: i4 = blom_i4                   ! 32-bit integer
+  integer,parameter :: i8 = blom_i8                   ! 64-bit integer
+  integer,parameter :: r4 = blom_r4                   ! 4 byte real
+  integer,parameter :: r8 = blom_r8                   ! 8 byte real
+  integer,parameter :: HAMOCC_CHAR_S  = blom_char_s   ! short char
+  integer,parameter :: HAMOCC_CHAR_M  = blom_char_m   ! mid-sized char
+  integer,parameter :: HAMOCC_CHAR_L  = blom_char_l   ! long char
+  integer,parameter :: HAMOCC_CHAR_X  = blom_char_x   ! extra-long char
+  integer,parameter :: HAMOCC_CHAR_XX = blom_char_xx  ! extra-extra-long char
 
-  integer,parameter :: bgc_fnmlen = fnmlen              ! default filename length
-  integer,parameter :: rp = r8                          ! default real precision
-  integer,parameter :: ip = i4                          ! default integer precision
+  integer,parameter :: bgc_fnmlen = fnmlen            ! default filename length
+  integer,parameter :: rp = r8                        ! default real precision
+  integer,parameter :: ip = i4                        ! default integer precision
 end module mo_kind

--- a/hamocc/mo_kind.F90
+++ b/hamocc/mo_kind.F90
@@ -17,7 +17,10 @@
 
 module mo_kind
 
-  use, intrinsic :: iso_fortran_env, only: int8, int16, int32, int64, real32, real64
+  use mod_types,   only: blom_i1 => i1, blom_i2 => i2, blom_i4 => i4, blom_i8 => i8, &
+                         blom_r4 => r4, blom_r8 => r8, blom_kind_cs, blom_kind_cm,   &
+                         blom_kind_cl, blom_kind_cx, blom_kind_cxx
+  use mod_utility, only: fnmlen
 
   implicit none
   !----------------------------------------------------------------------------
@@ -25,17 +28,17 @@ module mo_kind
   !----------------------------------------------------------------------------
 
   public
-  integer,parameter :: i1 = int8               ! 8-bit integer
-  integer,parameter :: i2 = int16              ! 16-bit integer
-  integer,parameter :: i4 = int32              ! 32-bit integer
-  integer,parameter :: i8 = int64              ! 64-bit integer
-  integer,parameter :: r4 = real32             ! 4 byte real
-  integer,parameter :: r8 = real64             ! 8 byte real
-  integer,parameter :: HAMOCC_KIND_CS = 80     ! short char
-  integer,parameter :: HAMOCC_KIND_CM = 160    ! mid-sized char
-  integer,parameter :: HAMOCC_KIND_CL = 256    ! long char
-  integer,parameter :: HAMOCC_KIND_CX = 512    ! extra-long char
-  integer,parameter :: HAMOCC_KIND_CXX= 4096   ! extra-extra-long char
+  integer,parameter :: i1 = blom_i1                     ! 8-bit integer
+  integer,parameter :: i2 = blom_i2                     ! 16-bit integer
+  integer,parameter :: i4 = blom_i4                     ! 32-bit integer
+  integer,parameter :: i8 = blom_i8                     ! 64-bit integer
+  integer,parameter :: r4 = blom_r4                     ! 4 byte real
+  integer,parameter :: r8 = blom_r8                     ! 8 byte real
+  integer,parameter :: HAMOCC_KIND_CS  = blom_kind_cs   ! short char
+  integer,parameter :: HAMOCC_KIND_CM  = blom_kind_cm   ! mid-sized char
+  integer,parameter :: HAMOCC_KIND_CL  = blom_kind_cl   ! long char
+  integer,parameter :: HAMOCC_KIND_CX  = blom_kind_cx   ! extra-long char
+  integer,parameter :: HAMOCC_KIND_CXX = blom_kind_cxx  ! extra-extra-long char
 
-  integer,parameter :: bgc_fnmlen = 512        ! default filename length
+  integer,parameter :: bgc_fnmlen = fnmlen              ! default filename length
 end module mo_kind

--- a/hamocc/mo_kind.F90
+++ b/hamocc/mo_kind.F90
@@ -1,0 +1,41 @@
+! Copyright (C) 2025  J. Maerz, J. Schwinger, T. Torsvik
+!
+! This file is part of BLOM/iHAMOCC.
+!
+! BLOM is free software: you can redistribute it and/or modify it under the
+! terms of the GNU Lesser General Public License as published by the Free
+! Software Foundation, either version 3 of the License, or (at your option)
+! any later version.
+!
+! BLOM is distributed in the hope that it will be useful, but WITHOUT ANY
+! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+! FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+! more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with BLOM. If not, see https://www.gnu.org/licenses/.
+
+module mo_kind
+
+  use, intrinsic :: iso_fortran_env, only: int8, int16, int32, int64, real32, real64
+
+  implicit none
+  !----------------------------------------------------------------------------
+  ! precision/kind constants add data public
+  !----------------------------------------------------------------------------
+
+  public
+  integer,parameter :: i1 = int8               ! 8-bit integer
+  integer,parameter :: i2 = int16              ! 16-bit integer
+  integer,parameter :: i4 = int32              ! 32-bit integer
+  integer,parameter :: i8 = int64              ! 64-bit integer
+  integer,parameter :: r4 = real32             ! 4 byte real
+  integer,parameter :: r8 = real64             ! 8 byte real
+  integer,parameter :: HAMOCC_KIND_CS = 80     ! short char
+  integer,parameter :: HAMOCC_KIND_CM = 160    ! mid-sized char
+  integer,parameter :: HAMOCC_KIND_CL = 256    ! long char
+  integer,parameter :: HAMOCC_KIND_CX = 512    ! extra-long char
+  integer,parameter :: HAMOCC_KIND_CXX= 4096   ! extra-extra-long char
+
+  integer,parameter :: bgc_fnmlen = 512        ! default filename length
+end module mo_kind

--- a/hamocc/mo_kind.F90
+++ b/hamocc/mo_kind.F90
@@ -41,4 +41,6 @@ module mo_kind
   integer,parameter :: HAMOCC_KIND_CXX = blom_kind_cxx  ! extra-extra-long char
 
   integer,parameter :: bgc_fnmlen = fnmlen              ! default filename length
+  integer,parameter :: rp = r8                          ! default real precision
+  integer,parameter :: ip = i4                          ! default integer precision
 end module mo_kind

--- a/hamocc/mo_kind.F90
+++ b/hamocc/mo_kind.F90
@@ -23,11 +23,12 @@ module mo_kind
   use mod_utility, only: fnmlen
 
   implicit none
+  private
+
   !----------------------------------------------------------------------------
-  ! precision/kind constants add data public
+  ! precision/kind constants, default settings
   !----------------------------------------------------------------------------
 
-  public
   integer,parameter :: i1 = blom_i1                   ! 8-bit integer
   integer,parameter :: i2 = blom_i2                   ! 16-bit integer
   integer,parameter :: i4 = blom_i4                   ! 32-bit integer
@@ -43,4 +44,9 @@ module mo_kind
   integer,parameter :: bgc_fnmlen = fnmlen            ! default filename length
   integer,parameter :: rp = r8                        ! default real precision
   integer,parameter :: ip = i4                        ! default integer precision
+
+  ! Only expose the default parameters at this stage.
+  ! We can revisit this if we see that a larger set of parameters is needed.
+  public :: bgc_fnmlen, rp, ip
+
 end module mo_kind

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -222,13 +222,14 @@ contains
                               SDM_rem_aerob,SDM_rem_denit,SDM_rem_sulf,jsdm_rem_aerob,             &
                               jsdm_rem_denit,jsdm_rem_sulf
     use mo_param_bgc,   only: c14fac,param4nc,nentries,controls4nc,centries
+    use mo_kind,        only: bgc_fnmlen
 
     ! Arguments
     integer                  :: i,j,k,l,nt
     integer                  :: ny,nm,nd,dayfrac,cmpflg,iogrp
     integer,            save :: irec(nbgcmax)
     logical,            save :: append2file(nbgcmax)
-    character(len=256), save :: fname(nbgcmax)
+    character(len=bgc_fnmlen), save :: fname(nbgcmax)
     character(len=20)        :: startdate
     character(len=30)        :: timeunits
     real                     :: datenum,rnacc

--- a/hamocc/mo_read_fedep.F90
+++ b/hamocc/mo_read_fedep.F90
@@ -29,6 +29,8 @@ module mo_read_fedep
   !    and a module that applies the fluxes in core hamocc (mo_apply_fedep)
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -36,7 +38,7 @@ module mo_read_fedep
   public :: get_fedep      ! Get the iron (dust) deposition for a given month
 
   ! File name (incl. full path) for input data, set through namelist in hamocc_init
-  character(len=512), public :: fedepfile=''
+  character(len=bgc_fnmlen), public :: fedepfile=''
 
   ! Array to store dust deposition flux after reading from file
   real, allocatable,  public :: dustflx(:,:,:)

--- a/hamocc/mo_read_ndep.F90
+++ b/hamocc/mo_read_ndep.F90
@@ -49,6 +49,8 @@ module mo_read_ndep
   !
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -56,7 +58,7 @@ module mo_read_ndep
   public :: get_ndep      ! Read and return n-deposition data for a given month.
   public :: ndepfile
 
-  character(len=512)  :: ndepfile=''
+  character(len=bgc_fnmlen)  :: ndepfile=''
   real,  allocatable  :: noydepread(:,:)
   real,  allocatable  :: nhxdepread(:,:)
   integer             :: startyear,endyear

--- a/hamocc/mo_read_oafx.F90
+++ b/hamocc/mo_read_oafx.F90
@@ -57,6 +57,8 @@ module mo_read_oafx
   !  - add ability to use an OA input file
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -68,7 +70,7 @@ module mo_read_oafx
   ! Module variables
 
   character(len=128), protected, public  :: oalkscen   =''
-  character(len=512), protected, public  :: oalkfile   =''
+  character(len=bgc_fnmlen), protected, public  :: oalkfile   =''
   real,allocatable,   protected          :: oalkflx(:,:)
   integer,            protected          :: startyear,endyear
 

--- a/hamocc/mo_read_pi_ph.F90
+++ b/hamocc/mo_read_pi_ph.F90
@@ -17,6 +17,8 @@
 
 module mo_read_pi_ph
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -33,7 +35,7 @@ module mo_read_pi_ph
   ! Module variables
 
   ! Path to input data, set through namelist in hamocc_init.F
-  character(len=256) :: pi_ph_file = ''
+  character(len=bgc_fnmlen) :: pi_ph_file = ''
 
   ! Length of surface PI pH record from file
   ! Current implementation only support monthly records.

--- a/hamocc/mo_read_rivin.F90
+++ b/hamocc/mo_read_rivin.F90
@@ -52,6 +52,7 @@ module mo_read_rivin
 
   use dimensions, only: idm,jdm
   use mod_xc ,    only: nbdy
+  use mo_kind,    only: bgc_fnmlen
 
   implicit none
   private
@@ -60,7 +61,7 @@ module mo_read_rivin
   public :: ini_read_rivin ! read gnews riverine nutrient and carbon data
 
   ! File name (incl. full path) for input data, set through namelist in mo_hamocc_init
-  character(len=256), public :: rivinfile = ''
+  character(len=bgc_fnmlen), public :: rivinfile = ''
   real, allocatable,  public :: rivflx(:,:,:) ! holds input data as read from file
 
   ! arrays for reading riverine inputs on the model grid

--- a/hamocc/mo_read_sedpor.F90
+++ b/hamocc/mo_read_sedpor.F90
@@ -27,6 +27,8 @@ module mo_read_sedpor
   ! sed_por holds then the porosity that can be applied later in mo_sedmnt (ini_sedmnt_por)
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -34,7 +36,7 @@ module mo_read_sedpor
   public :: read_sedpor ! read sediment porosity file
 
   ! Module variables
-  character(len=512), public :: sedporfile = ''
+  character(len=bgc_fnmlen), public :: sedporfile = ''
 
 contains
 

--- a/hamocc/mo_read_sedqual.F90
+++ b/hamocc/mo_read_sedqual.F90
@@ -25,6 +25,8 @@ module mo_read_sedqual
   ! sed_POCage_init holds then the age that can be applied later in mo_sedmnt (ini_sed_qual)
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
@@ -32,7 +34,7 @@ module mo_read_sedqual
   public :: read_sedqual ! read sediment porosity file
 
   ! Module variables
-  character(len=512), public :: sedqualfile = ''
+  character(len=bgc_fnmlen), public :: sedqualfile = ''
 
 contains
 

--- a/hamocc/mo_read_shelfmask.F90
+++ b/hamocc/mo_read_shelfmask.F90
@@ -31,12 +31,14 @@ module mo_read_shelfmask
   !
   !*************************************************************************************************
 
+  use mo_kind, only: bgc_fnmlen
+
   implicit none
   private
 
   public :: ini_read_shelfmask
 
-  character(len=512),               public :: shelfsea_maskfile =''
+  character(len=bgc_fnmlen),        public :: shelfsea_maskfile =''
   logical, allocatable,  protected, public :: shelfmask(:,:)
 
 contains

--- a/phy/mod_dia.F90
+++ b/phy/mod_dia.F90
@@ -61,7 +61,7 @@ module mod_dia
                            surrlx, salflx, brnflx, salrlx, taux, tauy, &
                            ustar, ustar3
   use mod_niw,       only: idkedt
-  use mod_utility,   only: util1, util2, util3, util4
+  use mod_utility,   only: util1, util2, util3, util4, fnmlen
   use mod_ben02,     only: dfl, alb
   use mod_thdysi,    only: tsrfm,ticem
   use mod_tracers,   only: ntrocn, ntr, natr, itriag, itrtke, itrgls, trc
@@ -161,8 +161,8 @@ module mod_dia
   integer, parameter         :: slenmax=50
   integer, parameter, public :: rflgdm=20
   character(len=slenmax), dimension(odm), public :: mer_regnam = ''
-  character(len=256), public :: mer_orfile
-  character(len=256), public :: mer_mifile
+  character(len=fnmlen), public :: mer_orfile
+  character(len=fnmlen), public :: mer_mifile
   integer, dimension(odm,rflgdm), public :: mer_regflg = -1
   integer, dimension(odm), public :: mer_nflg
   real, dimension(odm), public :: mer_minlat=-90.
@@ -178,7 +178,7 @@ module mod_dia
        mhflx,mhftd,mhfsm,mhfld,msflx,msftd,msfsm,msfld
 
   ! Section transports
-  character(len = 256), public :: sec_sifile
+  character(len = fnmlen), public :: sec_sifile
   integer :: sec_num
   integer, parameter :: max_sec = 400
   character(len = slenmax) :: sec_name(max_sec)
@@ -374,7 +374,7 @@ contains
     character(len = *), intent(out):: fname   ! file name
 
     ! Local variables
-    character(len = 256) :: prefix
+    character(len = fnmlen) :: prefix
     character(len = 1) :: sep1,sep2
     type(date_type) :: date_tmp
     integer :: errstat,ns
@@ -1886,15 +1886,15 @@ contains
     integer :: iogrp
     integer, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), save :: iuu
     integer, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), save :: ivv
-    integer,              save :: irec(nphymax)
-    character(len=256),   save :: fname(nphymax)
-    logical                    :: iniflg = .true.
-    logical                    :: append2file(nphymax) = .false.
-    integer                    :: i,j,k,l,cmpflg
-    character(len=30)          :: timeunits
-    character(len=20)          :: startdate
-    real                       :: datenum,rnacc
-    real, dimension(itdm,jtdm) :: bflxg,strg
+    integer,               save :: irec(nphymax)
+    character(len=fnmlen), save :: fname(nphymax)
+    logical                     :: iniflg = .true.
+    logical                     :: append2file(nphymax) = .false.
+    integer                     :: i,j,k,l,cmpflg
+    character(len=30)           :: timeunits
+    character(len=20)           :: startdate
+    real                        :: datenum,rnacc
+    real, dimension(itdm,jtdm)  :: bflxg,strg
     integer, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: ind1,ind2
     real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,ddm) :: wghts
     real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,ddm) :: wghtsflx

--- a/phy/mod_diffusion.F90
+++ b/phy/mod_diffusion.F90
@@ -27,6 +27,7 @@ module mod_diffusion
    use mod_constants, only: spval, epsilk
    use mod_xc
    use mod_forcing, only: wavsrc_opt, wavsrc_none, wavsrc_param, wavsrc_extern
+   use mod_utility, only: fnmlen
 
    implicit none
    private
@@ -72,7 +73,7 @@ module mod_diffusion
                 ! according to Gregg et al. (2003).
       smobld    ! If true, apply lateral smoothing of CVMix estimated boundary
                 ! layer depth.
-   character(len = 256) :: &
+   character(len = fnmlen) :: &
       tbfile    ! Name of file containing topographic beta parameter.
    character(len = 80) :: &
       lngmtp, & ! Type of Langmuir turbulence parameterization. Valid types:

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -32,6 +32,7 @@ module mod_forcing
    use mod_tracers, only: ntr
    use mod_ifdefs, only: use_TRC
    use mod_checksum, only: csdiag, chksummsk
+   use mod_utility, only: fnmlen
 
    implicit none
 
@@ -58,7 +59,7 @@ module mod_forcing
       srxlim          ! Maximum absolute value of SSS difference in relaxation
                       ! [g kg-1].
 
-   character(len = 256) :: &
+   character(len = fnmlen) :: &
       scfile, &       ! Name of file containing monthly SSS climatology.
       wavsrc          ! Source of wave fields. Valid source: 'none', 'param',
                       ! 'extern'.

--- a/phy/mod_geoenv.F90
+++ b/phy/mod_geoenv.F90
@@ -31,6 +31,7 @@ module mod_geoenv
                            scv2, qlon, qlat, plon, plat, ulon, ulat, &
                            vlon, vlat, depths, corioq, coriop, betafp, &
                            betatp, angle, cosang, sinang, hangle, nwp
+  use mod_utility,   only: fnmlen
   use netcdf
 
   implicit none
@@ -50,7 +51,7 @@ contains
 
     ! Local variables
     integer, parameter :: cwmlen = 100
-    character (len = 256) :: nlfnm
+    character (len = fnmlen) :: nlfnm
     character (len = 80), dimension(cwmlen) :: cwmtag
     character (len = 1), dimension(cwmlen) :: cwmedg
     real, dimension(itdm,jtdm) :: tmpg

--- a/phy/mod_grid.F90
+++ b/phy/mod_grid.F90
@@ -25,13 +25,14 @@ module mod_grid
    use mod_types, only: r8
    use mod_constants, only: spval
    use mod_xc, only: idm, jdm, kdm, nbdy, ii, jj, kk
+   use mod_utility, only: fnmlen
 
    implicit none
 
    private
 
    ! Variable to be set in namelist:
-   character(len = 256) :: &
+   character(len = fnmlen) :: &
       grfile     ! Name of file containing grid specification.
 
    real(r8), dimension(1 - nbdy:idm + nbdy, 1 - nbdy:jdm + nbdy, 4) :: &

--- a/phy/mod_inicon.F90
+++ b/phy/mod_inicon.F90
@@ -59,13 +59,14 @@ module mod_inicon
   use mod_pointtest, only: itest, jtest, ptest
   use mod_checksum,  only: csdiag, chksummsk
   use mod_inicon_ben02, only: inicon_ben02
+  use mod_utility,   only: fnmlen
   use netcdf
 
   implicit none
   private
 
   ! Variables to be set in namelist:
-  character(len = 256), public :: &
+  character(len = fnmlen), public :: &
        icfile ! Name of file containing initial conditions, that is
   ! either a valid restart file or 'inicon.nc' if
   ! climatological based initial conditions are desired.

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -111,6 +111,7 @@ module mod_rdlim
   use mod_checksum,    only: csdiag
   use mod_nctools,     only: ncfopn, ncgeti, ncgetr, ncfcls
   use mod_ifdefs,      only: use_diag
+  use mod_utility,     only: fnmlen
 
   implicit none
   private
@@ -126,8 +127,8 @@ contains
 
     ! Local variables
     type(date_type) :: date0_rest
-    character(len = 256) :: nlfnm,rstfnm
-    character(len = 256) :: l_rpfile
+    character(len = fnmlen) :: nlfnm,rstfnm
+    character(len = fnmlen) :: l_rpfile
     logical :: fexist
     integer :: m,n,idate,idate0,nfu,ios
 
@@ -1030,7 +1031,7 @@ contains
         call ncfcls
         nday1 = nint(time-time0)
         n = 1
-        do while (n < 256.and.rstfnm(n:n) /= ' ')
+        do while (n < fnmlen.and.rstfnm(n:n) /= ' ')
           n = n+1
         end do
         n = n-1

--- a/phy/mod_restart.F90
+++ b/phy/mod_restart.F90
@@ -116,6 +116,7 @@ module mod_restart
    use mod_ifdefs,         only: use_TRC, use_TKE, use_IDLAGE
    use mod_idlage,         only: idlage_init
    use mod_tracers_update, only: restart_trcwt, restart_trcrd
+   use mod_utility,        only: fnmlen
 
    implicit none
 
@@ -1049,7 +1050,7 @@ contains
       ! local variables
       integer :: nfu, i, j, n
       character(len = 256), dimension(4) :: rstdate_str
-      character(len = 256) :: rstfnm, fnm
+      character(len = fnmlen) :: rstfnm, fnm
       character(len = 2) :: c2
 
       ! Formulate restart filename.
@@ -1299,7 +1300,7 @@ contains
 
       type(date_type) :: date_rest
       integer :: nfu, errstat, dndiff, ntr_file, i, j, l, n
-      character(len = 256) :: rstfnm, fnm, l_rpfile
+      character(len = fnmlen) :: rstfnm, fnm, l_rpfile
       character(len = 2) :: c2
       real(r8) :: pb_max, phi_min, rho_restart
       logical :: file_exist, fld_read

--- a/phy/mod_swabs.F90
+++ b/phy/mod_swabs.F90
@@ -55,6 +55,7 @@ module mod_swabs
   use mod_time,     only: xmi, l1mi, l2mi, l3mi, l4mi, l5mi
   use mod_checksum, only: csdiag, chksummsk
   use mod_intp1d,   only: intp1d
+  use mod_utility,  only: fnmlen
   use netcdf
 
   implicit none
@@ -78,9 +79,9 @@ module mod_swabs
   !                         observations during 1997-2010.
   !  ccfile: Name of file containing chlorophyll concentration
   !          climatology.
-  character (len = 80),  public :: swamth,chlopt
-  character (len = 256), public :: ccfile
-  integer,               public :: jwtype
+  character (len = 80),     public :: swamth,chlopt
+  character (len = fnmlen), public :: ccfile
+  integer,                  public :: jwtype
 
   ! Parameter arrays related to shortwave radiation absorption
   ! following Paulson and Simpson's (1977) fit to the data of Jerlov

--- a/phy/mod_swabs.F90
+++ b/phy/mod_swabs.F90
@@ -55,6 +55,7 @@ module mod_swabs
    use mod_time,     only: xmi, l1mi, l2mi, l3mi, l4mi, l5mi
    use mod_checksum, only: csdiag, chksummsk
    use mod_intp1d,   only: intp1d
+   use mod_utility,  only: fnmlen
    use netcdf
 
    implicit none
@@ -82,9 +83,9 @@ module mod_swabs
    !   ccfile: Name of file containing chlorophyll concentration climatology.
    !   svfile: Name of file containing spatially varying spectral band fractions
    !           and attenuation lengths.
-   character (len = 80)  :: swamth, chlopt
-   character (len = 256) :: ccfile, svfile
-   integer               :: jwtype
+   character (len = 80)     :: swamth, chlopt
+   character (len = fnmlen) :: ccfile, svfile
+   integer                  :: jwtype
 
   ! Parameter arrays related to shortwave radiation absorption following Paulson
   ! and Simpson's (1977) fit to the data of Jerlov (1968):

--- a/phy/mod_tidaldissip.F90
+++ b/phy/mod_tidaldissip.F90
@@ -27,6 +27,7 @@ module mod_tidaldissip
    use mod_constants, only: spval
    use mod_xc
    use mod_checksum, only: csdiag, chksummsk
+   use mod_utility, only: fnmlen
    use netcdf
 
    implicit none
@@ -36,7 +37,7 @@ module mod_tidaldissip
    real(r8), dimension(1 - nbdy:idm + nbdy,1 - nbdy:jdm + nbdy) :: &
       twedon ! Tidal wave energy dissipation over buoyancy frequency [g s-2].
 
-   character(len = 256) :: &
+   character(len = fnmlen) :: &
       tdfile ! Name of file containing tidal wave energy dissipation divided by
              ! by bottom buoyancy frequency.
 

--- a/phy/mod_types.F90
+++ b/phy/mod_types.F90
@@ -36,7 +36,17 @@ module mod_types
       i8 = int64, &
       r4 = real32, &
       r8 = real64
+   integer,parameter :: BLOM_KIND_CS = 80      ! short char
+   integer,parameter :: BLOM_KIND_CM = 160     ! mid-sized char
+   integer,parameter :: BLOM_KIND_CL = 256     ! long char
+   integer,parameter :: BLOM_KIND_CX = 512     ! extra-long char
+   integer,parameter :: BLOM_KIND_CXX= 4096    ! extra-extra-long char
 
-   public :: i1, i2, i4, i8, r4, r8
+   public :: i1, i2, i4, i8, r4, r8,   &
+        BLOM_KIND_CS,                  &
+        BLOM_KIND_CM,                  &
+        BLOM_KIND_CL,                  &
+        BLOM_KIND_CX,                  &
+        BLOM_KIND_CXX
 
 end module mod_types

--- a/phy/mod_types.F90
+++ b/phy/mod_types.F90
@@ -36,17 +36,17 @@ module mod_types
       i8 = int64, &
       r4 = real32, &
       r8 = real64
-   integer,parameter :: BLOM_KIND_CS = 80      ! short char
-   integer,parameter :: BLOM_KIND_CM = 160     ! mid-sized char
-   integer,parameter :: BLOM_KIND_CL = 256     ! long char
-   integer,parameter :: BLOM_KIND_CX = 512     ! extra-long char
-   integer,parameter :: BLOM_KIND_CXX= 4096    ! extra-extra-long char
+   integer,parameter :: BLOM_CHAR_S = 80      ! short char
+   integer,parameter :: BLOM_CHAR_M = 160     ! mid-sized char
+   integer,parameter :: BLOM_CHAR_L = 256     ! long char
+   integer,parameter :: BLOM_CHAR_X = 512     ! extra-long char
+   integer,parameter :: BLOM_CHAR_XX= 4096    ! extra-extra-long char
 
-   public :: i1, i2, i4, i8, r4, r8,   &
-        BLOM_KIND_CS,                  &
-        BLOM_KIND_CM,                  &
-        BLOM_KIND_CL,                  &
-        BLOM_KIND_CX,                  &
-        BLOM_KIND_CXX
+   public :: i1, i2, i4, i8, r4, r8,  &
+        BLOM_CHAR_S,                  &
+        BLOM_CHAR_M,                  &
+        BLOM_CHAR_L,                  &
+        BLOM_CHAR_X,                  &
+        BLOM_CHAR_XX
 
 end module mod_types

--- a/phy/mod_utility.F90
+++ b/phy/mod_utility.F90
@@ -22,7 +22,7 @@ module mod_utility
 ! This module contains various utility variables.
 ! ------------------------------------------------------------------------------
 
-   use mod_types, only: r8, blom_kind_cx
+   use mod_types, only: r8, blom_char_x
    use mod_constants, only: spval
    use mod_xc
    use mod_checksum, only: csdiag, chksummsk
@@ -50,7 +50,7 @@ module mod_utility
       util1, util2, util3, util4
 
    ! Default length of character variables for filenames
-   integer,parameter :: fnmlen = blom_kind_cx
+   integer,parameter :: fnmlen = blom_char_x
 
    public :: utotm, vtotm, utotn, vtotn, &
              uflux, vflux, uflux2, vflux2, uflux3, vflux3, &

--- a/phy/mod_utility.F90
+++ b/phy/mod_utility.F90
@@ -22,7 +22,7 @@ module mod_utility
 ! This module contains various utility variables.
 ! ------------------------------------------------------------------------------
 
-   use mod_types, only: r8
+   use mod_types, only: r8, blom_kind_cx
    use mod_constants, only: spval
    use mod_xc
    use mod_checksum, only: csdiag, chksummsk
@@ -49,11 +49,14 @@ module mod_utility
    real(r8), dimension(1 - nbdy:idm + nbdy, 1 - nbdy:jdm + nbdy) :: &
       util1, util2, util3, util4
 
+   ! Default length of character variables for filenames
+   integer,parameter :: fnmlen = blom_kind_cx
+
    public :: utotm, vtotm, utotn, vtotn, &
              uflux, vflux, uflux2, vflux2, uflux3, vflux3, &
              umax, vmax, &
              util1, util2, util3, util4, &
-             inivar_utility
+             inivar_utility, fnmlen
    
 contains
 

--- a/phy/mod_wdiflx.F90
+++ b/phy/mod_wdiflx.F90
@@ -25,6 +25,7 @@ module mod_wdiflx
   use mod_forcing, only: tflxdi, sflxdi, nflxdi, ditflx, disflx
   use mod_nctools
   use mod_dia,     only : iotype
+  use mod_utility, only: fnmlen
 
   implicit none
   private
@@ -38,7 +39,7 @@ contains
     ! --- Write accumulated diagnosed heat and salt fluxes
 
     ! Local variables
-    character(len=256) :: fname
+    character(len=fnmlen) :: fname
     integer :: i,j,k
 
     if (ditflx) then

--- a/trc/mod_tracers_update.F90
+++ b/trc/mod_tracers_update.F90
@@ -37,6 +37,7 @@ module mod_tracers_update
   use mod_dia,             only: iotype, rstfmt, rstcmp
   use mod_config,          only: expcnf
   use mod_ifdefs,          only: use_ATRC, use_IDLAGE
+  use mod_utility,         only: fnmlen
   use mod_nctools
   use mod_xc
 
@@ -179,8 +180,8 @@ contains
 
     ! Local variables
     logical :: error
-    character(len=256) :: rstfnm_ocntrc
-    character(len=256) :: rstfnm_hamocc
+    character(len=fnmlen) :: rstfnm_ocntrc
+    character(len=fnmlen) :: rstfnm_hamocc
 
     ! ------------------------------------------------------------------
     ! Generate file name
@@ -242,8 +243,8 @@ contains
 
     ! Local variables
     logical :: error
-    character(len=256) :: rstfnm_ocntrc
-    character(len=256) :: rstfnm_hamocc
+    character(len=fnmlen) :: rstfnm_ocntrc
+    character(len=fnmlen) :: rstfnm_hamocc
 
     ! ------------------------------------------------------------------
     ! Generate file name
@@ -303,7 +304,7 @@ contains
 
     ! Local variables
     integer :: nt,nat
-    character(len = 256) :: trcnm
+    character(len=fnmlen) :: trcnm
 
     ! ------------------------------------------------------------------
     ! if no ocean tracers are defined, return
@@ -412,7 +413,7 @@ contains
     integer :: nt,nat
     real :: time0r,timer
     logical :: fexist
-    character(len = 256) :: trcnm
+    character(len=fnmlen) :: trcnm
 
     ! ------------------------------------------------------------------
     ! If no ocean tracers are defined, return


### PR DESCRIPTION
Some test configurations require more than 256 characters for PATH + filename specifications. I suggest to set all filenames to 512 characters by default.

I have included a new `mo_kind.F90` file for iHAMOCC. I see we sometimes use the BLOM file `mod_types.F90`, but I think it can be useful to define this internally in iHAMOCC as well.

**Tests**: `prealpha_noresm` and `aux_blom_noresm` tests pass, except expected fails