### PR TITLE
Add stream functionality for the new GESAMP dust/iron deposition data set 

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -10049,7 +10049,7 @@
     </desc>
     <values>
       <value hamocc_fedep_source="mahw2006">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_mhw2006_T42.nc</value>
-      <value hamocc_fedep_source="GESAMP2018">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_GESAMP2018_r360x180_20250515.nc</value>
+      <value hamocc_fedep_source="GESAMP2018">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_GESAMP2018_r360x180_20250526.nc</value>
     </values>
   </entry>
   <entry id="stream_dust_varnames">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3967,7 +3967,7 @@
     </values>
     <desc>Source of dust/iron deposition data ('mahw2006' or 'GESAMP2018')</desc>
   </entry>
-  
+
   <entry id="fedepfile">
     <type>char</type>
     <category>bgcnml</category>
@@ -4086,7 +4086,7 @@
     </values>
     <desc>Switch to couple N2O fluxes to atmosphere</desc>
   </entry>
-  
+
   <entry id="do_nh3_coupled" modify_via_xml="HAMOCC_NH3C">
     <type>logical</type>
     <category>bgcnml</category>
@@ -10036,7 +10036,8 @@
     <group>stream_dust</group>
     <desc>stream mesh file</desc>
     <values>
-      <value>$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_mhw2006_T42_ESMFmesh_cdf5.nc</value>
+      <value hamocc_fedep_source="mahw2006">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_mhw2006_T42_ESMFmesh_cdf5.nc</value>
+      <value hamocc_fedep_source="GESAMP2018">/cluster/projects/nn9560k/matsbn/WOA_mesh/WOA_1.00_degree_ESMFmesh_20250506_cdf5.nc</value>
     </values>
   </entry>
   <entry id="stream_dust_data_filename">
@@ -10047,7 +10048,8 @@
       file name(s) containing dust deposition data
     </desc>
     <values>
-      <value>$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_mhw2006_T42.nc</value>
+      <value hamocc_fedep_source="mahw2006">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_mhw2006_T42.nc</value>
+      <value hamocc_fedep_source="GESAMP2018">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_GESAMP2018_r360x180_20250515.nc</value>
     </values>
   </entry>
   <entry id="stream_dust_varname">
@@ -10055,10 +10057,11 @@
     <category>stream_dust</category>
     <group>stream_dust</group>
     <desc>
-      variable name on stream file
+      variable name(s) on stream file
     </desc>
     <values>
-      <value>dustdep</value>
+      <value hamocc_fedep_source="mahw2006">dustdep</value>
+      <value hamocc_fedep_source="GESAMP2018">TFe:LFe</value>
     </values>
   </entry>
   <entry id="stream_dust_year_first">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -10052,12 +10052,12 @@
       <value hamocc_fedep_source="GESAMP2018">$DIN_LOC_ROOT/ocn/blom/bndcon/dustdep_GESAMP2018_r360x180_20250515.nc</value>
     </values>
   </entry>
-  <entry id="stream_dust_varname">
+  <entry id="stream_dust_varnames">
     <type>char</type>
     <category>stream_dust</category>
     <group>stream_dust</group>
     <desc>
-      variable name(s) on stream file
+      variable names as colon deliminted string on stream file
     </desc>
     <values>
       <value hamocc_fedep_source="mahw2006">dustdep</value>

--- a/drivers/nuopc/ocn_stream_dust.F90
+++ b/drivers/nuopc/ocn_stream_dust.F90
@@ -68,7 +68,6 @@ contains
       integer                        :: nfiles
       integer                        :: nf
       integer                        :: errstat
-      integer                        :: ndust
       integer                        :: nfld
       character(*), parameter :: subName = "('ocn_stream_dust_init')"
       !-----------------------------------------------------------------------
@@ -250,7 +249,7 @@ contains
          call ESMF_Finalize(endflag=ESMF_END_ABORT)
       end if
 
