### PR TITLE
Fix externals.cfg file for GSW-Fortran

### DIFF
--- a/Externals_BLOM.cfg
+++ b/Externals_BLOM.cfg
@@ -5,12 +5,20 @@ repo_url = https://github.com/CVMix/CVMix-src
 local_path = pkgs/CVMix-src
 required = True
 
+[GSW]
+branch = master
+protocol = git
+repo_url = https://github.com/TEOS-10/GSW-Fortran
+local_path = pkgs/GSW-Fortran
+
 [M4AGO]
 tag = v1.1.1
 protocol = git
 repo_url = https://github.com/jmaerz/M4AGO-sinking-scheme
 local_path = pkgs/M4AGO-sinking-scheme
 required = True
+
+
 
 [externals_description]
 schema_version = 1.0.0

--- a/Externals_BLOM.cfg
+++ b/Externals_BLOM.cfg
@@ -10,6 +10,7 @@ branch = master
 protocol = git
 repo_url = https://github.com/TEOS-10/GSW-Fortran
 local_path = pkgs/GSW-Fortran
+required = True
 
 [M4AGO]
 tag = v1.1.1

--- a/Externals_BLOM.cfg
+++ b/Externals_BLOM.cfg
@@ -19,7 +19,5 @@ repo_url = https://github.com/jmaerz/M4AGO-sinking-scheme
 local_path = pkgs/M4AGO-sinking-scheme
 required = True
 
-
-
 [externals_description]
 schema_version = 1.0.0


### PR DESCRIPTION
Hi @TomasTorsvik  and @matsbn, this short snippet fixes a backwards compatibility of master with NorESM-release version 2.1.3. I just used the information from the `.submodules`-file as adjusted for git-fleximod. 