### PR TITLE
Adjust default BLOM namelist parameters and number of vertical levels

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -92,7 +92,7 @@
     <valid_values/>
     <default_value>53</default_value>
     <values>
-      <value compset="_BLOM%HYB">56</value>
+      <value compset="_BLOM%HYB">72</value>
       <value compset="_BLOM%LVL">56</value>
     </values>
     <group>build_component_blom</group>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1607,7 +1607,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>1.e-6</value>
+      <value>2.e-6</value>
     </values>
     <desc>Minimum background diapycnal diffusivity (m**2/s) (f)</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -149,7 +149,7 @@
     <group>limits</group>
     <values>
       <value>.false.</value>
-      <value comp_interface="nuopc">.false.</value>
+      <value comp_interface="nuopc">.true.</value>
     </values>
     <desc>if .true., use NUOPC capability to read WOA climatology</desc>
   </entry>
@@ -963,7 +963,8 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>'inicon'</value>
+      <value>function</value>
+      <value blom_vcoord="isopyc_bulkml">inicon</value>
     </values>
     <desc>Reference potential density specification: Valid specs.: 'inicon', 'namelist'</desc>
   </entry>
@@ -973,7 +974,8 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>'inflation'</value>
+      <value>namelist</value>
+      <value blom_vcoord="plevel">inflation</value>
     </values>
     <desc>Pressure level specification: Valid specs.: 'inflation', 'namelist'</desc>
   </entry>
@@ -993,7 +995,7 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>23.70</value>
+      <value>23.0</value>
     </values>
     <desc>Sigma value at Bezier point 1 (z = 0) [kg m-3]</desc>
   </entry>
@@ -1003,7 +1005,7 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>0.21</value>
+      <value>0.27</value>
     </values>
     <desc>z value at Bezier point 2 []</desc>
   </entry>
@@ -1063,7 +1065,7 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>38.0</value>
+      <value>37.8</value>
     </values>
     <desc>Sigma value of parabola at z = 1 [kg m-3]</desc>
   </entry>
@@ -1073,7 +1075,7 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
     <desc>Flag to enable adaption of reference potential densities to model state</desc>
   </entry>
@@ -1155,7 +1157,7 @@
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
-      <value>-1.,-1.</value>
+      <value>0.000,    2.000,    4.061,    6.185,    8.374,   10.631,   12.959,   15.362,   17.843,   20.408,   23.061,   25.808,   28.659,   31.621,   34.706,   37.925,   41.294,   44.830,   48.553,   52.487,   56.661,61.104,   65.854,   70.953,   76.446,   82.389,   88.841,   95.868,  103.544,  111.949,  121.172,  131.306,  142.450,  154.708,  168.188,  182.999,  199.248,  217.040,  236.479,  257.657,  280.661,  305.568,  332.442,  361.336,  392.292,  425.339,  460.498,  497.778,  537.183,  578.707,  622.344,  668.083,  715.914, 765.827,  817.814,  871.871,  927.997,  986.197, 1046.481, 1108.863, 1173.364, 1240.010, 1308.833, 1379.870, 1453.162, 1528.755, 1606.702, 1687.056, 1769.879, 1855.233, 1943.185, 2033.806</value>
     </values>
     <desc>Array of pressure levels (m)</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1602,6 +1602,16 @@
     <desc>Make the background mixing latitude dependent according to</desc>
   </entry>
 
+  <entry id="nubmin">
+    <type>real</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>1.e-6</value>
+    </values>
+    <desc>Minimum background diapycnal diffusivity (m**2/s) (f)</desc>
+  </entry>
+
   <entry id="tkepf">
     <type>real</type>
     <category>diffusion</category>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -419,7 +419,7 @@
     <category>limits</category>
     <group>limits</group>
     <values>
-      <value>fox08</value>
+      <value>bod23</value>
     </values>
     <desc>Mixed layer restratification method</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1427,7 +1427,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>3.0</value>
+      <value>2.0</value>
     </values>
     <desc>Parameter c in Eden and Greatbatch (2008) parameterization (f)</desc>
   </entry>
@@ -1457,7 +1457,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>1.</value>
+      <value>50.</value>
       <value ocn_grid="tnx0.125v4">0.</value>
     </values>
     <desc>Minimum diffusivity in E. and G. (2008) param. (m**2/s) (f)</desc>
@@ -1479,7 +1479,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>1.</value>
+      <value>.8</value>
     </values>
     <desc>Factor relating the isopycnal diffusivity to the layer</desc>
   </entry>

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -162,6 +162,7 @@
 ! BDMC2    : Background diapycnal diffusivity (m**2/s) (f)
 ! BDMLDP   : Make the background mixing latitude dependent according to
 !            Gregg et al. (2003) (l)
