### PR TITLE
Add more efficient PE-layout for NOIIAJRA compsets

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -281,8 +281,8 @@
   <!-- 512 pes is minimum setting for normal job size on betzy !-->
   <grid name="a%TL319.+oi%tnx1v4">
     <mach name="betzy">
-      <pes pesize="L" compset="any">
-        <comment>Large pe-layout with 512 pes in total</comment>
+      <pes pesize="M" compset="any">
+        <comment>Medium pe-layout with 512 pes in total</comment>
         <ntasks>
           <ntasks_atm>128</ntasks_atm>
           <ntasks_rof>128</ntasks_rof>
@@ -311,6 +311,44 @@
           <rootpe_ocn>128</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  
+  <grid name="a%TL319.+oi%tnx1v4">
+    <mach name="betzy">
+      <pes pesize="L" compset="any">
+        <comment>Large pe-layout with 640 pes in total</comment>
+        <ntasks>
+          <ntasks_atm>80</ntasks_atm>
+          <ntasks_rof>80</ntasks_rof>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>431</ntasks_ocn>
+          <ntasks_cpl>209</ntasks_cpl>
+          <ntasks_lnd>80</ntasks_lnd>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>129</rootpe_atm>
+          <rootpe_lnd>129</rootpe_lnd>
+          <rootpe_rof>129</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>209</rootpe_ocn>
+          <rootpe_glc>128</rootpe_glc>
+          <rootpe_wav>128</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>


### PR DESCRIPTION
This PR adds a more efficient PE layout for compsets using the JRA forcing. Although it uses 1 core more (on betzy) it even is more efficient in terms of PE hours/simulated year than the current default. 

current default:
```
  Overall Metrics: 
    Model Cost:             874.01   pe-hrs/simulated_year 
    Model Throughput:        14.06   simulated_years/day 

    Init Time   :     154.391 seconds 
    Run Time    :    6145.382 seconds       16.837 seconds/day 
    Final Time  :       0.831 seconds 


Runs Time in total seconds, seconds/model-day, and model-years/wall-day 
CPL Run Time represents time in CPL pes alone, not including time associated with data exchange with other components 

    TOT Run Time:    6145.382 seconds       16.837 seconds/mday        14.06 myears/wday 
    CPL Run Time:     747.981 seconds        2.049 seconds/mday       115.51 myears/wday 
    ATM Run Time:     256.908 seconds        0.704 seconds/mday       336.31 myears/wday 
    LND Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    ICE Run Time:    1535.587 seconds        4.207 seconds/mday        56.27 myears/wday 
    OCN Run Time:    5095.236 seconds       13.960 seconds/mday        16.96 myears/wday 
    ROF Run Time:      31.168 seconds        0.085 seconds/mday      2772.07 myears/wday 
    GLC Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    WAV Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    ESP Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    CPL COMM Time:   1770.220 seconds        4.850 seconds/mday        48.81 myears/wday 
```

new PE-layout:
```
  Overall Metrics: 
    Model Cost:             851.61   pe-hrs/simulated_year 
    Model Throughput:        18.04   simulated_years/day 

    Init Time   :     149.088 seconds 
    Run Time    :    4790.319 seconds       13.124 seconds/day 
    Final Time  :       0.837 seconds 


Runs Time in total seconds, seconds/model-day, and model-years/wall-day 
CPL Run Time represents time in CPL pes alone, not including time associated with data exchange with other components 

    TOT Run Time:    4790.319 seconds       13.124 seconds/mday        18.04 myears/wday 
    CPL Run Time:     582.272 seconds        1.595 seconds/mday       148.38 myears/wday 
    ATM Run Time:     243.015 seconds        0.666 seconds/mday       355.53 myears/wday 
    LND Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    ICE Run Time:    1318.291 seconds        3.612 seconds/mday        65.54 myears/wday 
    OCN Run Time:    3873.763 seconds       10.613 seconds/mday        22.30 myears/wday 
    ROF Run Time:      32.323 seconds        0.089 seconds/mday      2673.01 myears/wday 
    GLC Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    WAV Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    ESP Run Time:       0.000 seconds        0.000 seconds/mday         0.00 myears/wday 
    CPL COMM Time:   1892.499 seconds        5.185 seconds/mday        45.65 myears/wday 
```
The new PE-layout can be activated with `--pecount L`  in the `create_newcase` command
