### PR TITLE
Change name convention for inventory output file

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -3,7 +3,7 @@
     <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rbgc</rest_file_extension>
     <hist_file_extension>h[dmy]\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>hbgc[dmy]\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>hbgc[idmy]\d*.*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -809,6 +809,9 @@ CONTAINS
       endif
     enddo
 
+    ! Only allow inventory output to netcdf file at one interval
+    call check_glb_inventory(glb_inventory,nbgc)
+
     ! Re-define index variables according to namelist
     i_bsc_m2d=0
     do n=1,nbgc
@@ -2731,5 +2734,35 @@ CONTAINS
     !$OMP END PARALLEL DO
     !
   end subroutine bgczlv
+
+  subroutine check_glb_inventory(glb_inventory,nbgc)
+    !
+    ! --- ------------------------------------------------------------------
+    ! --- Description: check that we only write invetory to netcdf file at
+    ! ---              a single time interval, set by glb_inventory(n) == 2.
+    ! ---              If there are multiple instances where glb_inventory
+    ! ---              is 2, keep only the first instance.
+    ! --- ------------------------------------------------------------------
+
+    ! Arguments
+    integer, intent(inout) :: glb_inventory(nbgcmax)
+    integer, intent(in)    :: nbgc
+    !
+    ! Local variables
+    integer :: i,maxval_glb_inventory, maxloc_glb_inventory
+
+    maxval_glb_inventory = maxval(glb_inventory)
+    if (max_glb_inventory == 2) then
+       maxloc_glb_inventory = maxloc(glb_inventory)
+       if (maxloc_glb_inventory < nbgc) then
+          ! Set subsequent instances of glb_inventory to max 1
+          do i=maxloc_glb_inventory+1,nbgc
+             if (glb_inventory(i) == 2) then
+                glb_inventory(i) = 1
+             endif
+          enddo
+       endif
+    endif
+  end subroutine check_glb_inventory
 
 end module mo_bgcmean

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -2738,7 +2738,7 @@ CONTAINS
   subroutine check_glb_inventory(glb_inventory,nbgc)
     !
     ! --- ------------------------------------------------------------------
-    ! --- Description: check that we only write invetory to netcdf file at
+    ! --- Description: check that we only write inventory to netcdf file at
     ! ---              a single time interval, set by glb_inventory(n) == 2.
     ! ---              If there are multiple instances where glb_inventory
     ! ---              is 2, keep only the first instance.

--- a/hamocc/mo_bgcmean.F90
+++ b/hamocc/mo_bgcmean.F90
@@ -2752,8 +2752,8 @@ CONTAINS
     integer :: i,maxval_glb_inventory, maxloc_glb_inventory
 
     maxval_glb_inventory = maxval(glb_inventory)
-    if (max_glb_inventory == 2) then
-       maxloc_glb_inventory = maxloc(glb_inventory)
+    if (maxval_glb_inventory == 2) then
+       maxloc_glb_inventory = maxloc(glb_inventory, 1)
        if (maxloc_glb_inventory < nbgc) then
           ! Set subsequent instances of glb_inventory to max 1
           do i=maxloc_glb_inventory+1,nbgc

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -743,8 +743,8 @@ contains
                                nf90_put_att, nf90_put_var, nf90_unlimited, nf90_write
       use mod_types,     only: r8
       use mod_config,    only: expcnf, runid, inst_suffix
-      use mod_time,      only: date0, time0, date, time, nstep, nday_of_year,nstep_in_day,calendar &
-                               blom_time
+      use mod_time,      only: date0, time0, date, time, nstep, nday_of_year, nstep_in_day,        &
+                               calendar, blom_time
       use mo_bgcmean,    only: filefq_bgc, fileann_bgc, filemon_bgc,glb_fnametag
       use mo_param1_bgc, only: idicsat,idms,ifdust,iiron,iprefalk,iprefdic,iprefo2,iprefpo4,       &
                                iadust,inos,ibromo,icfc11,icfc12,isf6,icalc13,icalc14,idet13,       &

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -904,7 +904,7 @@ contains
         call blom_time(ymd, tod)
         write(tstamp,'(i4.4,a1,i2.2,a1,i2.2,a1,i5.5)')                            &
              &    date%year,sep2,date%month,sep2,date%day,sep2,tod
-        fname_inv(iogrp) = prefix//sep1//'bgci'//sep1//trim(tstamp)//'.nc'
+        fname_inv(iogrp) = prefix//sep1//'hbgci'//sep1//trim(tstamp)//'.nc'
 
         !--- create a new netCDF file
         write(io_stdo_bgc,*) 'Create BGC inventory file : ',trim(fname_inv(iogrp))

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -743,7 +743,8 @@ contains
                                nf90_put_att, nf90_put_var, nf90_unlimited, nf90_write
       use mod_types,     only: r8
       use mod_config,    only: expcnf, runid, inst_suffix
-      use mod_time,      only: date0, time0, date, time, nstep, nday_of_year,nstep_in_day,calendar
+      use mod_time,      only: date0, time0, date, time, nstep, nday_of_year,nstep_in_day,calendar &
+                               blom_time
       use mo_bgcmean,    only: filefq_bgc, fileann_bgc, filemon_bgc,glb_fnametag
       use mo_param1_bgc, only: idicsat,idms,ifdust,iiron,iprefalk,iprefdic,iprefo2,iprefpo4,       &
                                iadust,inos,ibromo,icfc11,icfc12,isf6,icalc13,icalc14,idet13,       &
@@ -770,6 +771,7 @@ contains
       character(len=20) :: tstamp
       character(len=30) :: timeunits
       integer :: l
+      integer :: ymd, tod           ! used to access blom_time
       real(r8) :: datenum
 
       !=== Variables for netcdf
@@ -899,9 +901,10 @@ contains
           sep1='_'
           sep2='.'
         endif
-        write(tstamp,'(i4.4,a1,i2.2,a1,i2.2)')                                    &
-             &    date%year,sep2,date%month,sep2,date%day
-        fname_inv(iogrp) = prefix//sep1//'hbgci'//sep1//trim(tstamp)//'.nc'
+        call blom_time(ymd, tod)
+        write(tstamp,'(i4.4,a1,i2.2,a1,i2.2,a1,i5.5)')                            &
+             &    date%year,sep2,date%month,sep2,date%day,sep2,tod
+        fname_inv(iogrp) = prefix//sep1//'bgci'//sep1//trim(tstamp)//'.nc'
 
         !--- create a new netCDF file
         write(io_stdo_bgc,*) 'Create BGC inventory file : ',trim(fname_inv(iogrp))

--- a/hamocc/mo_inventory_bgc.F90
+++ b/hamocc/mo_inventory_bgc.F90
@@ -901,8 +901,7 @@ contains
         endif
         write(tstamp,'(i4.4,a1,i2.2,a1,i2.2)')                                    &
              &    date%year,sep2,date%month,sep2,date%day
-        fname_inv(iogrp) = prefix//sep1//trim(glb_fnametag(iogrp))//sep1//        &
-             &    'i'//sep1//trim(tstamp)//'.nc'
+        fname_inv(iogrp) = prefix//sep1//'hbgci'//sep1//trim(tstamp)//'.nc'
 
         !--- create a new netCDF file
         write(io_stdo_bgc,*) 'Create BGC inventory file : ',trim(fname_inv(iogrp))


### PR DESCRIPTION
In this PR I assume we only want to write netcdf output at a single time interval, and prioritize the highest frequency, i.e. 'daily' > 'monthly' > 'yearly', and therefore that we only have one set of output files.

I have not tried to implement writing netcdf output at a time step frequency at this stage.

Closes #586 