### PR TITLE
Correct and add a CaCO3 dissolution rate constant

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4764,6 +4764,16 @@
     <desc>remineralization and dissolution parameter: 1/d Dissolution rate for opal</desc>
   </entry>
 
+  <entry id="dremcalc">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>remineralization and dissolution parameter: 1/d Dissolution rate for CaCO3 (applied if Omega_c lt 1)</desc>
+  </entry>
+
   <entry id="dremn2o">
     <type>real</type>
     <category>bgcparams</category>

--- a/hamocc/mo_carchm.F90
+++ b/hamocc/mo_carchm.F90
@@ -95,15 +95,14 @@ contains
     use mo_control_bgc, only: dtbgc,use_cisonew,use_natDIC,use_CFC,use_BROMO,                      &
                               use_cisonew,use_sedbypass,use_extNcycle
     use mo_param1_bgc,  only: ialkali,iatmo2,iatmco2,iatmdms,iatmn2,iatmn2o,ian2o,icalc,           &
-                              idicsat,idms,igasnit,ioxygen,iphosph,                                &
-                              isco212,isilica,                                                     &
+                              idicsat,idms,igasnit,ioxygen,iphosph,isco212,isilica,                &
                               iatmf11,iatmf12,iatmsf6,icfc11,icfc12,isf6,                          &
                               iatmc13,iatmc14,icalc13,icalc14,idet14,idoc14,iphy14,                &
                               isco213,isco214,izoo14,safediv,                                      &
                               iatmnco2,inatalkali,inatcalc,inatsco212,                             &
                               ks,issso14,isssc14,ipowc14,                                          &
                               iatmbromo,ibromo,iatmnh3,ianh4
-    use mo_param_bgc,   only: srfdic_min,c14dec,atm_co2_nat,atm_n2o
+    use mo_param_bgc,   only: dremcalc,srfdic_min,c14dec,atm_co2_nat,atm_n2o
     use mo_vgrid,       only: dp_min,kmle,kbo,ptiestu
     use mo_carbch,      only: atm_cfc11_nh,atm_cfc11_sh,atm_cfc12_nh,atm_cfc12_sh,                 &
                               atm_sf6_nh,atm_sf6_sh,                                               &
@@ -632,14 +631,14 @@ contains
             OmegaC(i,j,k) = omega / Kspc
             supsat=co3(i,j,k)-co3(i,j,k)/OmegaC(i,j,k)
             undsa=max(0.0,-supsat)
-            dissol=min(undsa,0.05*ocetra(i,j,k,icalc))
+            dissol=min(undsa,dremcalc*ocetra(i,j,k,icalc))
             if (use_natDIC) then
               natomega = ( calcon * s / 35.0 ) * natcc
               natOmegaA(i,j,k) = natomega / Kspa
               natOmegaC(i,j,k) = natomega / Kspc
               natsupsat=natco3(i,j,k)-natco3(i,j,k)/natOmegaC(i,j,k)
               natundsa=max(0.0,-natsupsat)
-              natdissol=min(natundsa,0.05*ocetra(i,j,k,inatcalc))
+              natdissol=min(natundsa,dremcalc*ocetra(i,j,k,inatcalc))
             endif
             if (use_cisonew) then
               dissol13=dissol*ocetra(i,j,k,icalc13)/(ocetra(i,j,k,icalc)+safediv)

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -72,7 +72,7 @@ module mo_param_bgc
   ! Module variables set by bgcparams namelist
   public :: wpoc_const,wcal_const,wopal_const,wdust_const
   public :: bkopal,bkphy,bluefix,bkzoo
-  public :: drempoc,dremopal,dremn2o,dremsul
+  public :: drempoc,dremopal,dremcalc,dremn2o,dremsul
   public :: drempoc_anaerob,bkox_drempoc
   public :: grazra,gammap,gammaz,spemor
   public :: ecan,epsher,fetune
@@ -287,14 +287,15 @@ module mo_param_bgc
   real, parameter :: O2thresh_aerob   = 5.e-8  ! Above O2thresh_aerob aerob remineralization takes place
   real, parameter :: O2thresh_hypoxic = 5.e-7  ! Below O2thresh_hypoxic denitrification and sulfate reduction takes place (default model version)
   real, parameter :: NO3thresh_sulf   = 3.e-6  ! Below NO3thresh_sulf 'sufate reduction' takes place
-  real, protected :: remido     = 0.004        ! 1/d - remineralization rate (of DOM)
+  real, protected :: remido           = 0.004  ! 1/d - remineralization rate (of DOM)
   ! deep sea remineralisation constants
