### PR TITLE
fixed dust issue where it was growing each year

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -10081,7 +10081,7 @@
       First year in stream to use
     </desc>
     <values>
-      <value>1</value>
+      <value>1850</value>
     </values>
   </entry>
   <entry id="stream_dust_year_last">
@@ -10103,7 +10103,7 @@
       Align stream_year_first with this model year
     </desc>
     <values>
-      <value>1850</value>
+      <value>1</value>
     </values>
   </entry>
 

--- a/drivers/nuopc/ocn_stream_dust.F90
+++ b/drivers/nuopc/ocn_stream_dust.F90
@@ -15,6 +15,7 @@ module ocn_stream_dust
    use mod_forcing       , only : dust_stream
    use mo_intfcblom      , only : omask
    use mod_config        , only : inst_suffix
+   use mod_fill_global   , only : fill_global
    use mod_xc
 
    implicit none
@@ -249,6 +250,8 @@ contains
          call ESMF_Finalize(endflag=ESMF_END_ABORT)
       end if
 
+      ! Set to unreasonable value to catch errors
+      dust_stream(:,:,:) = 1.e30
       do nfld = 1, size(stream_varnames)
 
          ! Get pointer for stream data that is time and spatially interpolated to model time and grid
@@ -283,6 +286,8 @@ contains
                end if
             end do
          end do
+
+         call fill_global(mval, fval, halo_ps, dust_stream(1-nbdy,1-nbdy,nfld))
 
          if (csdiag) then
             if (mnproc == 1) then


### PR DESCRIPTION
These changes fixes the problem found by @JorgSchwinger in  issue #594. 
The key problem was the settings for stream_dust_year_first and stream_dust_year_align in namelist_definition_blom.xml.
Testing: I have verified that running his case for 2 years gives the same field for tfluxdst in month 3 of year 2 versus month 3 of year 1.