-      do nfld = 1, ndust
+      do nfld = 1, size(stream_varnames)
 
          ! Get pointer for stream data that is time and spatially interpolated to model time and grid
          call dshr_fldbun_getFldPtr(sdat_dust%pstrm(1)%fldbun_model, stream_varnames(nfld), fldptr1=dataptr1, rc=rc)

--- a/drivers/nuopc/ocn_stream_dust.F90
+++ b/drivers/nuopc/ocn_stream_dust.F90
@@ -24,9 +24,11 @@ module ocn_stream_dust
    public :: ocn_stream_dust_interp    ! interpolates between two years of dust file data
 
    type(shr_strdata_type) :: sdat_dust ! input data stream
-   character(len=CS)      :: stream_dust_varname='dustdep'
+
+   character(len=CS), allocatable :: stream_varnames(:) ! stream variable names
 
    integer, parameter :: nfiles_max = 100  ! maximum number of stream files
+
    character(len=*), parameter :: sourcefile = &
         __FILE__
 
@@ -41,6 +43,7 @@ contains
       ! Uses
       use shr_nl_mod       , only: shr_nl_find_group_name
       use dshr_strdata_mod , only: shr_strdata_init_from_inline
+      use shr_string_mod   , only: shr_string_listGetNum, shr_string_listGetName
 
       ! input/output variables
       type(ESMF_CLock), intent(in)  :: model_clock
@@ -62,13 +65,16 @@ contains
       integer                        :: nfiles
       integer                        :: nf
       integer                        :: errstat
+      integer                        :: ndust
+      integer                        :: nfld
+      integer                        :: errstat
       character(*), parameter :: subName = "('ocn_stream_dust_init')"
       !-----------------------------------------------------------------------
 
       namelist /stream_dust/           &
            stream_dust_data_filename,  &
            stream_dust_mesh_filename,  &
-           stream_dust_varname,        &
+           stream_dust_varnames,       & ! colon delimited string
            stream_dust_year_first,     &
            stream_dust_year_last,      &
            stream_dust_year_align
@@ -105,10 +111,28 @@ contains
          call xcbcst(stream_dust_data_filename(nf))
       end do
       call xcbcst(stream_dust_mesh_filename)
-      call xcbcst(stream_dust_varname)
+      call xcbcst(stream_dust_varnames)
       call xcbcst(stream_dust_year_first)
       call xcbcst(stream_dust_year_last)
       call xcbcst(stream_dust_year_align)
+
+      ! Determine strearm_dust_varnames array from
+      ! stream_dust_varnames input - where stream_dust_varnames is a
+      ! colon delimited string of variables names
+      ndust = shr_string_listGetNum(stream_dust_varnames)
+      allocate(stream_varnames(ndust))
+      do nfld = 1,ndust
+         call shr_string_listGetName(stream_dust_varnames, nfld, stream_varnames(nfld))
+      end do
+
+      ! Assume order of TFE:LFe for GESAMP2018
+      if (ndust == 2) then
+         if (stream_varnames(1) /= 'TFe' .and. stream_varnames(2) /= 'LFe') then
+            write(lp,'(a)') 'Stream varnames must be TFe:LFe for GESAMP2018'
+            call xchalt(subname)
+            stop subname
+         end if
+      end if
 
       ! Determine the actual number and filenames of stream files that will be used
       nfiles = 0
@@ -139,7 +163,7 @@ contains
             write(lp,'(a,a)' )  '  stream_dust_data_filename('//trim(tmpchar)//') = ',trim(stream_filenames(nf))
          end do
          write(lp,'(a,a)' )  '  stream_dust_mesh_filename = ',trim(stream_dust_mesh_filename)
-         write(lp,'(a,a,a)') '  stream_dust_varname       = ',trim(stream_dust_varname)
+         write(lp,'(a,a,a)') '  stream_dust_varnames      = ',trim(stream_dust_varnames)
          write(lp,'(a,i8)')  '  stream_dust_year_first    = ',stream_dust_year_first
          write(lp,'(a,i8)')  '  stream_dust_year_last     = ',stream_dust_year_last
          write(lp,'(a,i8)')  '  stream_dust_year_align    = ',stream_dust_year_align
