### PR TITLE
Add options for CMIP6 settings through usermods

### DIFF
--- a/cime_config/usermods_dirs/cmip6_config_tn14/shell_commands
+++ b/cime_config/usermods_dirs/cmip6_config_tn14/shell_commands
@@ -1,0 +1,2 @@
+# configure BLOM/iHAMOCC with CMIP6 settings
+./xmlchange BLOM_UNIT=cgs

--- a/cime_config/usermods_dirs/cmip6_config_tn14/user_nl_blom
+++ b/cime_config/usermods_dirs/cmip6_config_tn14/user_nl_blom
@@ -1,0 +1,12 @@
+!----------------------------------------------------------------------------------
+! configure BLOM/iHAMOCC with CMIP6 settings  - tn14 grid
+!----------------------------------------------------------------------------------
+
+EDANIS = .false.
+EDDF2D = .false.
+EDSPRS = .true.
+RHSCTP = .false.
+EGC = 0.85
+EGMNDF = 100.e4
+EGMXDF = 1500.e4
+RHISCF = 0.

--- a/cime_config/usermods_dirs/cmip6_config_tn21/shell_commands
+++ b/cime_config/usermods_dirs/cmip6_config_tn21/shell_commands
@@ -1,0 +1,2 @@
+# configure BLOM/iHAMOCC with CMIP6 settings
+./xmlchange BLOM_UNIT=cgs

--- a/cime_config/usermods_dirs/cmip6_config_tn21/user_nl_blom
+++ b/cime_config/usermods_dirs/cmip6_config_tn21/user_nl_blom
@@ -1,0 +1,12 @@
+!----------------------------------------------------------------------------------
+! configure BLOM/iHAMOCC with CMIP6 settings  - tn21 grid
+!----------------------------------------------------------------------------------
+
+EDANIS = .false.
+EDDF2D = .false.
+EDSPRS = .true.
+RHSCTP = .false.
+EGC = 0.5
+EGMNDF = 100.e4
+EGMXDF = 1000.e4
+RHISCF = 0.


### PR DESCRIPTION
This PR makes it possible to enable CMIP6 settings for BLOM/iHAMOCC through usermods.

I start including this on the `release-1.6` branch, since this is what is being tested currently for NorESM2.3. If this is accepted, I will enable these usermods, with necessary modifications, for the `v1.7` and `master` branches as well.