+! NUBMIN   : Minimum background diapycnal diffusivity (m**2/s) (f)
 ! TKEPF    : Fraction of surface TKE that penetrates beneath mixed layer
 !            () (f)
 ! SMOBLD   : If true, apply lateral smoothing of CVMix estimated

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -32,8 +32,8 @@ module mod_difest
   use mod_state,             only: u, v, dp, dpu, dpv, temp, saln, sigma, p, &
                                    pbu, pbv, ubflxs_p, vbflxs_p, kfpla
   use mod_diffusion,         only: egc, eggam, eglsmn, egmndf, egmxdf, &
-                                   egidfq, rhiscf, ri0, bdmc1, bdmc2, &
-                                   bdmldp, tkepf, bdmtyp, eddf2d, edsprs, &
+                                   egidfq, rhiscf, ri0, bdmc1, bdmc2, bdmldp, &
+                                   nubmin, tkepf, bdmtyp, eddf2d, edsprs, &
                                    edanis, redi3d, rhsctp, edfsmo, smobld, &
                                    lngmtp, edritp_opt, edritp_shear, &
                                    edritp_large_scale, edwmth_opt, &
@@ -148,7 +148,6 @@ module mod_difest
   !   cori30 - coriolis parameter at 30N [1/s].
   !   bvf0   - reference stratification in the parameterization of
   !            latitude dependent background diapycnal mixing [1/s].
-  !   nubmin - minimum background diapycnal diffusivity [m^2/s].
   !   dpgc   - thickness of region near the bottom where the maximum
   !            diffusivity is increased due to gravity current mixing
   !            processes [kg/m/s^2].

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -191,7 +191,6 @@ module mod_difest
   real    , parameter :: niwls=300.*onem
   real    , parameter :: cori30 = 7.2722e-5
   real    , parameter :: bvf0=5.24e-3
-  real    , parameter :: nubmin = 1.e-6
   real    , parameter :: dpgc=300.*onem
   real    , parameter :: dpgrav=100.*onem
   real    , parameter :: dpdiav = 100.*onem

--- a/phy/mod_diffusion.F90
+++ b/phy/mod_diffusion.F90
@@ -53,6 +53,7 @@ module mod_diffusion
       bdmc1, &  ! Background diapycnal diffusivity times buoyancy frequency
                 ! [m2 s-2].
       bdmc2, &  ! Background diapycnal diffusivity [m2 s-1].
+      nubmin, & ! Minimum background diapycnal diffusivity [m2 s-1].
       tkepf     ! Fraction of surface TKE that penetrates beneath mixed layer
                 ! [].
    integer :: &
@@ -174,8 +175,8 @@ module mod_diffusion
 
    ! Public variables
    public :: egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-             bdmc1, bdmc2, bdmldp, tkepf, bdmtyp, eddf2d, edsprs, edanis, &
-             redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, &
+             bdmc1, bdmc2, bdmldp, nubmin, tkepf, bdmtyp, eddf2d, edsprs, &
+             edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, &
              eitmth_opt, eitmth_intdif, eitmth_gm, edritp_opt, edritp_shear, &
              edritp_large_scale, edwmth_opt, edwmth_smooth, edwmth_step, &
              ltedtp_opt, ltedtp_layer, ltedtp_neutral, &
@@ -203,8 +204,9 @@ contains
 
       namelist /diffusion/ &
          egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-         bdmc1, bdmc2, bdmldp, tkepf, bdmtyp, eddf2d, edsprs, edanis, redi3d, &
-         rhsctp, tbfile, edfsmo, smobld, lngmtp, eitmth, edritp, edwmth, ltedtp
+         bdmc1, bdmc2, bdmldp, nubmin, tkepf, bdmtyp, eddf2d, edsprs, edanis, &
+         redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, eitmth, edritp, &
+         edwmth, ltedtp
 
       ! Read variables in the namelist group 'diffusion'.
       if (mnproc == 1) then
@@ -245,6 +247,7 @@ contains
         call xcbcst(bdmc1)
         call xcbcst(bdmc2)
         call xcbcst(bdmldp)
+        call xcbcst(nubmin)
         call xcbcst(tkepf)
         call xcbcst(bdmtyp)
         call xcbcst(eddf2d)
@@ -274,6 +277,7 @@ contains
          write (lp,*) '  bdmc1  = ', bdmc1
          write (lp,*) '  bdmc2  = ', bdmc2
          write (lp,*) '  bdmldp = ', bdmldp
+         write (lp,*) '  nubmin = ', nubmin
          write (lp,*) '  tkepf  = ', tkepf
          write (lp,*) '  bdmtyp = ', bdmtyp
          write (lp,*) '  eddf2d = ', eddf2d

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -14,20 +14,20 @@
 ! ICFILE   : Name of file containing initial conditions, that is either
 !            a valid restart file or 'inicon.nc' if climatological based
 !            initial conditions are desired (a)
-! PREF     : Reference pressure for potential density (g/cm/s2) (f)
+! PREF     : Reference pressure for potential density (kg/m/s2) (f)
 ! BACLIN   : Baroclinic time step (sec) (f)
 ! BATROP   : Barotropic time step (sec) (f)
