### PR TITLE
Fixes an issue with truncated model depth when using WOA initial conditions.

### DIFF
--- a/phy/mod_inicon.F90
+++ b/phy/mod_inicon.F90
@@ -467,7 +467,6 @@ contains
         ! Create source arrays of practical salinity (sp_src), potential
         ! temperature (pt_src) and source interface depths bounded by model
         ! depth (z_src). Fill remaining missing values from above.
-        z_src(1) = z_src_ref(1)
         do k = 1, kdm_woa
           if (t_woa(i,j,k) /= t_woa_fval .and. &
               t_woa(i,j,k) /= t_woa_mval .and. &
@@ -481,13 +480,16 @@ contains
             sp_src(k) = sp_src(k-1)
             pt_src(k) = pt_src(k-1)
           endif
-          z_src(k+1) = max(z_src_ref(k+1), - depths(i,j))
+          z_src(k) = max(z_src_ref(k), - depths(i,j))
         enddo
+        z_src(kdm_woa+1) = - depths(i,j)
 
         ! Bound destination interface depths by model depth.
-        do k = 1, kk+1
+        do k = 1, kk
           z_dst(k) = max(z_dst_ref(k), - depths(i,j))
         enddo
+         z_dst(kk+1) = - depths(i,j)
+
 
         ! Prepare vertical reconstruction and remapping.
 

--- a/phy/mod_inicon.F90
+++ b/phy/mod_inicon.F90
@@ -488,8 +488,7 @@ contains
         do k = 1, kk
           z_dst(k) = max(z_dst_ref(k), - depths(i,j))
         enddo
-         z_dst(kk+1) = - depths(i,j)
-
+        z_dst(kk+1) = - depths(i,j)
 
         ! Prepare vertical reconstruction and remapping.
 


### PR DESCRIPTION
This PR fixes a bug that caused the model depth to be truncated when the model depth was deeper than the World Ocean Atlas depth range (5500 m).