### PR TITLE
New N-cycle parameter suggestion

### DIFF
--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -373,7 +373,7 @@ module mo_param_bgc
   real(rp), protected :: Trefanh4nitr  = 20._rp      ! Reference temperature for nitrification on NH4 (degr C)
   real(rp), protected :: bkoxamox      = 0.333e-6_rp ! Half-saturation constant for oxygen limitation of nitrification on NH4 (kmol/m3)
   real(rp), protected :: bkanh4nitr    = 0.133e-6_rp ! Half-saturation constant for nitrification on NH4 (kmol/m3)
-  real(rp), protected :: bkamoxn2o     = 0.5e-6_rp   ! Half saturation constant for NH4 in pathway splitting function N2O for nitrification on NH4 (kmol/m3)
+  real(rp), protected :: bkamoxn2o     = 0.1e-6_rp   ! Half saturation constant for NH4 in pathway splitting function N2O for nitrification on NH4 (kmol/m3)
   real(rp), protected :: yield_n2o_inf = 0.077_rp    ! Santoro et al. a_2 = 0.077+-0.07
   real(rp), protected :: mufn2o                      !       = 0.11/(50.*1e6*bkoxamox) !=6.61e-3  0.11/(50*1e6)=2.2e-9 - ~Santoro et al. 2011 with simple MM,
   real(rp), protected :: bn2o                        !       = 0.077/(50.*mufn2o)  !=0.2331 - before set to 0.3 - base fraction entering N2O
@@ -390,7 +390,7 @@ module mo_param_bgc
   real(rp), protected :: NOB2AOAy      = 0.44_rp     ! Ratio of NOB versus AOA yield per energy source ~0.043/0.098 according to Zakem et al. 2022
 
   ! === Denitrification step NO3 -> NO2:
-  real(rp), protected :: rano3denit    = 0.0001_rp   ! Maximum growth rate denitrification on NO3 at reference T (1/d -> 1/dt)
+  real(rp), protected :: rano3denit    = 0.0002_rp   ! Maximum growth rate denitrification on NO3 at reference T (1/d -> 1/dt)
   real(rp), protected :: q10ano3denit  = 2._rp       ! Q10 factor for denitrification on NO3 (-)
   real(rp), protected :: Trefano3denit = 10._rp      ! Reference temperature for denitrification on NO3 (degr C)
   real(rp), protected :: sc_ano3denit  = 0.12e6_rp   ! Shape factor for NO3 denitrification oxygen inhibition function (m3/kmol)
@@ -413,14 +413,14 @@ module mo_param_bgc
   real(rp), protected :: bkano2denit   = 5.6e-6_rp   ! Half-saturation constant for denitrification on NO2 (kmol/m3)
 
   ! === DNRA NO2 -> NH4
-  real(rp), protected :: rdnra         = 0.0003_rp   ! Maximum growth rate DNRA on NO2 at reference T (1/d -> 1/dt)
+  real(rp), protected :: rdnra         = 0.0002_rp   ! Maximum growth rate DNRA on NO2 at reference T (1/d -> 1/dt)
   real(rp), protected :: q10dnra       = 2._rp       ! Q10 factor for DNRA on NO2 (-)
   real(rp), protected :: Trefdnra      = 10._rp      ! Reference temperature for DNRA (degr C)
   real(rp), protected :: bkoxdnra      = 2.5e-6_rp   ! Half saturation constant for (quadratic) oxygen inhibition function of DNRA on NO2 (kmol/m3)
   real(rp), protected :: bkdnra        = 0.05e-6_rp  ! Half-saturation constant for DNRA on NO2 (kmol/m3)
 
   ! === Denitrification step N2O -> N2
-  real(rp), protected :: ran2odenit    = 0.00045_rp  ! Maximum growth rate denitrification on N2O at reference T (1/d -> 1/dt)
+  real(rp), protected :: ran2odenit    = 0.0002_rp  ! Maximum growth rate denitrification on N2O at reference T (1/d -> 1/dt)
   real(rp), protected :: q10an2odenit  = 3._rp       ! Q10 factor for denitrificationj on N2O (-)
   real(rp), protected :: Trefan2odenit = 10._rp      ! Reference temperature for denitrification on N2O (degr C)
   real(rp), protected :: bkoxan2odenit = 10.e-6_rp   ! Half-saturation constant for (quadratic) oxygen inhibition function of denitrification on N2O (kmol/m3)


### PR DESCRIPTION
Hi @TomasTorsvik and @JorgSchwinger ,

this is an update of new parameter suggestions for the N-cycle based on some own runs and Jörgs default setup run in https://github.com/NorESMhub/noresm3_dev_simulations/discussions/171 , where denitrification was too low and N2O sea-air fluxes were also too low. With the tuning, I focus on the water column.

**For explanation:**
- `bkamoxn2o` is lowered to allow for higher N2O production by first nitrification step also at low NH4 concentrations (changes the partitioning between N2O and NO2 pathway at low NH concentrations towards N2O)
- `rano3denit` is increased to allow for stronger first denitrification step (NO3 -> NO2) - providing more NO2 to DNRA, 2nd denitrification step and anammox, likely it will be still a bit too low
- `rdnra` is lowered to avoid potential too high loss of NO2 to NH4 (allowing for a stronger direct re-circulation from NO2 to NO3 by nitrification) - aiming at keeping the NO3 inventory stable
- `ran2odenit` is lowered to have lower final denitrification step in order to circulate N2O a bit longer (slightly reduced sink of N2O in ODZs) - allowing for higher N2O fluxes from atop of ODZs 

 