### PR TITLE
Modification to reference density modification

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1078,7 +1078,17 @@
     <desc>Flag to enable adaption of reference potential densities to model state</desc>
   </entry>
 
-  <entry id="sra_ts">
+  <entry id="sra_clim_ts">
+    <type>real</type>
+    <category>vcoord</category>
+    <group>vcoord</group>
+    <values>
+      <value>5.0</value>
+    </values>
+    <desc>e-folding time scale (years) for adjusting mixed layer climatology</desc>
+  </entry>
+
+  <entry id="sra_param_ts">
     <type>real</type>
     <category>vcoord</category>
     <group>vcoord</group>

--- a/phy/mod_restart.F90
+++ b/phy/mod_restart.F90
@@ -36,7 +36,8 @@ module mod_restart
                                  sigref_fun_spec, sigref_adaption, &
                                  sra_massdc_colsum, sra_sigmassdc_colsum, &
                                  sra_massgs_colsum, sra_dpml_sum, &
-                                 sra_sigmlb_sum, sra_sigref_sum, &
+                                 sra_sigmlb_sum, sra_dpml_clim, &
+                                 sra_sigmlb_clim, sra_sigref_sum, &
                                  sra_s_bot_sum, sra_tlev_accnum, sra_accnum, &
                                  sigref_fun_spec_old, sigref_fun_spec_new
    use mod_inicon,         only: icfile
@@ -390,6 +391,10 @@ contains
             call defwrtfld('sra_sigmlb_sum', trim(c5p)//' sratlev', &
                             sra_sigmlb_sum, ip, defmode)
          endif
+         call defwrtfld('sra_dpml_clim', trim(c5p)//' sratlev', &
+                         sra_dpml_clim, ip, defmode)
+         call defwrtfld('sra_sigmlb_clim', trim(c5p)//' sratlev', &
+                         sra_sigmlb_clim, ip, defmode)
       endif
 
       if (vcoord_tag == vcoord_isopyc_bulkml) then
@@ -1782,6 +1787,10 @@ contains
             call readfld('sra_dpml_sum', p_unitconv, sra_dpml_sum, ip)
             call readfld('sra_sigmlb_sum', r_unitconv, sra_sigmlb_sum, ip)
          endif
+         call readfld('sra_dpml_clim', p_unitconv, &
+                       sra_dpml_clim, ip, required = .false.)
+         call readfld('sra_sigmlb_clim', r_unitconv, &
+                       sra_sigmlb_clim, ip, required = .false.)
       endif
 
       if (vcoord_tag == vcoord_isopyc_bulkml) then


### PR DESCRIPTION
This PR introduces the possibility to apply a time filter on the mixed layer climatology used in the optimisation of reference density function parameters. Namelist variables `sra_clim_ts` and `sra_param_ts` has been added, controlling the e-folding adjustment time scale in years of climatology and reference density function parameters, respectively. The namelist variable `sra_param_ts` replaces the current `sra_ts` variable.

A multi-decadal simulation piControl simulation is underway to test the modification, and inspection after the first 20 years gives the desired impact on the parameter optmisation with less year-to-year variation. Correct restart has been verified in the piControl test simulation. Setting `sra_clim_ts = 0.0` should get close to the current implementation.