### PR TITLE
Allow longer time for 0.5 degree ERS test

### DIFF
--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -107,7 +107,7 @@
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:20:00</option>
+      <option name="wallclock">01:00:00</option>
       <option name="comment">restart test; 0.5 degree; hybrid coordinates; JRA forcing</option>
     </options>
   </test>


### PR DESCRIPTION
The 0.5 degree ERS test sometimes times out before completing.