### PR TITLE
Various small fixes on the river2omip feature

### DIFF
--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -476,7 +476,7 @@ contains
                                   + zocetratot(itdoc_hc)*roxy_tdochc
         totalphos   = totalphos   + zocetratot(itdoc_lc) + zocetratot(itdoc_hc)
 
-        totalcarbon = totalcarbon- srivflux(irdoc)*rcar-srivflux(irtdoc)*rcar_tdochc               &
+        totalcarbon = totalcarbon- (srivflux(irdoc)+srivflux(irtdoc))*rcar_tdochc                  &
              &                   - srivflux(irdet)*rcar_tdoclc                                     &
              &                   - srivflux(iralk) ! no DIN & DIP substraction because alkalinity
                                                    ! changes due to instantaneous remineralisation 

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -807,11 +807,9 @@ contains
               endif
 
               if (use_river2omip) then
-                tdoclc_rem = rem_tdoclc*ocetra(i,j,k,itdoc_lc)
-                tdochc_rem = rem_tdochc*ocetra(i,j,k,itdoc_hc)
-                tdoclc_rem = min(rem_tdoclc*ocetra(i,j,k,idoc), 0.33*ocetra(i,j,k,ioxygen)         &
+                tdoclc_rem = min(rem_tdoclc*ocetra(i,j,k,itdoc_lc), 0.33*ocetra(i,j,k,ioxygen)     &
                            & /merge(ro2utammo_tdoclc,ro2ut_tdoclc,use_extNcycle))
-                tdochc_rem = min(rem_tdochc*ocetra(i,j,k,idoc), 0.33*ocetra(i,j,k,ioxygen)         &
+                tdochc_rem = min(rem_tdochc*ocetra(i,j,k,itdoc_hc), 0.33*ocetra(i,j,k,ioxygen)     &
                            & /merge(ro2utammo_tdochc,ro2ut_tdochc,use_extNcycle)) 
                 ocetra(i,j,k,itdoc_lc) = ocetra(i,j,k,itdoc_lc) - tdoclc_rem
                 ocetra(i,j,k,itdoc_hc) = ocetra(i,j,k,itdoc_hc) - tdochc_rem


### PR DESCRIPTION
In `mo_inventory_bgc.F90`, use the high-carbon C:P ratio for DOC conversion, as describe in the R2OMIP protocol.

In 'mo_ocprod.F90', remove useless lines 810-811 and use the proper `tDOC` species in remineralisation terms, instead of `DOC`.
