### PR TITLE
Add output for dust and soluble iron deposition fluxes

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6496,6 +6496,32 @@
     <desc>NHx nitrogen deposition flux [mol N m-2 s-1] - extended N cycle only</desc>
   </entry>
 
+  <entry id="flx_tdust">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+      <value hamocc_output_size="spinup">2,2</value>
+    </values>
+    <desc>Atmospheric dust deposition flux [kg m-2 s-1]</desc>
+  </entry>
+
+  <entry id="flx_sfe">
+    <type>integer(3)</type>
+    <category>diabgc</category>
+    <group>diabgc</group>
+    <values>
+      <value>0,2,2</value>
+      <value is_test="yes">4,2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
+      <value hamocc_output_size="spinup">2,2</value>
+    </values>
+    <desc>Atmospheric deposition flux of soluble iron [mol Fe m-2 s-1]</desc>
+  </entry>
+
   <entry id="flx_oalk">
     <type>integer(3)</type>
     <category>diabgc</category>

--- a/hamocc/mo_accfields.F90
+++ b/hamocc/mo_accfields.F90
@@ -44,10 +44,10 @@ contains
     use mod_xc,           only: mnproc
     use mod_dia,          only: ddm
     use mo_carbch,        only: atm,atmflx,co2fxd,co2fxu,co3,hi,kwco2sol,                          &
-                                ndepnoyflx,rivinflx,oalkflx,ocetra,omegaa,omegac,fco2,pco2,xco2,   &
-                                pco2_gex,satoxy,sedfluxo,sedfluxb,kwco2a,co2sol,pn2om,             &
-                                co213fxd,co213fxu,co214fxd,co214fxu,                               &
-                                natco3,nathi,natomegaa,natomegac,natpco2,pnh3,ndepnhxflx,          &
+                                ndepnoyflx,ndepnhxflx,dustflx,rivinflx,oalkflx,ocetra,             &
+                                omegaa,omegac,fco2,pco2,xco2,pco2_gex,satoxy,sedfluxo,sedfluxb,    &
+                                kwco2a,co2sol,pn2om,co213fxd,co213fxu,co214fxd,co214fxu,           &
+                                natco3,nathi,natomegaa,natomegac,natpco2,pnh3,                     &
                                 nutlim_diag,inutlim_fe,inutlim_n,inutlim_phosph,zeu_nutlim_diag
     use mo_biomod,        only: bsiflx_bot,bsiflx0100,bsiflx0500,bsiflx1000,                       &
                                 bsiflx2000,bsiflx4000,calflx_bot,calflx0100,calflx0500,            &
@@ -98,8 +98,8 @@ contains
                                 jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                           &
                                 jprefdic,jprefo2,jprefpo4,jsilica,jsrfalkali,                      &
                                 jsrfano3,jsrfdic,jsrfiron,jsrfoxygen,jsrfphosph,                   &
-                                jsrfphyto,jsrfsilica,jsrfph,jwnos,jwphy,jndepnoyfx,                &
-                                joalkfx,nbgc,nacc_bgc,bgcwrt,glb_inventory,                        &
+                                jsrfphyto,jsrfsilica,jsrfph,jwnos,jwphy,jndepnoyfx,jtdustfx,       &
+                                jsfefx,joalkfx,nbgc,nacc_bgc,bgcwrt,glb_inventory,                 &
                                 bgct2d,acclvl,acclyr,accsrf,bgczlv,                                &
                                 jatmbromo,jbromo,jbromo_prod,jbromo_uv,jbromofx,jsrfbromo,         &
                                 jcfc11,jcfc11fx,jcfc12,jcfc12fx,jsf6,jsf6fx,                       &
@@ -146,7 +146,7 @@ contains
     use mo_param1_bgc,    only: ialkali,ian2o,iano3,iatmco2,iatmdms,iatmn2,iatmn2o,iatmo2,         &
                                 icalc,idet,idms,idicsat,idoc,iiron,iopal,itdoc_lc,itdoc_hc,        &
                                 ioxygen,iphosph,iphy,iprefalk,iprefdic,                            &