-  real, protected :: drempoc    = 0.025        ! 1/d Aerob remineralization rate detritus
+  real, protected :: drempoc         = 0.025   ! 1/d Aerob remineralization rate detritus
   real, protected :: drempoc_anaerob = 1.25e-3 ! =0.05*drempoc - remin in sub-/anoxic environm. - not be overwritten by M4AGO
   real, protected :: bkox_drempoc    = 1e-7    ! half-saturation constant for oxygen for ammonification (aerobic remin via drempoc)
-  real, protected :: dremopal   = 0.003        ! 1/d Dissolution rate for opal
-  real, protected :: dremn2o    = 0.01         ! 1/d Remineralization rate of detritus on N2O
-  real, protected :: dremsul    = 0.005        ! 1/d Remineralization rate for sulphate reduction
+  real, protected :: dremopal        = 0.003   ! 1/d Dissolution rate for opal
+  real, protected :: dremcalc        = 0.00035 ! 1/d Dissolution rate for CaCO3 (applied if Omega_c < 1)
+  real, protected :: dremn2o         = 0.01    ! 1/d Remineralization rate of detritus on N2O
+  real, protected :: dremsul         = 0.005   ! 1/d Remineralization rate for sulphate reduction
   real, protected :: POM_remin_q10   = 2.1     ! Bidle et al. 2002: Regulation of Oceanic Silicon...
   real, protected :: opal_remin_q10  = 2.6     ! Bidle et al. 2002: Regulation of Oceanic Silicon...
   real, protected :: POM_remin_Tref  = 10.     ! [deg C] reference temperatue for Q10-dep. POC remin
@@ -615,9 +616,9 @@ contains
 
     namelist /bgcparams/ bkphy,dyphy,bluefix,bkzoo,grazra,spemor,gammap,gammaz,  &
                          ecan,zinges,epsher,bkopal,rcalc,ropal,                  &
-                         remido,drempoc,dremopal,dremn2o,dremsul,fetune,relaxfe, &
-                         wmin,wmax,wlin,wpoc_const,wcal_const,wopal_const,       &
-                         disso_poc,disso_sil,disso_caco3,                        &
+                         remido,drempoc,dremopal,dremcalc,dremn2o,dremsul,       &
+                         fetune,relaxfe,wmin,wmax,wlin,wpoc_const,wcal_const,    &
+                         wopal_const,disso_poc,disso_sil,disso_caco3,            &
                          rano3denit,rano2anmx,rano2denit,ran2odenit,rdnra,       &
                          ranh4nitr,rano2nitr,rano3denit_sed,rano2anmx_sed,       &
                          rano2denit_sed,ran2odenit_sed,rdnra_sed,ranh4nitr_sed,  &
@@ -718,6 +719,7 @@ contains
     drempoc  = drempoc*dtb    ! 1/d to 1/time step  Aerob remineralization rate of detritus
     drempoc_anaerob = drempoc_anaerob*dtb ! 1/d Anaerob remin rate of detritus
     dremopal = dremopal*dtb   ! 1/d to 1/time step  Dissolution rate of opal
+    dremcalc = dremcalc*dtb   ! 1/d to 1/time step  Dissolution rate of CaCO3
     dremn2o  = dremn2o*dtb    ! 1/d to 1/time step  Remineralization rate of detritus on N2O
     dremsul  = dremsul*dtb    ! 1/d to 1/time step  Remineralization rate for sulphate reduction
 
@@ -922,6 +924,7 @@ contains
       call pinfo_add_entry('NO3thresh_sulf',  NO3thresh_sulf)
       call pinfo_add_entry('drempoc',     drempoc*dtbinv)
       call pinfo_add_entry('dremopal',    dremopal*dtbinv)
+      call pinfo_add_entry('dremcalc',    dremcalc*dtbinv)
       call pinfo_add_entry('dremn2o',     dremn2o*dtbinv)
       call pinfo_add_entry('dremsul',     dremsul*dtbinv)
       call pinfo_add_entry('bluefix',     bluefix*dtbinv)


### PR DESCRIPTION
This PR fixes the treatment of CaCO3 dissolution in `mo_carchm`. Before, there was a hard-coded dissolution rate of 0.05, but a multiplication with `dtb` was missing. This means effectively that 5% of CaCO3 was dissolved per timestep under undersaturated conditions. The distribution of alkalinity (large positive biases in the deep ocean) points towards this value being much too large. 

To fix these shortcomings and to facilitate tuning, this PR introduces a CaCO3 dissolution constant `dremcalc` that can be set via namelist and is correctly treated w.r.t. time-step length.