### PR TITLE
New default parameters for HAMOCC

### DIFF
--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -521,7 +521,7 @@ module mo_param_bgc
   real(rp), protected :: wdust_const                    ! m/d   Sinking speed of dust
   real(rp), protected :: wmin        =  5._rp           ! m/d   minimum sinking speed
   real(rp), protected :: wmax        = 60._rp           ! m/d   maximum sinking speed
-  real(rp), protected :: wlin        = 60._rp/2400._rp  ! m/d/m constant describing incr. with depth, r/a=1.0
+  real(rp), protected :: wlin        = 60._rp/3120._rp  ! m/d/m constant describing incr. with depth, r/a=1.3 (r=0.025)
   real(rp), protected :: dustd1      = 0.0001_rp        ! cm = 1 um, boundary between clay and silt
   real(rp), protected :: dustd2                         ! dust diameter squared
   real(rp), protected :: dustd3                         ! dust diameter cubed
@@ -660,7 +660,7 @@ contains
       epsher  = 0.9_rp        ! dimensionless fraction -fraction of grazing egested
     else if ((use_WLIN .eqv. .true.) .or. (use_M4AGO .eqv. .true.))  then
       zinges  = 0.7_rp        ! dimensionless fraction -assimilation efficiency
-      epsher  = 0.75_rp       ! dimensionless fraction -fraction of grazing egested
+      epsher  = 0.8_rp        ! dimensionless fraction -fraction of grazing egested
     else
       zinges  = 0.6_rp        ! dimensionless fraction -assimilation efficiency
       epsher  = 0.8_rp        ! dimensionless fraction -fraction of grazing egest
@@ -675,7 +675,7 @@ contains
       calmax = 0.20_rp
     else if ((use_WLIN .eqv. .true.) .or. (use_M4AGO .eqv. .true.)) then
       rcalc  =  8._rp         ! calcium carbonate to organic phosphorous production ratio
-      ropal  = 70._rp         ! opal to organic phosphorous production ratio
+      ropal  = 75._rp         ! opal to organic phosphorous production ratio
     else
       rcalc  = 40._rp         ! iris 40 !calcium carbonate to organic phosphorous production ratio
       ropal  = 30._rp         ! iris 25 !opal to organic phosphorous production ratio


### PR DESCRIPTION
This PR sets a few new parameter defaults for HAMOCC. The goal is to reduce the vertical gradient in phosphate and nitrate, which has been consistently too strong in recent simulations. This is achieved by

* increasing the exponent b of the Martin-curve formulation from 1 to 1.3 by setting `wlin=60/3120`, which slows down the sinking of POC above 3120 m depth (beyond which the maximum sinking speed is reached)
* increasing `epsher` (which controls the efficiency of export by grazing) back to 0.8 (this parameter was decreased in the course of tuning when the split between euphotic zone and deep ocean was removed, but it turns out it was too much)

`ropal` is also slightly increased to keep the opal export approximately stable with the above changes. I expect some final tunings of sediment dissolution rates will be necessary to eliminate model drift, but this has to be done once a longer simulation (~200 years) is available.

@jmaerz I'm slightly puzzled by the fact that our b-exponent apparently needs to be that large (isn't otherwise 0.9 a ballpark-estimate?). It is probably reflecting the fact that the model has a low diffusivity, so maybe it is ok, or would you be worried about that?