@@ -159,8 +183,8 @@ contains
            stream_yearFirst    = stream_dust_year_first,           &
            stream_yearLast     = stream_dust_year_last,            &
            stream_yearAlign    = stream_dust_year_align,           &
-           stream_fldlistFile  = (/stream_dust_varname/),          &
-           stream_fldlistModel = (/stream_dust_varname/),          &
+           stream_fldlistFile  = stream_dust_varnames,             &
+           stream_fldlistModel = stream_dust_varnames,             &
            stream_lev_dimname  = 'null',                           &
            stream_mapalgo      = 'bilinear',                       &
            stream_offset       = 0,                                &
@@ -174,7 +198,11 @@ contains
       end if
 
       ! allocate field to hold dust fields
-      dust_stream(:,:) = 0.0
+      allocate(dust_stream(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,ndust), stat=errstat)
+      if (errstat /= 0) then
+         stop 'not enough memory for dust_stream'
+      end if
+      dust_stream(:,:,:) = 0.0
 
    end subroutine ocn_stream_dust_init
 
@@ -184,6 +212,7 @@ contains
       use dshr_strdata_mod   , only : shr_strdata_advance
       use dshr_methods_mod   , only : dshr_fldbun_getfldptr
       use mod_checksum       , only : csdiag, chksummsk
+      use mo_read_fedep      , only : fedep_source
 
       ! input/output variables
       type(ESMF_Clock), intent(in)  :: model_clock
@@ -219,45 +248,48 @@ contains
          call ESMF_Finalize(endflag=ESMF_END_ABORT)
       end if
 
