### PR TITLE
Fix r2o stoichiometric ratio of riverine labile DOC in mo_apply_rivin

### DIFF
--- a/hamocc/mo_apply_rivin.F90
+++ b/hamocc/mo_apply_rivin.F90
@@ -59,7 +59,7 @@ contains
     !***********************************************************************************************
 
     use mo_control_bgc, only: dtb,do_rivinpt,use_cisonew,use_river2omip
-    use mo_param_bgc,   only: rcar,rcar_tdochc
+    use mo_param_bgc,   only: rcar_tdochc
     use mo_param1_bgc,  only: nriv,irdin,irdip,irsi,iralk,iriron,irdoc,irtdoc,irdet,               &
                               iano3,iphosph,isilica,isco212,iiron,idoc,itdoc_lc,itdoc_hc,idet,     &
                               ialkali,inatsco212,inatalkali,itdoc_lc13,itdoc_hc13,itdoc_lc14,      &

--- a/hamocc/mo_apply_rivin.F90
+++ b/hamocc/mo_apply_rivin.F90
@@ -106,8 +106,7 @@ contains
                    &                             + ocetra(i,j,1:kmle(i,j),isco213)                 &
                    &                             /(ocetra(i,j,1:kmle(i,j),isco212)+safediv)        &
                    &                             * (rivin(i,j,iralk)*fdt/volij                     &
-                   &                             +  rivin(i,j,irdoc)*rcar_tdochc*fdt/volij) ! Alkalinity changes from instantaneous riverine
-                                                                                            ! DOC remineralisation are ignored.
+                   &                             +  rivin(i,j,irdoc)*rcar_tdochc*fdt/volij)
               ocetra(i,j,1:kmle(i,j),isco214)    = ocetra(i,j,1:kmle(i,j),isco214)                 &
                    &                             + ocetra(i,j,1:kmle(i,j),isco214)                 &
                    &                             /(ocetra(i,j,1:kmle(i,j),isco212)+safediv)        &

--- a/hamocc/mo_apply_rivin.F90
+++ b/hamocc/mo_apply_rivin.F90
@@ -59,7 +59,7 @@ contains
     !***********************************************************************************************
 
     use mo_control_bgc, only: dtb,do_rivinpt,use_cisonew,use_river2omip
-    use mo_param_bgc,   only: rcar
+    use mo_param_bgc,   only: rcar,rcar_tdochc
     use mo_param1_bgc,  only: nriv,irdin,irdip,irsi,iralk,iriron,irdoc,irtdoc,irdet,               &
                               iano3,iphosph,isilica,isco212,iiron,idoc,itdoc_lc,itdoc_hc,idet,     &
                               ialkali,inatsco212,inatalkali,itdoc_lc13,itdoc_hc13,itdoc_lc14,      &
@@ -106,13 +106,13 @@ contains
                    &                             + ocetra(i,j,1:kmle(i,j),isco213)                 &
                    &                             /(ocetra(i,j,1:kmle(i,j),isco212)+safediv)        &
                    &                             * (rivin(i,j,iralk)*fdt/volij                     &
-                   &                             +  rivin(i,j,irdoc)*rcar*fdt/volij) ! Alkalinity changes from instantaneous riverine
-                                                                                     ! DOC remineralisation are ignored.
+                   &                             +  rivin(i,j,irdoc)*rcar_tdochc*fdt/volij) ! Alkalinity changes from instantaneous riverine
+                                                                                            ! DOC remineralisation are ignored.
               ocetra(i,j,1:kmle(i,j),isco214)    = ocetra(i,j,1:kmle(i,j),isco214)                 &
                    &                             + ocetra(i,j,1:kmle(i,j),isco214)                 &
                    &                             /(ocetra(i,j,1:kmle(i,j),isco212)+safediv)        &
                    &                             * (rivin(i,j,iralk)*fdt/volij                     &
-                   &                             + rivin(i,j,irdoc)*rcar*fdt/volij)
+                   &                             + rivin(i,j,irdoc)*rcar_tdochc*fdt/volij)
               ocetra(i,j,1:kmle(i,j),itdoc_lc13) = ocetra(i,j,1:kmle(i,j),itdoc_lc13)              &
                                                  + ocetra(i,j,1:kmle(i,j),itdoc_lc13)              &
                                                  /(ocetra(i,j,1:kmle(i,j),itdoc_lc)+safediv)       &
@@ -190,11 +190,11 @@ contains
                  &                           + rivin(i,j,irtdoc)*fdt/volij
             ocetra(i,j,1:kmle(i,j),isco212)  = ocetra(i,j,1:kmle(i,j),isco212)                     &
                  &                           + rivin(i,j,iralk)*fdt/volij                          &
-                 &                           + rivin(i,j,irdoc)*rcar*fdt/volij
+                 &                           + rivin(i,j,irdoc)*rcar_tdochc*fdt/volij
             if (use_natDIC) then
               ocetra(i,j,1:kmle(i,j),inatsco212) = ocetra(i,j,1:kmle(i,j),inatsco212)              &
                    &                             + rivin(i,j,iralk)*fdt/volij                      &
-                   &                             + rivin(i,j,irdoc)*rcar*fdt/volij
+                   &                             + rivin(i,j,irdoc)*rcar_tdochc*fdt/volij
               ocetra(i,j,1:kmle(i,j),inatalkali) = ocetra(i,j,1:kmle(i,j),inatalkali)              &
                    &                             + rivin(i,j,iralk)*fdt/volij
             endif


### PR DESCRIPTION
`rcar` was used for instantaneous remineralisation of labile DOC in `mo_apply_rivin`.

`rcar_tdochc` ( `= 2583.`) should be used for this matter according to R2OMIP protocol.

I also removed a redundant comment, already written further down in `mo_apply_rivin`.