-! MDV2HI   : Laplacian diffusion velocity for momentum dissipation (cm/s) (f)
-! MDV2LO   : Laplacian diffusion velocity for momentum dissipation (cm/s) (f)
-! MDV4HI   : Biharmonic diffusion velocity for momentum dissipation (cm/s) (f)
-! MDV4LO   : Biharmonic diffusion velocity for momentum dissipation (cm/s) (f)
-! MDC2HI   : Laplacian diffusivity for momentum dissipation (cm**2/s) (f)
-! MDC2LO   : Laplacian diffusivity for momentum dissipation (cm**2/s) (f)
+! MDV2HI   : Laplacian diffusion velocity for momentum dissipation (m/s) (f)
+! MDV2LO   : Laplacian diffusion velocity for momentum dissipation (m/s) (f)
+! MDV4HI   : Biharmonic diffusion velocity for momentum dissipation (m/s) (f)
+! MDV4LO   : Biharmonic diffusion velocity for momentum dissipation (m/s) (f)
+! MDC2HI   : Laplacian diffusivity for momentum dissipation (m**2/s) (f)
+! MDC2LO   : Laplacian diffusivity for momentum dissipation (m**2/s) (f)
 ! VSC2HI   : Parameter in deformation-dependent Laplacian viscosity (f)
 ! VSC2LO   : Parameter in deformation-dependent Laplacian viscosity (f)
 ! VSC4HI   : Parameter in deformation-dependent Biharmonic viscosity (f)
 ! VSC4LO   : Parameter in deformation-dependent Biharmonic viscosity (f)
-! CBAR     : rms flow speed for linear bottom friction law (cm/s) (f)
+! CBAR     : rms flow speed for linear bottom friction law (m/s) (f)
 ! CB       : Nondiemnsional coefficient of quadratic bottom friction (f)
 ! CWBDTS   : Coastal wave breaking damping resiprocal time scale (1/s) (f)
 ! CWBDLS   : Coastal wave breaking damping length scale (m) (f)
@@ -179,9 +179,9 @@
 ! EDSPRS   : Apply eddy mixing suppression away from steering level (l)
 ! EGC      : Parameter c in Eden and Greatbatch (2008) parameterization (f)
 ! EGGAM    : Parameter gamma in E. & G. (2008) param. (f)
-! EGLSMN   : Minimum eddy length scale in  E. & G. (2008) param. (cm) (f)
-! EGMNDF   : Minimum diffusivity in E. & G. (2008) param. (cm**2/s) (f)
-! EGMXDF   : Maximum diffusivity in E. & G. (2008) param. (cm**2/s) (f)
+! EGLSMN   : Minimum eddy length scale in  E. & G. (2008) param. (m) (f)
+! EGMNDF   : Minimum diffusivity in E. & G. (2008) param. (m**2/s) (f)
+! EGMXDF   : Maximum diffusivity in E. & G. (2008) param. (m**2/s) (f)
 ! EGIDFQ   : Factor relating the isopycnal diffusivity to the layer
 !            interface diffusivity in the Eden and Greatbatch (2008)
 !            parameterization. egidfq=difint/difiso () (f)
@@ -199,10 +199,11 @@
 !            Brunt-Vaisala frequency, if bdmtyp=2 the background
 !            diffusivity is constant () (i)
 ! BDMC1    : Background diapycnal diffusivity times buoyancy frequency
-!            frequency (cm**2/s**2) (f)
-! BDMC2    : Background diapycnal diffusivity (cm**2/s) (f)
+!            frequency (m**2/s**2) (f)
+! BDMC2    : Background diapycnal diffusivity (m**2/s) (f)
 ! BDMLDP   : Make the background mixing latitude dependent according to
 !            Gregg et al. (2003) (l)
+! NUBMIN   : Minimum background diapycnal diffusivity (m**2/s) (f)
 ! TKEPF    : Fraction of surface TKE that penetrates beneath mixed layer
 !            () (f)
 ! SMOBLD   : If true, apply lateral smoothing of CVMix estimated
@@ -233,6 +234,7 @@
   BDMC1    = 5.e-8
   BDMC2    = 1.e-5
   BDMLDP   = .false.
+  NUBMIN   = 1.e-6
   TKEPF    = 0.
   SMOBLD   = .true.
   LNGMTP   = 'none'


### PR DESCRIPTION
This PR includes the following namelist changes:
- Minimum background vertical diffusivity is now available as namelist variable and increased from 1.e-6 m2 s-1 to 2.e-6 m2 s-1.
- Default eddy diffusivity parameters have been adjusted: EGC 3.0 -> 2.0; EGIDFQ 1.0 -> 0.8; EGMNDF 1.0 m2 s-1 -> 50.0 m2 s-1.
- Default mixed layer stratification method is changed from Fox-Kemper et al. (2008) to Bodner et al. (2023).
- Adaption of reference potential densities is enabled as default.

Consistent with testing of parameters related to the potential density adaption, the number of vertical layers for hybrid coordinate is increased from 56 to 72.