-                                iprefpo4,iprefo2,isco212,isilica,izoo,                             &
+                                iprefpo4,iprefo2,isco212,isilica,izoo,itdust,isfe,                 &
                                 irdin,irdip,irsi,iralk,iriron,irdoc,irdet,inos,iatmbromo,ibromo,   &
                                 iatmf11,iatmf12,iatmsf6,icfc11,icfc12,isf6,irtdoc,                 &
                                 iatmc13,iatmc14,icalc13,idet13,idoc13,iphy13,isco213,isco214,      &
@@ -340,9 +340,11 @@ contains
       call accsrf(jbromo_uv,int_chbr3_uv,omask,0)
     endif
 
-    ! Accumulate fluxes due to N-deposition, ocean alkalinization
+    ! Accumulate fluxes due to N-deposition, dust fluxes, and ocean alkalinization
     call accsrf(jndepnoyfx,ndepnoyflx,omask,0)
     call accsrf(joalkfx,oalkflx,omask,0)
+    call accsrf(jtdustfx,dustflx(1,1,itdust),omask,0)
+    call accsrf(jsfefx,dustflx(1,1,isfe),omask,0)
 
     if (use_extNcycle) then
       call accsrf(jsrfanh4,ocetra(1,1,1,ianh4),omask,0)

--- a/hamocc/mo_apply_fedep.F90
+++ b/hamocc/mo_apply_fedep.F90
@@ -55,15 +55,18 @@ contains
     real    :: dustinp
 
     ! dust flux from the atmosphere to the surface layer; dust fields are
-    ! monthly mean values (kg/m2/month - assume 30 days per month here)
-    ! dissolved iron is a fixed fraction (typically 3.5%), and immediately released
-
+    ! monthly mean values (kg/m2/month - assume 30 days per month here).
+    ! The iron content of dust is a fixed fraction (typically 3.5%), of 
+    ! which a fixed fraction (typically 1%) is soluble (bioavailable) and immediately 
+    ! released. The bioavailable fraction is perc_diron = fetune * 0.035 * 0.01 / 55.85
+    ! where fetune is intended to globally tune iron deposition and 55.85 is the molar
+    ! weight of Fe.
     !$OMP PARALLEL DO PRIVATE(i,dustinp)
     do j = 1,kpje
       do i = 1,kpie
         if(omask(i,j) > 0.5) then
           dustflx(i,j,itdust)  = dust(i,j) / 30. * dtb / pddpo(i,j,1)
-          dustflx(i,j,isfe)    = dust(i,j) / 30. * dtb / pddpo(i,j,1) * perc_diron
+          dustflx(i,j,isfe)    = dustflx(i,j,itdust) * perc_diron
           ocetra(i,j,1,ifdust) = ocetra(i,j,1,ifdust) + dustflx(i,j,itdust) 
           ocetra(i,j,1,iiron)  = ocetra(i,j,1,iiron)  + dustflx(i,j,isfe)
         endif

--- a/hamocc/mo_apply_fedep.F90
+++ b/hamocc/mo_apply_fedep.F90
@@ -39,9 +39,9 @@ contains
     !--------------------------------------------------------------------------------
 
     use mo_control_bgc, only: dtb
-    use mo_param1_bgc,  only: ifdust,iiron
+    use mo_param1_bgc,  only: ifdust,iiron,itdust,isfe
     use mo_param_bgc,   only: perc_diron
-    use mo_carbch,      only: ocetra
+    use mo_carbch,      only: ocetra,dustflx
 
     integer,intent(in) :: kpie                      ! 1st dimension of model grid.
     integer,intent(in) :: kpje                      ! 2nd dimension of model grid.
@@ -62,9 +62,10 @@ contains
     do j = 1,kpje
       do i = 1,kpie
         if(omask(i,j) > 0.5) then
