### PR TITLE
Adding heat flux due to material enthalpy flux of water exchange with atmosphere

### DIFF
--- a/cesm/mod_cesm.F90
+++ b/cesm/mod_cesm.F90
@@ -28,10 +28,11 @@ module mod_cesm
    use mod_constants,  only: pi
    use mod_time,       only: nstep
    use mod_xc
-   use mod_forcing,    only: trxday, srxday, swa, nsf, lip, sop, eva, rnf, rfi, &
-                             fmltfz, sfl, ztx, mty, ustarw, slp, abswnd, &
-                             lamult, lasl, ustokes, vstokes, atmco2, atmbrf, &
-                             flxdms, flxbrf, &
+   use mod_forcing,    only: trxday, srxday, swa, nsf, hmat, &
+                             lip, sop, eva, rnf, rfi, fmltfz, sfl, &
+                             ztx, mty, ustarw, slp, abswnd, &
+                             lamult, lasl, ustokes, vstokes, &
+                             atmco2, atmbrf, flxdms, flxbrf, &
                              atmn2o, atmnh3, atmnhxdep, atmnoydep, &
                              use_stream_relaxation
    use mod_ben02,      only: initai, rdcsic, rdctsf, fnlzai
@@ -66,6 +67,7 @@ module mod_cesm
    real(r8), dimension(1 - nbdy:idm + nbdy,1 - nbdy:jdm + nbdy, 2) :: &
       swa_da, &          ! Solar heat flux [W m-2].
       nsf_da, &          ! Non-solar heat flux [W m-2].
+      hmat_da, &         ! surf.mat.enth.flx
       hmlt_da, &         ! Heat flux due to melting [W m-2].
       lip_da, &          ! Liquid water flux [kg m-2 s-1].
       sop_da, &          ! Solid precipitation [kg m-2 s-1].
@@ -101,11 +103,12 @@ module mod_cesm
       l1ci, l2ci         ! Time-level indices for time smoothing of CESM fields.
 
    public :: runid_cesm, runtyp_cesm, ocn_cpl_dt_cesm, nstep_in_cpl, hmlt, &
-             frzpot, mltpot, swa_da, nsf_da, hmlt_da, lip_da, sop_da, eva_da, &
-             rnf_da, rfi_da, fmltfz_da, sfl_da, ztx_da, mty_da, ustarw_da, &
-             slp_da, abswnd_da, ficem_da, lamult_da, lasl_da, flxdms_da, flxbrf_da, &
-             ustokes_da, vstokes_da, atmco2_da, atmbrf_da,atmn2o_da,atmnh3_da,&
-             atmnhxdep_da,atmnoydep_da, &
+             frzpot, mltpot, swa_da, nsf_da, hmat_da, hmlt_da, &
+             lip_da, sop_da, eva_da, rnf_da, rfi_da, fmltfz_da, sfl_da, &
+             ztx_da, mty_da, ustarw_da, slp_da, abswnd_da, ficem_da, &
+             lamult_da, lasl_da, flxdms_da, flxbrf_da, ustokes_da, vstokes_da, &
+             atmco2_da, atmbrf_da, atmn2o_da, atmnh3_da, &
+             atmnhxdep_da, atmnoydep_da, &
              smtfrc, l1ci, l2ci,inicon_cesm, inifrc_cesm, getfrc_cesm
 
 contains
@@ -188,6 +191,7 @@ contains
            sfl(i, j)     = w1*sfl_da(i, j, l1ci)     + w2*sfl_da(i, j, l2ci)
            swa(i, j)     = w1*swa_da(i, j, l1ci)     + w2*swa_da(i, j, l2ci)
            nsf(i, j)     = w1*nsf_da(i, j, l1ci)     + w2*nsf_da(i, j, l2ci)
+           hmat(i, j)    = w1*hmat_da(i, j, l1ci)    + w2*hmat_da(i, j, l2ci)
            hmlt(i, j)    = w1*hmlt_da(i, j, l1ci)    + w2*hmlt_da(i, j, l2ci)
            slp(i, j)     = w1*slp_da(i, j, l1ci)     + w2*slp_da(i, j, l2ci)
            abswnd(i, j)  = w1*abswnd_da(i, j, l1ci)  + w2*abswnd_da(i, j, l2ci)
@@ -231,6 +235,7 @@ contains
         call ncdefvar('sfl_da', 'x y', ndouble, 8)
         call ncdefvar('swa_da', 'x y', ndouble, 8)
         call ncdefvar('nsf_da', 'x y', ndouble, 8)
+        call ncdefvar('hmat_da', 'x y', ndouble, 8)
         call ncdefvar('hmlt_da', 'x y', ndouble, 8)
         call ncdefvar('slp_da', 'x y', ndouble, 8)
         call ncdefvar('abswnd_da', 'x y', ndouble, 8)
