### PR TITLE
Ensure consistent sigma variable in BLOM and iHAMOCC output.

### DIFF
--- a/hamocc/mo_ncout_hamocc.F90
+++ b/hamocc/mo_ncout_hamocc.F90
@@ -33,7 +33,8 @@ contains
     use mod_time,       only: date0,date,calendar,nstep,nstep_in_day,nday_of_year,time0,time
     use mod_xc,         only: kdm,mnproc,itdm,jtdm,lp,idm,jdm,nbdy
     use mod_grid,       only: depths,plat,plon
-    use mod_dia,        only: diafnm,sigmar1,iotype,ddm,depthslev,depthslev_bnds
+    use mod_vcoord,     only: sigref
+    use mod_dia,        only: diafnm,iotype,ddm,depthslev,depthslev_bnds
     use mo_control_bgc, only: dtbgc,use_cisonew,use_AGG,use_CFC,use_natDIC,use_BROMO,              &
                               use_sedbypass,use_BOXATM,use_M4AGO,use_extNcycle,use_pref_tracers,   &
                               use_shelfsea_res_time,use_sediment_quality,use_river2omip,           &
@@ -322,7 +323,7 @@ contains
     call nctime(datenum,calendar,timeunits,startdate)
 
     ! --- write auxillary dimension information
-    call ncwrt1('sigma','sigma',sigmar1)
+    call ncwrt1('sigma','sigma',sigref(1:kdm))
     call ncwrt1('depth','depth',depthslev)
     call ncwrt1('depth_bnds','bounds depth',depthslev_bnds)
     dummy = 0

--- a/phy/mod_blom_init.F90
+++ b/phy/mod_blom_init.F90
@@ -38,7 +38,7 @@ module mod_blom_init
   use mod_eos,             only: inieos
   use mod_swabs,           only: iniswa
   use mod_tmsmt,           only: initms
-  use mod_dia,             only: diaini, diasg1
+  use mod_dia,             only: diaini
   use mod_inicon,          only: inicon, woa_nuopc_provided
   use mod_budget,          only: budget_init
   use mod_cmnfld_routines, only: cmnfld1
@@ -46,7 +46,8 @@ module mod_blom_init
   use mod_rdlim,           only: rdlim
   use mod_inifrc,          only: inifrc
   use mod_inivar,          only: inivar
-  use mod_vcoord,          only: vcoord_tag, vcoord_isopyc_bulkml, sigmar
+  use mod_vcoord,          only: vcoord_tag, vcoord_isopyc_bulkml, sigmar, &
+                                 extract_sigref
   use mod_ale_regrid_remap, only: init_ale_regrid_remap
   use mod_cppm,            only: init_cppm
   use mod_inigeo,          only: inigeo
@@ -428,11 +429,11 @@ contains
     call cmnfld1(m,n,mm,nn,k1m,k1n)
 
     ! --------------------------------------------------------------------------
-    ! Extract reference potential density vector representative of the
-    ! dominating ocean domain.
+    ! In case it is not otherwise specified, extract reference potential density
+    ! vector representative of the dominating ocean domain.
     ! --------------------------------------------------------------------------
 
-    call diasg1
+    call extract_sigref
 
     ! --------------------------------------------------------------------------
 


### PR DESCRIPTION
Reference potential densities written to iHAMOCC output were inconsistent when using reference density adaption adaptation. This PR resolves this and also restructures code to collect vertical coordinate functionality and data in mod_vcoord.F90.