-          dustinp = dust(i,j) / 30. * dtb / pddpo(i,j,1)
-          ocetra(i,j,1,ifdust) = ocetra(i,j,1,ifdust) + dustinp
-          ocetra(i,j,1,iiron) = ocetra(i,j,1,iiron) + dustinp * perc_diron
+          dustflx(i,j,itdust)  = dust(i,j) / 30. * dtb / pddpo(i,j,1)
+          dustflx(i,j,isfe)    = dust(i,j) / 30. * dtb / pddpo(i,j,1) * perc_diron
+          ocetra(i,j,1,ifdust) = ocetra(i,j,1,ifdust) + dustflx(i,j,itdust) 
+          ocetra(i,j,1,iiron)  = ocetra(i,j,1,iiron)  + dustflx(i,j,isfe)
         endif
       enddo
     enddo

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -117,7 +117,8 @@ module mo_bgcmean
        & SRF_PN2OM     =0    ,SRF_PNH3      =0    ,SRF_ATMNH3    =0    ,  &
        & SRF_ATMN2O    =0    ,INT_BROMOPRO  =0    ,INT_BROMOUV   =0    ,  &
        & INT_PHOSY     =0    ,INT_NFIX      =0    ,INT_DNIT      =0    ,  &
-       & FLX_NDEPNOY   =0    ,FLX_NDEPNHX   =0    ,FLX_OALK      =0    ,  &
+       & FLX_NDEPNOY   =0    ,FLX_NDEPNHX   =0    ,FLX_TDUST     =0    ,  &
+       & FLX_SFE       =0    ,FLX_OALK      =0    ,                       &
        & FLX_CAR0100   =0    ,FLX_CAR0500   =0    ,FLX_CAR1000   =0    ,  &
        & FLX_CAR2000   =0    ,FLX_CAR4000   =0    ,FLX_CAR_BOT   =0    ,  &
        & FLX_BSI0100   =0    ,FLX_BSI0500   =0    ,FLX_BSI1000   =0    ,  &
@@ -243,7 +244,8 @@ module mo_bgcmean
        & SRF_PN2OM         ,SRF_PNH3          ,SRF_ATMNH3        ,        &
        & SRF_ATMN2O        ,INT_BROMOPRO      ,INT_BROMOUV       ,        &
        & INT_PHOSY         ,INT_NFIX          ,INT_DNIT          ,        &
-       & FLX_NDEPNOY       ,FLX_NDEPNHX       ,FLX_OALK          ,        &
+       & FLX_NDEPNOY       ,FLX_NDEPNHX       ,FLX_TDUST         ,        &
+       & FLX_SFE           ,FLX_OALK          ,                           &
        & FLX_CAR0100       ,FLX_CAR0500       ,FLX_CAR1000       ,        &
        & FLX_CAR2000       ,FLX_CAR4000       ,FLX_CAR_BOT       ,        &
        & FLX_BSI0100       ,FLX_BSI0500       ,FLX_BSI1000       ,        &
@@ -415,6 +417,8 @@ module mo_bgcmean
        &          jintdnit   = 0 ,                                        &
        &          jndepnoyfx = 0 ,                                        &
        &          jndepnhxfx = 0 ,                                        &
+       &          jtdustfx   = 0 ,                                        &
+       &          jsfefx     = 0 ,                                        &
        &          joalkfx    = 0 ,                                        &
        &          jcarflx0100= 0 ,                                        &
        &          jcarflx0500= 0 ,                                        &