@@ -268,6 +273,8 @@ contains
         call ncwrtr('swa_da', 'x y', swa_da(1 - nbdy, 1 - nbdy, l2ci), &
              ip, 1, 1._r8, 0._r8, 8)
         call ncwrtr('nsf_da', 'x y', nsf_da(1 - nbdy, 1 - nbdy, l2ci), &
+             ip, 1, 1._r8, 0._r8, 8)
+        call ncwrtr('hmat_da', 'x y', hmat_da(1 - nbdy, 1 - nbdy, l2ci), &
              ip, 1, 1._r8, 0._r8, 8)
         call ncwrtr('hmlt_da', 'x y', hmlt_da(1 - nbdy, 1 - nbdy, l2ci), &
              ip, 1, 1._r8, 0._r8, 8)
@@ -320,6 +327,7 @@ contains
          call chksummsk(sfl, ip, 1, 'sfl')
          call chksummsk(swa, ip, 1, 'swa')
          call chksummsk(nsf, ip, 1, 'nsf')
+         call chksummsk(hmat, ip, 1, 'mhat')
          call chksummsk(hmlt, ip, 1, 'hmlt')
          call chksummsk(slp, ip, 1, 'slp')
          call chksummsk(abswnd, ip, 1, 'abswnd')

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -123,6 +123,7 @@ module mod_forcing
       hmltfz, &       ! Heat flux due to melting and freezing [W m-2].
       lip, &          ! Liquid water flux [kg m-2 s-1].
       sop, &          ! Solid precipitation [kg m-2 s-1].
+      hmat, &         ! Surface material enthalpy flux [W m-2].
       eva, &          ! Evaporation [kg m-2 s-1].
       rnf, &          ! Liquid runoff [kg m-2 s-1].
       rfi, &          ! Frozen runoff [kg m-2 s-1].
@@ -191,8 +192,8 @@ module mod_forcing
              wavsrc, wavsrc_opt, wavsrc_none, wavsrc_param, wavsrc_extern, &
              sref, tflxap, sflxap, tflxdi, sflxdi, nflxdi, &
              sstclm, ricclm, sssclm, prfac, eiacc, pracc, &
-             swa, nsf, hmltfz, lip, sop, eva, rnf, rfi, fmltfz, sfl, ztx, mty, &
-             ustarw, slp, abswnd, lamult, lasl, ustokes, vstokes, &
+             swa, nsf, hmltfz, hmat, lip, sop, eva, rnf, rfi, fmltfz, sfl, &
+             ztx, mty, ustarw, slp, abswnd, lamult, lasl, ustokes, vstokes, &
              atmco2, flxco2, flxdms, flxbrf, atmbrf, &
              atmn2o,flxn2o,atmnh3,flxnh3, atmnhxdep,atmnoydep, &
              surflx, surrlx, sswflx, salflx, brnflx, salrlx, taux, tauy, &
@@ -216,6 +217,7 @@ contains
       swa(:,:) = spval
       nsf(:,:) = spval
       hmltfz(:,:) = spval
+      hmat(:,:) = spval
       lip(:,:) = spval
       sop(:,:) = spval
       eva(:,:) = spval

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -82,7 +82,7 @@ module mod_rdlim
                              msc_massgs, msc_volgs, msc_salnga, msc_tempga, msc_sssga,  &
                              msc_sstga,  &
                              h2d_abswnd, h2d_alb, h2d_btmstr, h2d_brnflx, h2d_brnpd,  &
-                             h2d_dfl, h2d_eva, h2d_fice, h2d_fmltfz, h2d_hice,  &
+                             h2d_dfl, h2d_eva, h2d_fice, h2d_fmltfz, h2d_hice, h2d_hmat,  &
                              h2d_hmltfz, h2d_hsnw, h2d_iage, h2d_idkedt, h2d_lamult,  &
                              h2d_lasl, h2d_lip, h2d_maxmld, h2d_mld, h2d_mlts,  &
                              h2d_mltsmn, h2d_mltsmx, h2d_mltssq, h2d_mtkeus, h2d_mtkeni,  &
@@ -479,6 +479,7 @@ contains
       write (lp,*) 'H2D_FMLTFZ  ',H2D_FMLTFZ(1:nphy)
       write (lp,*) 'H2D_FICE    ',H2D_FICE(1:nphy)
       write (lp,*) 'H2D_HICE    ',H2D_HICE(1:nphy)
+      write (lp,*) 'H2D_HMAT    ',H2D_HMAT(1:nphy)
       write (lp,*) 'H2D_HMLTFZ  ',H2D_HMLTFZ(1:nphy)
       write (lp,*) 'H2D_HSNW    ',H2D_HSNW(1:nphy)
       write (lp,*) 'H2D_IAGE    ',H2D_IAGE(1:nphy)
@@ -657,6 +658,7 @@ contains
     call xcbcst(H2D_FICE)
     call xcbcst(H2D_FMLTFZ)
     call xcbcst(H2D_HICE)
