### PR TITLE
make sure that M4AGO gets same parameters for biol. as WLIN

### DIFF
--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -658,7 +658,7 @@ contains
     if (use_AGG) then
       zinges  = 0.5_rp        ! dimensionless fraction -assimilation efficiency
       epsher  = 0.9_rp        ! dimensionless fraction -fraction of grazing egested
-    else if (use_WLIN) then
+    else if ((use_WLIN .eqv. .true.) .or. (use_M4AGO .eqv. .true.))  then
       zinges  = 0.7_rp        ! dimensionless fraction -assimilation efficiency
       epsher  = 0.75_rp       ! dimensionless fraction -fraction of grazing egested
     else
@@ -673,7 +673,7 @@ contains
       rcalc  = 14._rp         ! calcium carbonate to organic phosphorous production ratio
       ropal  = 10.5_rp        ! opal to organic phosphorous production ratio
       calmax = 0.20_rp
-    else if (use_WLIN) then
+    else if ((use_WLIN .eqv. .true.) .or. (use_M4AGO .eqv. .true.)) then
       rcalc  =  8._rp         ! calcium carbonate to organic phosphorous production ratio
       ropal  = 70._rp         ! opal to organic phosphorous production ratio
     else


### PR DESCRIPTION
Hi @JorgSchwinger and @TomasTorsvik ,

this PR doesn't change any parameters - it just makes sure that the same zooplankton and production ratios are used in M4AGO as in the `use_WLIN` settings. Note that I didn't change the remin rate for M4AGO here, while it is likely needed. I thus far only looked at it in combination with DOMclasses (see https://github.com/NorESMhub/noresm3_dev_simulations/discussions/171#discussioncomment-13960955 for reference) while I cannot say, if the changed rates also apply, if used without DOMclasses (likely yes, but untested - something  I will check for my own work).

For info: I am currently checking a run with regards to changed N-cycle parameters - that PR with adjusted N-cycle parameters will come in later today.  