@@ -876,6 +880,10 @@ CONTAINS
       jintdnit(n)=i_bsc_m2d*min(1,INT_DNIT(n))
       if (FLX_NDEPNOY(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       jndepnoyfx(n)=i_bsc_m2d*min(1,FLX_NDEPNOY(n))
+      if (FLX_TDUST(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jtdustfx(n)=i_bsc_m2d*min(1,FLX_TDUST(n))
+      if (FLX_SFE(n) > 0) i_bsc_m2d=i_bsc_m2d+1
+      jsfefx(n)=i_bsc_m2d*min(1,FLX_SFE(n))
       if (FLX_OALK(n) > 0) i_bsc_m2d=i_bsc_m2d+1
       joalkfx(n)=i_bsc_m2d*min(1,FLX_OALK(n))
       if (FLX_CAR0100(n) > 0) i_bsc_m2d=i_bsc_m2d+1

--- a/hamocc/mo_carbch.F90
+++ b/hamocc/mo_carbch.F90
@@ -52,6 +52,7 @@ module mo_carbch
   real, dimension (:,:),     allocatable, public :: ndepnoyflx
   real, dimension (:,:),     allocatable, public :: ndepnhxflx
   real, dimension (:,:),     allocatable, public :: oalkflx
+  real, dimension (:,:,:),   allocatable, public :: dustflx
   real, dimension (:,:,:),   allocatable, public :: rivinflx
   real, dimension (:,:,:),   allocatable, public :: co3
   real, dimension (:,:,:),   allocatable, public :: co2star
@@ -110,7 +111,7 @@ contains
 
     use mod_xc,         only: mnproc
     use mo_control_bgc, only: io_stdo_bgc
-    use mo_param1_bgc,  only: nocetra,npowtra,nsedtra,natm,nriv
+    use mo_param1_bgc,  only: nocetra,npowtra,nsedtra,natm,nriv,ndust
     use mo_control_bgc, only: use_natDIC,use_cisonew,use_extNcycle
 
     integer, intent(in) :: kpie
@@ -345,7 +346,20 @@ contains
     if(errstat.ne.0) stop 'not enough memory oalkflx'
     oalkflx(:,:) = 0.0
 
-    ! Allocate field to hold riverine fluxes per timestep for inventory calculations
+    ! Allocate field to hold dust and iron fluxes per timestep for 
+    ! output
+    if (mnproc.eq.1) then
+      write(io_stdo_bgc,*)'Memory allocation for variable dustflx ...'
+      write(io_stdo_bgc,*)'First dimension    : ',kpie
+      write(io_stdo_bgc,*)'Second dimension   : ',kpje
+      write(io_stdo_bgc,*)'Third  dimension   : ',ndust
+    endif
+    allocate(dustflx(kpie,kpje,ndust),stat=errstat)
+    if(errstat.ne.0) stop 'not enough memory dustflx'
+    dustflx(:,:,:) = 0.0
+
+    ! Allocate field to hold riverine fluxes per timestep for 
+    ! inventory calculations and output
     if (mnproc.eq.1) then
       write(io_stdo_bgc,*)'Memory allocation for variable rivinflx ...'
       write(io_stdo_bgc,*)'First dimension    : ',kpie

--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -40,7 +40,7 @@ contains
     use mo_vgrid,       only: k0100,k0500,k1000,k2000,k4000
     use mo_param1_bgc,  only: ks
     use mod_nctools,    only: ncwrt1,ncdims,nctime,ncfcls,ncfopn,ncdimc,ncputr,ncputi,ncwrtr
-    use mo_bgcmean,     only: domassfluxes,flx_ndepnoy,flx_oalk,                                   &
+    use mo_bgcmean,     only: domassfluxes,flx_ndepnoy,flx_tdust,flx_sfe,flx_oalk,                 &
                               flx_cal0100,flx_cal0500,flx_cal1000,                                 &
                               flx_cal2000,flx_cal4000,flx_cal_bot,                                 &
                               flx_car0100,flx_car0500,flx_car1000,                                 &
@@ -84,7 +84,7 @@ contains
                               jlvlpoc13,jlvlprefalk,jlvlprefdic,                                   &
                               jlvlprefo2,jlvlprefpo4,jlvlsf6,jlvlsilica,                           &
                               jlvlwnos,jlvlwphy,jn2o,jsrfpn2om,                                    &
-                              jn2ofx,jndepnoyfx,jniflux,jnos,joalkfx,                              &
+                              jn2ofx,jndepnoyfx,jniflux,jnos,jtdustfx,jsfefx,joalkfx,              &
                               jo2sat,jomegaa,jomegac,jopal,joxflux,joxygen,jfco2,                  &
                               jpco2,jxco2,jpco2_gex,jkwco2sol,jco2sol,                             &
                               jph,jphosph,jphosy,jphyto,jpoc,jprefalk,                             &
@@ -615,6 +615,8 @@ contains
     call wrtsrf(jintnfix(iogrp),     INT_NFIX(iogrp),     rnacc*1e3/dtbgc,0.,cmpflg,'nfixint')
     call wrtsrf(jintdnit(iogrp),     INT_DNIT(iogrp),     rnacc*1e3/dtbgc,0.,cmpflg,'dnitint')
     call wrtsrf(jndepnoyfx(iogrp),   FLX_NDEPNOY(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'ndepnoy')
+    call wrtsrf(jtdustfx(iogrp),     FLX_TDUST(iogrp),    rnacc*1e3/dtbgc,0.,cmpflg,'tdustfx')
+    call wrtsrf(jsfefx(iogrp),       FLX_SFE(iogrp),      rnacc*1e3/dtbgc,0.,cmpflg,'sfefx')
     call wrtsrf(joalkfx(iogrp),      FLX_OALK(iogrp),     rnacc*1e3/dtbgc,0.,cmpflg,'oalkfx')
     call wrtsrf(jcarflx0100(iogrp),  FLX_CAR0100(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'carflx0100')
     call wrtsrf(jcarflx0500(iogrp),  FLX_CAR0500(iogrp),  rnacc*1e3/dtbgc,0.,cmpflg,'carflx0500')
@@ -1021,6 +1023,8 @@ contains
     call inisrf(jintnfix(iogrp),0.)
     call inisrf(jintdnit(iogrp),0.)
     call inisrf(jndepnoyfx(iogrp),0.)
+    call inisrf(jtdustfx(iogrp),0.)
+    call inisrf(jsfefx(iogrp),0.)
     call inisrf(joalkfx(iogrp),0.)
     call inisrf(jcarflx0100(iogrp),0.)
     call inisrf(jcarflx0500(iogrp),0.)
@@ -1405,7 +1409,7 @@ contains
                               srf_dms_bac,srf_dms_uv,srf_export,srf_exposi,srf_expoca,             &
                               srf_dic,srf_alkali,srf_phosph,srf_oxygen,srf_ano3,srf_silica,        &
                               srf_iron,srf_phyto,srf_ph,int_phosy,int_nfix,int_dnit,               &
-                              flx_ndepnoy,flx_oalk,flx_car0100,flx_car0500,                        &
+                              flx_ndepnoy,flx_tdust,flx_sfe,flx_oalk,flx_car0100,flx_car0500,      &
                               flx_car1000,flx_car2000,flx_car4000,flx_car_bot,                     &
                               flx_bsi0100,flx_bsi0500,flx_bsi1000,flx_bsi2000,flx_bsi4000,         &
                               flx_bsi_bot,flx_cal0100,flx_cal0500,flx_cal1000,flx_cal2000,         &
@@ -1609,6 +1613,10 @@ contains
          &   'Integrated denitrification',' ','mol N m-2 s-1',0)
     call ncdefvar3d(FLX_NDEPNOY(iogrp),cmpflg,'p','ndepnoy',                    &
          &   'Nitrogen NOy deposition flux',' ','mol N m-2 s-1',0)
+    call ncdefvar3d(FLX_TDUST(iogrp),cmpflg,'p','tdustfx',                      &
+         &   'Atmospheric dust deposition flux',' ','kg m-2 s-1',0)
+    call ncdefvar3d(FLX_SFE(iogrp),cmpflg,'p','sfefx',                          &
+         &   'Atmospheric deposition flux of soluble iron',' ','mol Fe m-2 s-1',0)
     call ncdefvar3d(FLX_OALK(iogrp),cmpflg,'p','oalkfx',                        &
          &   'Alkalinity flux due to OA',' ','mol TA m-2 s-1',0)
     call ncdefvar3d(FLX_CAR0100(iogrp),cmpflg,'p','carflx0100',                 &

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -171,10 +171,16 @@ module mo_param1_bgc
   integer, protected :: idepnoy ! index for NOy deposition
   integer, protected :: idepnhx ! index for NHx deposition
 
+  ! --------------------
+  ! Dust/fe deposition
+  ! --------------------
+  integer, protected :: ndust   ! size of dust deposition input field
+  integer, protected :: itdust  ! total atmospheric dust deposition
+  integer, protected :: isfe    ! atmospheric deposition of soluble Fe
+
   ! ------------------
   ! rivers
   ! ------------------
-
   integer, protected :: nriv   ! size of river input field
   integer, protected :: irdin  ! dissolved inorganic nitrogen
   integer, protected :: irdip  ! dissolved inorganic phosphorous
@@ -492,6 +498,11 @@ contains
       idepnoy = 1
       idepnhx = -1
     endif
+
+    ! Dust/fe
+    ndust  = 2
+    itdust = 1
+    isfe   = 2
 
     ! rivers
     nriv   =8


### PR DESCRIPTION
This PR adds output for the fluxes of total dust and of soluble iron to the surface ocean. It is a first step for introducing a new iron-deposition input data set, that will be done in a separate PR.