### PR TITLE
Set usermods for noresm3 development

### DIFF
--- a/cime_config/usermods_dirs/blom4noresm3-develop/shell_commands
+++ b/cime_config/usermods_dirs/blom4noresm3-develop/shell_commands
@@ -1,0 +1,3 @@
+# Limit the output size/volume for spinup
+./xmlchange BLOM_OUTPUT_SIZE=spinup
+./xmlchange HAMOCC_OUTPUT_SIZE=spinup

--- a/cime_config/usermods_dirs/blom4noresm3-develop/user_nl_blom
+++ b/cime_config/usermods_dirs/blom4noresm3-develop/user_nl_blom
@@ -1,0 +1,39 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of
+!   namelist_var = new_namelist_value
+!
+! NOTE: that it does not matter what namelist group the namelist_var belongs to
+! EXCEPT for when a variable appears in more than one namelist
+! There are a few history variables that have the same name in both diaphy and diabgc
+! For those variables an @diaphy or @diabgc  to be appendend for the namelist_var
+!
+!  GLB_FNAMETAG@diaphy
+!  GLB_AVEPERIO@diaphy
+!  GLB_FILEFREQ@diaphy
+!  GLB_COMPFLAG@diaphy
+!  GLB_NCFORMAT@diaphy
+!  LYR_DP@diaphy">
+!  GLB_FNAMETAG@diabgc
+!  GLB_AVEPERIO@diabgc
+!  GLB_FILEFREQ@diabgc
+!  GLB_COMPFLAG@diabgc
+!  GLB_NCFORMAT@diabgc
+!  LYR_DP@diabgc">
+!
+! For example:
+! GLB_FNAMETAG@diaphy = 'hd','hd','hd'
+!
+! NOTE: the array sections for MER_REGFLG must be entered as
+!   MER_REGFLG1 - sets MER_REGFLG(1,:)
+!   MER_REGFLG2 - sets MER_REGFLG(2,:)
+!   MER_REGFLG3 - sets MER_REGFLG(3,:)
+!   MER_REGFLG4 - sets MER_REGFLG(4,:)
+
+! To see a full documentation of the namelist variables - see $RUNDIR/ocn_in.readme
+!----------------------------------------------------------------------------------
+
+PGFMTH = 'dynamic enthalpy'
+ADVMTH = 'cppm'
+SWAMTH = 'chlorophyll'
+BDMC2 = 1.5e-5
+BDMLDP = .true.


### PR DESCRIPTION
Defining default settings in usermods makes it easier to share within the larger NorESM development team.

This usermods should be linked to a usermod within on the `noresm-develop` branch of NorESM.

To be merged after #546 