-      ! Get pointer for stream data that is time and spatially interpolated to model time and grid
-      call dshr_fldbun_getFldPtr(sdat_dust%pstrm(1)%fldbun_model, stream_dust_varname, fldptr1=dataptr1, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
-         call ESMF_Finalize(endflag=ESMF_END_ABORT)
-      end if
+      do n = 1, ndust
 
-      ! Set the j-extent of the local ocean domain to be exchanged. Needed because of
-      ! duplication of the last global domain row when using a tripolar grid.
-      ! dimensions.F is created at build time by the bash script blom_dimensions and contains
-
-      if (nreg == 2 .and. nproc == jpr) then
-         jjcpl = jj - 1
-      else
-         jjcpl = jj
-      endif
-
-      do j = 1, jjcpl
-         do i = 1, ii
-            if (ip(i,j) == 0) then
-               dust_stream(i,j) = mval
-            elseif (cplmsk(i,j) == 0) then
-               dust_stream(i,j) = fval
-            else
-               n = (j - 1)*ii + i
-               dust_stream(i,j) = dataptr1(n)  ! units in file are kg/m2/s
-            end if
-            ! set flux to zero over land
-            if (omask(i,j) < 0.5) then
-               dust_stream(i,j) = 0.0
-            end if
-         end do
-      end do
-
-      if (csdiag) then
-         if (mnproc == 1) then
-            write(lp,*) 'ocn_stream_dust_interp:'
+         ! Get pointer for stream data that is time and spatially interpolated to model time and grid
+         call dshr_fldbun_getFldPtr(sdat_dust%pstrm(1)%fldbun_model, stream_varnames, fldptr1=dataptr1, rc=rc)
+         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+            call ESMF_Finalize(endflag=ESMF_END_ABORT)
          end if
-         call chksummsk(dust_stream,ip,1,'dust_stream')
-      end if
+
+         ! Set the j-extent of the local ocean domain to be exchanged. Needed because of
+         ! duplication of the last global domain row when using a tripolar grid.
+         ! dimensions.F is created at build time by the bash script blom_dimensions and contains
+
+         if (nreg == 2 .and. nproc == jpr) then
+            jjcpl = jj - 1
+         else
+            jjcpl = jj
+         endif
+
+         do j = 1, jjcpl
+            do i = 1, ii
+               if (ip(i,j) == 0) then
+                  dust_stream(i,j,n) = mval
+               elseif (cplmsk(i,j,n) == 0) then
+                  dust_stream(i,j,n) = fval
+               else
+                  n = (j - 1)*ii + i
+                  dust_stream(i,j,n) = dataptr1(n)  ! units in file are kg/m2/s
+               end if
+               ! set flux to zero over land
+               if (omask(i,j) < 0.5) then
+                  dust_stream(i,j,n) = 0.0
+               end if
+            end do
+         end do
+
+         if (csdiag) then
+            if (mnproc == 1) then
+               write(lp,*) 'ocn_stream_dust_interp:'
+            end if
+            call chksummsk(dust_stream,ip,n,'dust_stream')
+         end if
+      end do
 
    end subroutine ocn_stream_dust_interp
 

--- a/hamocc/mo_read_fedep.F90
+++ b/hamocc/mo_read_fedep.F90
@@ -114,21 +114,21 @@ contains
       case('mahw2006')
         ! Dust/iron deposition using the Mahowald et al. 2006 model data.
         ! The variable 'DUST' contains the total dust-flux in kg/m2/month; this
-        ! is converted to kmol fe/m2/s of bioavailable (soluble) iron using the molar 
-        ! weight of iron (mw_fe=55.85) and assuming that dust contains a fraction 
-        ! 'frac_ironindust' of iron, and that soluble iron is a fraction 'frac_soliron' of 
+        ! is converted to kmol fe/m2/s of bioavailable (soluble) iron using the molar
+        ! weight of iron (mw_fe=55.85) and assuming that dust contains a fraction
+        ! 'frac_ironindust' of iron, and that soluble iron is a fraction 'frac_soliron' of
         ! total iron. A tuning factor 'fetune' is applied to the soluble fraction of iron.
-        ! Note the conversion kg/m2/month -> kg/m2/s is assuming 30 days per month.	  
+        ! Note the conversion kg/m2/month -> kg/m2/s is assuming 30 days per month.
         call read_netcdf_var(ncid,'DUST',dustflx_tot(1,1,1),12,0,0)
         dustflx_tot(:,:,:) = dustflx_tot(:,:,:)/30.0/sec_per_day
         dustflx_sfe(:,:,:) = dustflx_tot(:,:,:)*frac_ironindust*frac_soliron/mw_fe*fetune
 
       case('GESAMP2018')
         ! Iron deposition using data from the GESAMP atmospheric iron deposition
-        ! model intercomparison study (Myriokefalitakis et al. 2018, 
+        ! model intercomparison study (Myriokefalitakis et al. 2018,
         ! doi:10.5194/bg-15-6659-2018).
-        ! The variables 'TFe' and 'LFe' contain the total and soluble (labile) iron 
-        ! fluxes in kg/m2/s; soluble iron is converted to kmol Fe/m2/s using the molar weight of   
+        ! The variables 'TFe' and 'LFe' contain the total and soluble (labile) iron
+        ! fluxes in kg/m2/s; soluble iron is converted to kmol Fe/m2/s using the molar weight of
         ! iron (mw_fe=55.85). A tuning factor 'fetune' is applied to the soluble fraction of iron.
         ! The total dust-flux is 'back-calculated' from total iron assuming a fixed fraction
         ! of iron in dust.
@@ -195,26 +195,35 @@ contains
     integer,        intent(in)  :: kbnd                   ! nb of halo-rows
     integer,        intent(in)  :: kplmon                 ! current month.
     real,           intent(out) :: dust(kpie,kpje,ndust)  ! dust/sFe flux for current month
-    real, optional, intent(in)  :: dust_stream(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)
-    !real, optional, intent(in)  :: dust_stream(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,ndust)
+    real, optional, intent(in)  :: dust_stream(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,ndust)
 
-    integer :: i,j
+    integer :: i,j,n
     logical :: debug = .true.
     logical :: first_time = .true.
 
     if (present(dust_stream)) then
-    
+
       select case(trim(fedep_source))
 
         case('mahw2006')
           do j=1,kpje
             do i=1,kpie
               ! note that the stream is read from a file where units already are in kg/m2/s
-              dust(i,j,itdust) = dust_stream(i,j)  
-              dust(i,j,isfe)   = dust_stream(i,j)*frac_ironindust*frac_soliron/mw_fe*fetune
+              dust(i,j,itdust) = dust_stream(i,j,1)
+              dust(i,j,isfe)   = dust_stream(i,j,1)*frac_ironindust*frac_soliron/mw_fe*fetune
             end do
           end do
-       
+
+        case('GESAMP2018')
+          do
+          do j=1,kpje
+            do i=1,kpie
+              ! note that the stream is read from a file where units already are in kg/m2/s
+              dust(i,j,itdust) = dust_stream(i,j,1)
+              dust(i,j,isfe)   = dust_stream(i,j,2)*frac_ironindust*frac_soliron/mw_fe*fetune
+            end do
+          end do
+
         case default
           if (mnproc==1) then
             call xchalt('(get_fedep: invalid fedep_source for dust stream)')
@@ -222,7 +231,7 @@ contains
           end if
 
       end select
-       
+
     else
       dust(:,:,itdust) = dustflx_tot(:,:,kplmon)
       dust(:,:,isfe)   = dustflx_sfe(:,:,kplmon)

--- a/hamocc/mo_read_fedep.F90
+++ b/hamocc/mo_read_fedep.F90
@@ -218,8 +218,8 @@ contains
           do j=1,kpje
             do i=1,kpie
               ! note that the stream is read from a file where units already are in kg/m2/s
-              dust(i,j,itdust) = dust_stream(i,j,1)
-              dust(i,j,isfe)   = dust_stream(i,j,2)*frac_ironindust*frac_soliron/mw_fe*fetune
+              dust(i,j,itdust) = dust_stream(i,j,1)/frac_ironindust
+              dust(i,j,isfe)   = dust_stream(i,j,2)/mw_fe*fetune
             end do
           end do
 
@@ -238,7 +238,8 @@ contains
 
     if (debug) then
        if (first_time) then
-          call output_forcing('fedep.nc', 'fedep', kpie, kpje, dust)
+          call output_forcing('dustflx_tot.nc', 'dustflx_tot', kpie, kpje, dust(:,:,itdust))
+          call output_forcing('dustflx_sfe.nc', 'dustflx_sfe', kpie, kpje, dust(:,:,isfe))
           first_time = .false.
        end if
     end if

--- a/hamocc/mo_read_fedep.F90
+++ b/hamocc/mo_read_fedep.F90
@@ -215,7 +215,6 @@ contains
           end do
 
         case('GESAMP2018')
-          do
           do j=1,kpje
             do i=1,kpie
               ! note that the stream is read from a file where units already are in kg/m2/s

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -102,10 +102,9 @@ module mod_forcing
 
    logical :: use_stream_relaxation ! If true, use nuopc stream relaxation capability
 
-   real(r8), dimension(1 - nbdy:idm + nbdy, 1 - nbdy:jdm + nbdy) :: &
-        dust_stream              ! iron dust deposition flux (hamocc)
+   ! Allocate dust_stream in ocn_stream_dust.F90
+   real(r8), allocatable  :: dust_stream(:,:,:) ! iron dust deposition flux (hamocc)
    logical :: use_stream_dust    ! If true, use nuopc stream dust capability (hamocc only)
-
 
    ! Variables related to balancing the freshwater forcing budget.
    real(r8) :: &


### PR DESCRIPTION
This PR implements #581 
- I have converted the lons in dustdep_GESAMP2018_r360x180_20250515.nc to be -180->180 and created a new file with this dustdep_GESAMP2018_r360x180_20250526.nc. This permitted the plots below for dustflx_tot and dustflx_sfe to look reasonable.
- Successfully ran using noresm3_0_alpha03c:
```
- ERS_D_Ld3.T62_tn14.NOINYOC.betzy_gnu
- SMS_D_Ld1.T62_tn14.NOINYOC.betzy_intel
```