### PR TITLE
New default configuration for iHAMOCC

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -131,7 +131,7 @@
   <entry id="HAMOCC_FEDEP_SOURCE">
     <type>char</type>
     <valid_values>mahw2006,GESAMP2018</valid_values>
-    <default_value>mahw2006</default_value>
+    <default_value>GESAMP2018</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Source of dust/iron deposition data. Requires module ecosys</desc>
@@ -174,7 +174,7 @@
   <entry id="HAMOCC_EXTNCYCLE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+    <default_value>TRUE</default_value>
     <values>
        <value compset="_BGC.*%N2OC">TRUE</value>
        <value compset="_BGC.*%NH3C">TRUE</value>
@@ -309,7 +309,7 @@
   <entry id="HAMOCC_SEDSPINUP_YR_END">
     <type>integer</type>
     <valid_values/>
-    <default_value>800</default_value>
+    <default_value>500</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set end year for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE.
@@ -319,7 +319,7 @@
   <entry id="HAMOCC_SEDSPINUP_NCYCLE">
     <type>integer</type>
     <valid_values/>
-    <default_value>20</default_value>
+    <default_value>30</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set the number of sub-cycles for HAMOCC sediment spin-up if HAMOCC_SEDSPINUP == TRUE.

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -269,10 +269,10 @@ module mo_param_bgc
   !********************************************************************
   !ik weight percent iron in dust deposition times Fe solubility
   ! the latter three values come from Johnson et al., 1997
-  real(rp), protected :: fetune          = 0.6_rp        ! factor introduced to tune deposition/solubility
+  real(rp), protected :: fetune          = 1.0_rp        ! factor introduced to tune deposition/solubility
   real(rp), protected :: frac_ironindust = 0.035_rp      ! fraction of total iron in dust (typically 3.5%)
   real(rp), protected :: frac_soliron    = 0.01_rp       ! fraction of total iron that is immediately soluble
-  real(rp), protected :: fesoly          = 0.5e-9_rp     ! max. diss. iron concentration in deep water
+  real(rp), protected :: fesoly          = 0.55e-9_rp    ! max. diss. iron concentration in deep water
   real(rp), protected :: relaxfe         = 0.05_rp/365._rp  ! 1/d complexation rate to relax iron concentration to fesoly
 
   !********************************************************************
@@ -308,7 +308,7 @@ module mo_param_bgc
   real(rp), protected :: bkzoo      = 1.e-7_rp        ! kmol/m3 - i.e. 0.08 mmol P/m3 half saturation constant
   real(rp), protected :: grazra     = 1.5_rp          ! 1/d - grazing rate
   real(rp), protected :: spemor     = 3._rp*1.e6_rp   ! 1/d - mortality rate
-  real(rp), protected :: gammap     = 0.04_rp         ! 1/d - exudation rate
+  real(rp), protected :: gammap     = 0.03_rp         ! 1/d - exudation rate
   real(rp), protected :: gammaz     = 0.06_rp         ! 1/d - excretion rate
   real(rp), protected :: ecan       = 0.95_rp         ! fraction of mortality as PO_4
   real(rp), protected :: zinges                       ! dimensionless fraction - assimilation efficiency
@@ -349,7 +349,7 @@ module mo_param_bgc
   real(rp), protected :: drempoc_anaerob = 1.25e-3_rp  ! =0.05*drempoc - remin in sub-/anoxic environm. - not be overwritten by M4AGO
   real(rp), protected :: bkox_drempoc    = 1.e-5_rp    ! half-saturation constant for oxygen for ammonification (aerobic remin via drempoc)
   real(rp), protected :: dremopal        = 0.003_rp    ! 1/d Dissolution rate for opal
-  real(rp), protected :: dremcalc        = 0.0007_rp   ! 1/d Dissolution rate for CaCO3 (applied if Omega_c < 1)
+  real(rp), protected :: dremcalc        = 0.02_rp     ! 1/d Dissolution rate for CaCO3 (applied if Omega_c < 1)
   real(rp), protected :: dremn2o         = 0.01_rp     ! 1/d Remineralization rate of detritus on N2O
   real(rp), protected :: dremsul         = 0.005_rp    ! 1/d Remineralization rate for sulphate reduction
   real(rp), protected :: POM_remin_q10   = 2.1_rp      ! Bidle et al. 2002: Regulation of Oceanic Silicon...
@@ -546,7 +546,8 @@ module mo_param_bgc
   real(rp), protected :: sed_NO3thresh_sulf   = 3.e-6_rp   ! Below sed_NO3thresh_sulf 'sufate reduction' takes place
   real(rp), protected :: sedict      = 1.e-9_rp            ! m2/s Molecular diffusion coefficient
   real(rp), protected :: silsat      = 0.001_rp            ! kmol/m3 Silicate saturation concentration is 1 mol/m3
-  real(rp), protected :: disso_poc   = 0.19_rp/sec_per_day ! 1/(kmol O2/m3 s)      Degradation rate constant of POP
+  real(rp), protected :: disso_poc   = 1.3e-6_rp           ! 1/(kmol O2/m3 s)      Degradation rate constant of POP
+! real(rp), protected :: disso_poc   = 0.19_rp/sec_per_day ! 1/(kmol O2/m3 s)      Degradation rate constant of POP
   real(rp), protected :: disso_sil   = 1.4e-7_rp           ! 1/(kmol Si(OH)4/m3 s) Dissolution rate constant of opal
   real(rp), protected :: disso_caco3 = 1.e-7_rp            ! 1/(kmol CO3--/m3 s) Dissolution rate constant of CaCO3
   real(rp), protected :: sed_denit   = 0.01_rp/sec_per_day ! 1/s Denitrification rate constant of POP


### PR DESCRIPTION
This PR makes the following changes to the default iHAMOCC configuration
* extended N-cycle is activated by default
* the GESAMP2018 dust/iron deposition is used by default (and iron-cycle tuning parameters are changed accordingly)
* Adjustments to sediment spinup default settings (resulting in a faster spinup)
* `dremcalc` and `disso_poc` are adjusted to give a balanced simulation with JRA-forcing on the tnx1v4 grid

This configuration is used in https://github.com/NorESMhub/noresm3_dev_simulations/issues/147