+    call xcbcst(H2D_HMAT)
     call xcbcst(H2D_HMLTFZ)
     call xcbcst(H2D_HSNW)
     call xcbcst(H2D_IAGE)

--- a/phy/mod_restart.F90
+++ b/phy/mod_restart.F90
@@ -58,7 +58,7 @@ module mod_restart
                                  nphy, nacc_phy, &
                                  acc_abswnd, acc_alb, acc_brnflx, acc_brnpd, &
                                  acc_dfl, acc_eva, acc_fice, acc_fmltfz, &
-                                 acc_hice, acc_hmltfz, acc_hsnw, acc_iage, &
+                                 acc_hice, acc_hmat, acc_hmltfz, acc_hsnw, acc_iage, &
                                  acc_idkedt, acc_lamult, acc_lasl, acc_lip, &
                                  acc_maxmld, acc_mld, acc_mlts, acc_mltsmn, &
                                  acc_mltsmx, acc_mltssq, acc_mtkeus, &
@@ -121,7 +121,7 @@ module mod_restart
    use mod_eddtra,         only: tau_growing_hbl, tau_decaying_hbl, &
                                  tau_growing_hml, tau_decaying_hml, &
                                  hbl_tf, wpup_tf, hml_tf1, hml_tf
-   use mod_cesm,           only: frzpot, mltpot, swa_da, nsf_da, hmlt_da, &
+   use mod_cesm,           only: frzpot, mltpot, swa_da, nsf_da, hmat_da, hmlt_da, &
                                  lip_da, sop_da, eva_da, rnf_da, rfi_da, &
                                  fmltfz_da, sfl_da, ztx_da, mty_da, ustarw_da, &
                                  slp_da, abswnd_da, atmco2_da, atmbrf_da, &
@@ -530,6 +530,8 @@ contains
                          swa_da, ip, defmode)
          call defwrtfld('nsf_da', trim(c5p)//' k2 time', &
                          nsf_da, ip, defmode)
+         call defwrtfld('hmat_da', trim(c5p)//' k2 time', &
+                         hmat_da, ip, defmode)
          call defwrtfld('hmlt_da', trim(c5p)//' k2 time', &
                          hmlt_da, ip, defmode)
          call defwrtfld('slp_da', trim(c5p)//' k2 time', &
@@ -683,6 +685,9 @@ contains
             if (ACC_NSF(n) /= 0) &
                call defwrtfld('nsf_phy'//c2, trim(c5p)//' time', &
                               phyh2d(1-nbdy,1-nbdy,ACC_NSF(n)), ip, defmode)
+            if (ACC_HMAT(n) /= 0) &
+               call defwrtfld('hmat_phy'//c2, trim(c5p)//' time', &
+                              phyh2d(1-nbdy,1-nbdy,ACC_HMAT(n)), ip, defmode)
             if (ACC_DFL(n) /= 0) &
                call defwrtfld('dfl_phy'//c2, trim(c5p)//' time', &
                               phyh2d(1-nbdy,1-nbdy,ACC_DFL(n)), ip, defmode)
@@ -1874,6 +1879,7 @@ contains
          call readfld('sfl_da', no_unitconv, sfl_da, ip, required = .false.)
          call readfld('swa_da', no_unitconv, swa_da, ip, required = .false.)
          call readfld('nsf_da', no_unitconv, nsf_da, ip, required = .false.)
+         call readfld('hmat_da', no_unitconv, hmat_da, ip, required = .false.)
          call readfld('hmlt_da', no_unitconv, hmlt_da, ip, required = .false.)
          call readfld('slp_da', no_unitconv, slp_da, ip, required = .false.)
          call readfld('ficem_da', no_unitconv, ficem_da, ip, required = .false.)
@@ -2053,6 +2059,9 @@ contains
                if (ACC_NSF(n) /= 0) &
                   call readfld('nsf_phy'//c2, no_unitconv, &
                                phyh2d(1-nbdy,1-nbdy,ACC_NSF(n)), ip)
+               if (ACC_HMAT(n) /= 0) &
+                  call readfld('hmat_phy'//c2, no_unitconv, &
+                               phyh2d(1-nbdy,1-nbdy,ACC_HMAT(n)), ip)
                if (ACC_DFL(n) /= 0) &
                   call readfld('dfl_phy'//c2, no_unitconv, &
                                phyh2d(1-nbdy,1-nbdy,ACC_DFL(n)), ip)


### PR DESCRIPTION
With this PR, enthalpy flux as required for energy consistency with atmospheric water exchange is added to the non-solar heat flux field. Various methods for distributing the enthalpy flux components are available, and the current (hard-coded) method distributes the total enthalpy flux evenly over the sea-ice free ocean domain. This is based on an implementation of Tomas Toniazzo. 

This PR depends on CAM PR https://github.com/NorESMhub/CAM/pull/227/files and CMEPS PR https://github.com/NorESMhub/CMEPS/pull/36 and must be tested in coordination.