### PR TITLE
Set default atm. N2O concentration to pre-industrial value

### DIFF
--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -182,7 +182,7 @@ module mo_param_bgc
   !********************************************************************
 
   real, protected :: atm_n2      = 802000. ! atmosphere dinitrogen concentration
-  real, protected :: atm_n2o     = 300e3   ! atmosphere laughing gas mixing ratio around 1980: 300 ppb,provided in ppt,300ppb = 300e3ppt = 3e-7 mol/mol
+  real, protected :: atm_n2o     = 270.1e3 ! atmosphere N2O conc. pre-industrial: 270.1 (+-6ppb) IPCC 2021, p708, provided in ppt,300ppb = 300e3ppt = 3e-7 mol/mol
   real, protected :: atm_nh3     = 0.      ! Six & Mikolajewicz 2022: less than 1nmol m-3
   real, protected :: atm_o2      = 196800. ! atmosphere oxygen concentration
   real, protected :: atm_co2_nat = 284.32  ! atmosphere CO2 concentration CMIP6 pre-industrial reference


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik , this small PR changes the default atmosphere N2O concentration from formerly ca. 1980 value (300ppb)  to the currently known N2O concentration under pre-industrial state (270.1ppb). 

Individual coupling of N2O and NH3 can be carried out via switches introduced in #537. I am not entirely sure, if distinguishing between prognostic and diagnostic coupling to the atmosphere similar to CO2 makes sense under the current development steps, but I will investigate/discuss this afterward (potentially filing a second PR on this). For now, I feel that for spinups, another atm. N2O is useful, when ocean-only runs shall be later used in coupled simulations under pi-conditions.

Addresses parts of #547. 