### PR TITLE
Add functionality to limit the local vertical layer thickness variation

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1306,7 +1306,7 @@
     <values>
       <value>.1</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Minimum interior layer thickness [m]</desc>
   </entry>
 
   <entry id="regrid_method">
@@ -1336,7 +1336,7 @@
     <values>
       <value>86400.</value>
     </values>
-    <desc>add desc</desc>
+    <desc>e-folding time scale of interface nudging during regridding [s]</desc>
   </entry>
 
   <entry id="stab_fac_limit">
@@ -1346,7 +1346,17 @@
     <values>
       <value>.75</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Limit of stability factor (actual/reference vertical potential density difference) to contrain interface nudging and activate interface smoothing</desc>
+  </entry>
+
+  <entry id="dpvar_fac">
+    <type>real</type>
+    <category>ale_regrid_remap</category>
+    <group>ale_regrid_remap</group>
+    <values>
+      <value>.75</value>
+    </values>
+    <desc>Factor determining the maximum local vertical layer thicknesses variation []</desc>
   </entry>
 
   <entry id="smooth_diff_max">
@@ -1358,7 +1368,7 @@
       <value ocn_grid="tnx0.25v4" >40000.</value>
       <value ocn_grid="tnx0.125v4">20000.</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Maximum diffusivity of interface smoothing after regridding [m2 s-1]</desc>
   </entry>
 
   <entry id="dktzu">
@@ -1368,7 +1378,7 @@
     <values>
       <value>4</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Upper layer range of the transition zone between pressure levels and isopycnic interfaces</desc>
   </entry>
 
   <entry id="dktzl">
@@ -1378,7 +1388,7 @@
     <values>
       <value>2</value>
     </values>
-    <desc>add desc</desc>
+    <desc>Lower layer range of the transition zone between pressure levels and isopycnic interfaces</desc>
   </entry>
 
   <!-- ========================= -->

--- a/phy/mod_ale_regrid_remap.F90
+++ b/phy/mod_ale_regrid_remap.F90
@@ -70,6 +70,7 @@ module mod_ale_regrid_remap
         dpmin_interior         = .1_r8, &
         regrid_nudge_ts        = 86400._r8, &
         stab_fac_limit         = .75_r8, &
+        dpvar_fac              = .75_r8, &
         smooth_diff_max        = 50000._r8
    integer :: &
         upper_bndr_ord = 6, &
@@ -282,7 +283,7 @@ contains
 
       real(r8), dimension(kdm+1) :: sig_trg
       real(r8), dimension(kdm) :: sig_src
-      real(r8) :: beta, sdpsum, smean, dpmin_int, pku, pku_test, pmin, dpt, &
+      real(r8) :: beta, sdpsum, smean, dpmin, pku, pku_test, pmin, dpt, &
                   pt, ptu1, ptl1, ptu2, ptl2, w1, x
       integer :: l, i, k, kn, ks, ke, kl, ku, errstat
       logical :: thin_layers, layer_added
@@ -430,24 +431,24 @@ contains
 
             ! Modify interface pressures so that layer thicknesses are
             ! above a specified threshold.
-            dpmin_int = min(plevel(2) - plevel(1), dpmin_interior)
+            dpmin = min(plevel(2) - plevel(1), dpmin_interior)
             ks = max(2, ks)
             ke = min(kk, ke)
             k = ks
             do while (k <= ke)
-               if (p_dst(k+1,i) - p_dst(k,i) < dpmin_int) then
+               if (p_dst(k+1,i) - p_dst(k,i) < dpmin) then
                   if (k == ke) then
                      p_dst(k,i) = p_dst(ke+1,i)
                   else
                      ku = k
                      kl = k + 1
-                     pku = .5_r8*(p_dst(kl,i) + p_dst(ku,i) - dpmin_int)
+                     pku = .5_r8*(p_dst(kl,i) + p_dst(ku,i) - dpmin)
                      do
                         layer_added = .false.
                         kl = kl + 1
-                        pku_test = ((pku - dpmin_int)*(kl - ku) + p_dst(kl,i)) &
+                        pku_test = ((pku - dpmin)*(kl - ku) + p_dst(kl,i)) &
                                    /(kl - ku + 1)
-                        if (pku_test + (kl - ku)*dpmin_int > p_dst(kl,i)) then
+                        if (pku_test + (kl - ku)*dpmin > p_dst(kl,i)) then
                            if (kl == ke + 1) exit
                            pku = pku_test
                            layer_added = .true.
@@ -455,7 +456,7 @@ contains
                            kl = kl - 1
                         endif
                         ku = ku - 1
-                        pku_test = ((pku - dpmin_int)*(kl - ku) + p_dst(ku,i)) &
+                        pku_test = ((pku - dpmin)*(kl - ku) + p_dst(ku,i)) &
                                    /(kl - ku + 1)
                         if (pku_test < p_dst(ku,i)) then
                            if (ku == 1) exit
@@ -469,12 +470,12 @@ contains
                      if     (ku == 1) then
                         do k = 2, kl
                            p_dst(k,i) = min(p_dst(ke+1,i), &
-                                            p_dst(k -1,i) + dpmin_int)
+                                            p_dst(k -1,i) + dpmin)
                         enddo
                         do k = kl+1, ke
                            p_dst(k,i) = &
                               min(p_dst(ke+1,i), &
-                              max(p_dst(k,i), p_dst(1,i) + dpmin_int*(k - 1)))
+                              max(p_dst(k,i), p_dst(1,i) + dpmin*(k - 1)))
                         enddo
                      elseif (kl == ke + 1) then
                         do k = ku, kl
@@ -483,7 +484,7 @@ contains
                      else
                         p_dst(ku,i) = pku
                         do k = ku+1, kl
-                           p_dst(k,i) = p_dst(k-1,i) + dpmin_int
+                           p_dst(k,i) = p_dst(k-1,i) + dpmin
                         enddo
                      endif
                      k = kl
@@ -517,8 +518,7 @@ contains
                   x = .5_r8*(p_dst(k+1,i) - ptu2)/dpt
                   pt = w1*pt + (1._r8 - w1)*(pmin + dpt*x*x)
                endif
-               p_dst(k,i) = min(p_dst(ke+1,i), &
-                                max(p_dst(k-1,i) + dpmin_int, pt))
+               p_dst(k,i) = min(p_dst(ke+1,i), max(p_dst(k-1,i) + dpmin, pt))
             enddo
 
          enddo
@@ -527,7 +527,7 @@ contains
    end subroutine regrid_cntiso_hybrid_direct_jslice
 
    subroutine regrid_cntiso_hybrid_nudge_jslice( &
-                 p_src, ksmx, tpc_src, t_srcdi, p_dst, stab_fac, ilb, iub, j)
+                 p_src, ksmx, tpc_src, t_srcdi, p_dst, smooth_fac, ilb, iub, j)
    ! ---------------------------------------------------------------------------
    ! For vcoord == 'cntiso_hybrid' and regrid_method = 'nudge', nudge the
    ! interface pressures to reduce the deviation from interface target potential
@@ -537,7 +537,7 @@ contains
       real(r8), dimension(:,1-nbdy:), intent(in) :: p_src
       integer, dimension(1-nbdy:), intent(in) :: ksmx
       real(r8), dimension(:,:,:,1-nbdy:), intent(in) :: tpc_src, t_srcdi
-      real(r8), dimension(:,1-nbdy:), intent(out) :: p_dst, stab_fac
+      real(r8), dimension(:,1-nbdy:), intent(out) :: p_dst, smooth_fac
       integer, intent(in) :: ilb, iub, j
 
       integer, parameter :: &
@@ -548,11 +548,13 @@ contains
       integer, dimension(1-nbdy:idm+nbdy) :: kdmx
 
       real(r8), dimension(kdm+1) :: sig_trg, sig_pmin
-      real(r8), dimension(kdm) :: dsig_trg, pmin
+      real(r8), dimension(kdm) :: dsig_trg, pmin, dpmin
       real(r8) :: sig_max, ckt, sig_up, sig_lo, dk, dki, &
                   dsigdx_up, dsigdx_lo, x, xi, si, t, nudge_fac, &
-                  dsig, dsigdx, dp_up, dp_lo, sig_intrp
-      integer :: l, i, k, kt, kl, ktzmin, ktzmax
+                  dsig, dsigdx, stab_fac, dp_up, dp_lo, sig_intrp, &
+                  dpmin_sum, dp_sum, dpmin_sum_test, dp_sum_test
+      integer :: l, i, k, kt, kl, ktzmin, ktzmax, ks, ke, ku
+      logical :: layer_added
 
       do l = 1, isp(j)
          do i = max(ilb, ifp(j,l)), min(iub, ilp(j,l))
@@ -599,7 +601,7 @@ contains
             kl = 1
             sig_pmin(1) = sig_srcdi(1,1)
             p_dst(1,i) = pmin(1)
-            stab_fac(1,i) = 0._r8
+            smooth_fac(1,i) = 1._r8
             do k = 2, k_range_plevel
                do while (p_src(kl+1,i) < pmin(k))
                   kl = kl + 1
@@ -611,7 +613,7 @@ contains
                p_dst(k,i) = min(max(p_dst(k,i), pmin(k), &
                                     p_dst(k-1,i) + dpmin_interior), &
                                 p_src(kk+1,i))
-               stab_fac(k,i) = 0._r8
+               smooth_fac(k,i) = 1._r8
             enddo
 
             ! Find the index of the first interface with potential density at
@@ -695,7 +697,7 @@ contains
                p_dst(kt,i) = min(max(p_dst(kt,i), pmin(kt), &
                                      p_dst(kt-1,i) + dpmin_interior), &
                                  p_src(kk+1,i))
-               stab_fac(kt,i) = 0._r8
+               smooth_fac(kt,i) = 1._r8
                kt = kt + 1
             enddo
 
@@ -705,7 +707,7 @@ contains
 
             do k = kt, kk+1
                p_dst(k,i) = p_src(kk+1,i)
-               stab_fac(k,i) = 1._r8
+               smooth_fac(k,i) = 0._r8
             enddo
 
             do k = kt, min(ksmx(i), kdmx(i))
@@ -716,8 +718,8 @@ contains
                            *dpeval1(tpc_src(:,k-1,it,i)) &
                          + dsigds(t_srcdi(2,k-1,it,i), t_srcdi(2,k-1,is,i)) &
                            *dpeval1(tpc_src(:,k-1,is,i))
-                  stab_fac(k,i) = dsigdx/dsig_trg(k-1)
-                  dsigdx = dsig_trg(k-1)*max(stab_fac(k,i), stab_fac_limit)
+                  stab_fac = dsigdx/dsig_trg(k-1)
+                  dsigdx = dsig_trg(k-1)*max(stab_fac, stab_fac_limit)
                   p_dst(k,i) = p_src(k,i) &
                              + max(- .5_r8, dsig*nudge_fac/dsigdx) &
                                *(p_src(k,i) - p_src(k-1,i))
@@ -728,8 +730,8 @@ contains
                            *dpeval0(tpc_src(:,k,it,i)) &
                          + dsigds(t_srcdi(1,k,it,i), t_srcdi(1,k,is,i)) &
                            *dpeval0(tpc_src(:,k,is,i))
-                  stab_fac(k,i) = dsigdx/dsig_trg(k)
-                  dsigdx = dsig_trg(k)*max(stab_fac(k,i), stab_fac_limit)
+                  stab_fac = dsigdx/dsig_trg(k)
+                  dsigdx = dsig_trg(k)*max(stab_fac, stab_fac_limit)
                   p_dst(k,i) = p_src(k,i) &
                              + min(.5_r8, dsig*nudge_fac/dsigdx) &
                                *(p_src(k+1,i) - p_src(k,i))
@@ -753,15 +755,15 @@ contains
                   dsig = sig_trg(k) - sig_intrp
                   if (dsig < 0._r8) then
                      dsigdx = dsigdx_up + 2._r8*(sig_intrp - sig_srcdi(2,k-1))
-                     stab_fac(k,i) = dsigdx/dsig_trg(k-1)
-                     dsigdx = dsig_trg(k-1)*max(stab_fac(k,i), stab_fac_limit)
+                     stab_fac = dsigdx/dsig_trg(k-1)
+                     dsigdx = dsig_trg(k-1)*max(stab_fac, stab_fac_limit)
                      p_dst(k,i) = p_src(k,i) &
                                 + max(- .5_r8, dsig*nudge_fac/dsigdx) &
                                   *(p_src(k,i) - p_src(k-1,i))
                   else
                      dsigdx = dsigdx_lo + 2._r8*(sig_srcdi(1,k  ) - sig_intrp)
-                     stab_fac(k,i) = dsigdx/dsig_trg(k)
-                     dsigdx = dsig_trg(k)*max(stab_fac(k,i), stab_fac_limit)
+                     stab_fac = dsigdx/dsig_trg(k)
+                     dsigdx = dsig_trg(k)*max(stab_fac, stab_fac_limit)
                      p_dst(k,i) = p_src(k,i) &
                                 + min(.5_r8, dsig*nudge_fac/dsigdx) &
                                   *(p_src(k+1,i) - p_src(k,i))
@@ -770,6 +772,9 @@ contains
                p_dst(k,i) = min(max(p_dst(k,i), pmin(k), &
                                     p_dst(k-1,i) + dpmin_interior), &
                                 p_src(kk+1,i))
+               smooth_fac(k,i) = &
+                  max(0._r8, min(1._r8, (stab_fac_limit - stab_fac) &
+                                        /stab_fac_limit))
             enddo
 
             do k = max(kt, min(ksmx(i), kdmx(i))) + 1, kdmx(i)
@@ -781,16 +786,92 @@ contains
                          + dsigds(t_srcdi(2,ksmx(i),it,i), &
                                   t_srcdi(2,ksmx(i),is,i)) &
                            *dpeval1(tpc_src(:,ksmx(i),is,i))
-                  stab_fac(k,i) = dsigdx/dsig_trg(ksmx(i)-1)
-                  dsigdx = dsig_trg(ksmx(i)-1) &
-                           *max(stab_fac(k,i), stab_fac_limit)
+                  stab_fac = dsigdx/dsig_trg(ksmx(i)-1)
+                  dsigdx = dsig_trg(ksmx(i)-1)*max(stab_fac, stab_fac_limit)
                   p_dst(k,i) = p_src(kk+1,i) &
                              + max(- .5_r8, dsig*nudge_fac/dsigdx) &
                                *(p_src(kk+1,i) - p_src(ksmx(i),i))
                   p_dst(k,i) = min(max(p_dst(k,i), pmin(k), &
                                        p_dst(k-1,i) + dpmin_interior), &
                                    p_src(kk+1,i))
+                  smooth_fac(k,i) = &
+                     max(0._r8, min(1._r8, (stab_fac_limit - stab_fac) &
+                                           /stab_fac_limit))
                endif
+            enddo
+
+            ! Limit the local vertical layer thickness variation. The overall
+            ! goal is that layer thickness of layer k has a lower bound of:
+            !
+            !    dpvar_fac*(dp(k-1) + dp(k) + dp(k+1))/3
+
+            ks = kt
+            ke = kk
+            do k = kk, 1, -1
+               if (p_dst(k,i) == p_dst(kk+1,i)) ke = k - 1
+            enddo
+
+            do k = ks, ke - 1
+               dpmin(k) = &
+                  min(2._r8*p_dst(ke+1,i) - p_dst(k+1,i) - p_dst(k,i), &
+                      max(dpmin_interior, &
+                          dpvar_fac*(p_dst(k+2,i) - p_dst(k-1,i))/3._r8))
+            enddo
+
+            k = ks
+            do while (k < ke)
+               if (p_dst(k+1,i) - p_dst(k,i) < dpmin(k)) then
+                  ku = k
+                  kl = k + 1
+                  dpmin_sum = dpmin(ku)
+                  dp_sum = p_dst(k+1,i) - p_dst(k,i)
+                  layer_added = .true.
+                  do while (layer_added)
+                     layer_added = .false.
+                     if (kl + 1 < ke) then
+                        dpmin_sum_test = dpmin_sum + dpmin(kl)
+                        dp_sum_test = dp_sum + p_dst(kl+1,i) - p_dst(kl,i)
+                        if (dpmin_sum_test > dp_sum_test) then
+                           dpmin_sum = dpmin_sum_test
+                           dp_sum = dp_sum_test
+                           kl = kl + 1
+                           layer_added = .true.
+                        endif
+                     endif
+                     if (ku > ks) then
+                        dpmin_sum_test = dpmin_sum + dpmin(ku-1)
+                        dp_sum_test = dp_sum + p_dst(ku,i) - p_dst(ku-1,i)
+                        if (dpmin_sum_test > dp_sum_test) then
+                           dpmin_sum = dpmin_sum_test
+                           dp_sum = dp_sum_test
+                           ku = ku - 1
+                           layer_added = .true.
+                        endif
+                     endif
+                  enddo
+                  if (ku == ks) then
+                     do k = ks, kl - 1
+                        p_dst(k+1,i) = min(p_dst(ke+1,i), p_dst(k,i) + dpmin(k))
+                     enddo
+                     do k = kl, ke - 1
+                        p_dst(k+1,i) = max(p_dst(k+1,i), p_dst(k,i))
+                     enddo
+                     ks = kl - 1
+                     k = ks
+                  else
+                     dp_up = p_dst(ku,i) - p_dst(ku-1,i)
+                     dp_lo = p_dst(kl+1,i) - p_dst(kl,i)
+                     p_dst(ku,i) = &
+                        max(p_dst(ku-1,i), &
+                            p_dst(ku,i) - (dpmin_sum - dp_sum)*dp_up &
+                                          /max(epsilp, dp_up + dp_lo))
+                     do k = ku, kl - 1
+                        p_dst(k+1,i) = min(p_dst(ke+1,i), p_dst(k,i) + dpmin(k))
+                     enddo
+                     k = kl
+                  endif
+               endif
+               k = k + 1
             enddo
 
          enddo
@@ -798,7 +879,7 @@ contains
 
    end subroutine regrid_cntiso_hybrid_nudge_jslice
 
-   subroutine regrid_jslice(p_src, ksmx, tpc_src, t_srcdi, p_dst, stab_fac, &
+   subroutine regrid_jslice(p_src, ksmx, tpc_src, t_srcdi, p_dst, smooth_fac, &
                             ilb, iub, j, js, nn)
    ! ---------------------------------------------------------------------------
    ! Carry out regridding layer interfaces.
@@ -807,7 +888,7 @@ contains
       real(r8), dimension(:,1-nbdy:), intent(in) :: p_src
       integer, dimension(1-nbdy:), intent(in) :: ksmx
       real(r8), dimension(:,:,:,1-nbdy:), intent(in) :: tpc_src, t_srcdi
-      real(r8), dimension(:,1-nbdy:), intent(out) :: p_dst, stab_fac
+      real(r8), dimension(:,1-nbdy:), intent(out) :: p_dst, smooth_fac
       integer, intent(in) :: ilb, iub, j, js, nn
 
       if (vcoord_tag == vcoord_plevel) then
@@ -818,14 +899,14 @@ contains
                                                     ilb, iub, j, js, nn)
          else
             call regrid_cntiso_hybrid_nudge_jslice(p_src, ksmx, tpc_src, &
-                                                   t_srcdi, p_dst, stab_fac, &
+                                                   t_srcdi, p_dst, smooth_fac, &
                                                    ilb, iub, j)
          endif
       endif
 
    end subroutine regrid_jslice
 
-   subroutine regrid_smooth_jslice(p_dst_js, stab_fac_js, smtflxconv_js, &
+   subroutine regrid_smooth_jslice(p_dst_js, smooth_fac_js, smtflxconv_js, &
                                    ilb, iub, j, js2, js3)
    ! ---------------------------------------------------------------------------
    ! For vcoord == 'cntiso_hybrid' and regrid_method == 'nudge', apply lateral
@@ -834,10 +915,10 @@ contains
    ! ---------------------------------------------------------------------------
 
       real(r8), dimension(:,1-nbdy:,:), intent(inout) :: &
-         p_dst_js, stab_fac_js, smtflxconv_js
+         p_dst_js, smooth_fac_js, smtflxconv_js
       integer, intent(in) :: ilb, iub, j, js2, js3
 
-      real(r8) :: cdiff, difmx, flxhi, flxlo, flx, q, sdiff
+      real(r8) :: cdiff, difmx, flxhi, flxlo, flx, sdiff
       integer :: l, i, k
 
       smtflxconv_js(:,:,js3) = 0._r8
@@ -855,12 +936,9 @@ contains
                                      - p_dst_js(k-1,i  ,js3))*scp2(i  ,j+1), &
                                      ( p_dst_js(k+1,i-1,js3) &
                                      - p_dst_js(k  ,i-1,js3))*scp2(i-1,j+1))
-               q = .5_r8*( max(0._r8, min(stab_fac_limit, &
-                                          stab_fac_js(k,i-1,js3))) &
-                         + max(0._r8, min(stab_fac_limit, &
-                                          stab_fac_js(k,i  ,js3))))
-               sdiff = min((stab_fac_limit - q)*smooth_diff_max &
-                           /stab_fac_limit, difmx)
+               sdiff = min(.5_r8*( smooth_fac_js(k,i-1,js3) &
+                                 + smooth_fac_js(k,i  ,js3))*smooth_diff_max, &
+                           difmx)
                flx = min(flxhi, max(flxlo, cdiff*sdiff*( p_dst_js(k,i-1,js3) &
                                                        - p_dst_js(k,i  ,js3))))
                smtflxconv_js(k,i-1,js3) = smtflxconv_js(k,i-1,js3) + flx
@@ -882,12 +960,9 @@ contains
                                      - p_dst_js(k-1,i,js3))*scp2(i,j+1), &
                                      ( p_dst_js(k+1,i,js2) &
                                      - p_dst_js(k  ,i,js2))*scp2(i,j  ))
-               q = .5_r8*( max(0._r8, min(stab_fac_limit, &
-                                          stab_fac_js(k,i,js2))) &
-                         + max(0._r8, min(stab_fac_limit, &
-                                          stab_fac_js(k,i,js3))))
-               sdiff = min((stab_fac_limit - q)*smooth_diff_max &
-                           /stab_fac_limit, difmx)
+               sdiff = min(.5_r8*( smooth_fac_js(k,i,js2) &
+                                 + smooth_fac_js(k,i,js3))*smooth_diff_max, &
+                           difmx)
                flx = min(flxhi, max(flxlo, cdiff*sdiff*( p_dst_js(k,i,js2) &
                                                        - p_dst_js(k,i,js3))))
                smtflxconv_js(k,i,js2) = smtflxconv_js(k,i,js2) + flx
@@ -925,6 +1000,7 @@ contains
             errstat = prepare_remapping(rcgs, rms, p_dst(:,i), i, js)
             if (errstat /= hor3map_noerr) then
                write(lp,*) trim(hor3map_errstr(errstat))
+               write(lp,*) 'i,j',i+i0,j+j0
                call xchalt('(remap_trc_jslice)')
                stop '(remap_trc_jslice)'
             endif
@@ -993,7 +1069,7 @@ contains
          tracer_pc_upper_bndr, tracer_pc_lower_bndr, &
          velocity_pc_upper_bndr, velocity_pc_lower_bndr, dpmin_interior, &
          regrid_method, k_range_plevel, regrid_nudge_ts, stab_fac_limit, &
-         smooth_diff_max, dktzu, dktzl
+         dpvar_fac, smooth_diff_max, dktzu, dktzl
 
       ! Return if ALE method is not required.
       if (vcoord_tag == vcoord_isopyc_bulkml) return
@@ -1044,6 +1120,7 @@ contains
          call xcbcst(k_range_plevel)
          call xcbcst(regrid_nudge_ts)
          call xcbcst(stab_fac_limit)
+         call xcbcst(dpvar_fac)
          call xcbcst(smooth_diff_max)
          call xcbcst(dktzu)
          call xcbcst(dktzl)
@@ -1067,6 +1144,7 @@ contains
          write (lp,*) '  k_range_plevel =         ', k_range_plevel
          write (lp,*) '  regrid_nudge_ts =        ', regrid_nudge_ts
          write (lp,*) '  stab_fac_limit =         ', stab_fac_limit
+         write (lp,*) '  dpvar_fac =              ', dpvar_fac
          write (lp,*) '  smooth_diff_max =        ', smooth_diff_max
          write (lp,*) '  dktzu =                  ', dktzu
          write (lp,*) '  dktzl =                  ', dktzl
@@ -1276,7 +1354,7 @@ contains
       integer, parameter :: p_ord = 4
 
       real(r8), dimension(kdm+1,1-nbdy:idm+nbdy,3) :: &
-         p_src_js, p_dst_js, stab_fac_js, smtflxconv_js
+         p_src_js, p_dst_js, smooth_fac_js, smtflxconv_js
       real(r8), dimension(p_ord+1,kdm,ntr_loc,1-nbdy:idm+nbdy,3) :: tpc_src_js
       real(r8), dimension(2,kdm,ntr_loc,1-nbdy:idm+nbdy,3) :: t_srcdi_js
       real(r8), dimension(2,kdm,1-nbdy:idm+nbdy,3) :: &
@@ -1369,7 +1447,7 @@ contains
          enddo
       end if
 
-      ! Inital j-slice indices.
+      ! Initial j-slice indices.
       js1 = 1
       js2 = js1 + jofs2
       js3 = js1 + jofs3
@@ -1388,50 +1466,51 @@ contains
                                      ilb3, iub3, j+jofs3, js3, nn)
 
          ! Regrid.
-         call regrid_jslice         (p_src_js(:,:,js3), ksmx_js(:,js3), &
-                                     tpc_src_js(:,:,:,:,js3), &
-                                     t_srcdi_js(:,:,:,:,js3), &
-                                     p_dst_js(:,:,js3), stab_fac_js(:,:,js3), &
-                                     ilb3, iub3, j+jofs3, js3, nn)
+         call regrid_jslice(p_src_js(:,:,js3), ksmx_js(:,js3), &
+                            tpc_src_js(:,:,:,:,js3), &
+                            t_srcdi_js(:,:,:,:,js3), &
+                            p_dst_js(:,:,js3), &
+                            smooth_fac_js(:,:,js3), &
+                            ilb3, iub3, j+jofs3, js3, nn)
 
          ! If requested, apply lateral smoothing of the interfaces after
          ! regridding.
          if (j >= jlb_regrid_smooth) &
-            call regrid_smooth_jslice   (p_dst_js, stab_fac_js, smtflxconv_js, &
-                                         ilb2, iub2, j+jofs2, js2, js3)
+            call regrid_smooth_jslice(p_dst_js, smooth_fac_js, smtflxconv_js, &
+                                      ilb2, iub2, j+jofs2, js2, js3)
 
          ! If requested, prepare neutral diffusion.
          if (j >= jlb_ndiff_prep) &
-            call ndiff_prep_jslice      (p_src_js, ksmx_js, &
-                                         tpc_src_js, t_srcdi_js, &
-                                         p_dst_js, kdmx_js, p_srcdi_js, &
-                                         drhodt_srcdi_js, drhods_srcdi_js, &
-                                         flxconv_js, &
-                                         ilb2, iub2, j+jofs2, js2, mm)
+            call ndiff_prep_jslice(p_src_js, ksmx_js, &
+                                   tpc_src_js, t_srcdi_js, &
+                                   p_dst_js, kdmx_js, p_srcdi_js, &
+                                   drhodt_srcdi_js, drhods_srcdi_js, &
+                                   flxconv_js, &
+                                   ilb2, iub2, j+jofs2, js2, mm)
 
          ! If requested, compute the contribution of u-component fluxes to the
          ! flux convergence of neutral diffusion.
          if (j >= jlb_ndiff_uflx) &
-            call ndiff_uflx_jslice      (ksmx_js, tpc_src_js, t_srcdi_js, &
-                                         p_dst_js, kdmx_js, p_srcdi_js, &
-                                         drhodt_srcdi_js, drhods_srcdi_js, &
-                                         flxconv_js, &
-                                         ntr_loc, ilb1, iub2, j, js1, mm, nn)
+            call ndiff_uflx_jslice(ksmx_js, tpc_src_js, t_srcdi_js, &
+                                   p_dst_js, kdmx_js, p_srcdi_js, &
+                                   drhodt_srcdi_js, drhods_srcdi_js, &
+                                   flxconv_js, &
+                                   ntr_loc, ilb1, iub2, j, js1, mm, nn)
 
          ! If requested, compute the contribution of v-component fluxes to the
          ! flux convergence of neutral diffusion.
          if (j >= jlb_ndiff_vflx) &
-            call ndiff_vflx_jslice      (ksmx_js, tpc_src_js, t_srcdi_js, &
-                                         p_dst_js, kdmx_js, p_srcdi_js, &
-                                         drhodt_srcdi_js, drhods_srcdi_js, &
-                                         flxconv_js, &
-                                         ntr_loc, ilb1, iub1, j+jofs2, &
-                                         js1, js2, mm, nn)
+            call ndiff_vflx_jslice(ksmx_js, tpc_src_js, t_srcdi_js, &
+                                   p_dst_js, kdmx_js, p_srcdi_js, &
+                                   drhodt_srcdi_js, drhods_srcdi_js, &
+                                   flxconv_js, &
+                                   ntr_loc, ilb1, iub1, j+jofs2, &
+                                   js1, js2, mm, nn)
 
          ! Remap tracers to the regridded layers.
          if (j >= 1) &
-            call remap_trc_jslice       (p_dst_js(:,:,js1), trc_rm, &
-                                         ilb1, iub1, j, js1)
+            call remap_trc_jslice(p_dst_js(:,:,js1), trc_rm, &
+                                  ilb1, iub1, j, js1)
 
          ! If requested, update the tracers by applying the neutral diffusion
          ! flux convergence.
@@ -1441,8 +1520,8 @@ contains
 
          ! Copy from the j-slice array to the full tracer array.
          if (j >= 1) &
-            call copy_jslice_to_3d      (p_dst_js(:,:,js1), trc_rm, &
-                                         ilb1, iub1, j, nn)
+            call copy_jslice_to_3d(p_dst_js(:,:,js1), trc_rm, &
+                                   ilb1, iub1, j, nn)
       enddo
 
       ! ------------------------------------------------------------------------


### PR DESCRIPTION
This functionality applies to the ALE method when using `regrid_method = 'nudge'` and mitigates the issue of unsatisfactory layer structure that may develop after multidecadal integration times. A namelist variable `dpvar_fac` controls the layer thickness variation limiting and should be in the range [0, 1], reducing variation with increased value. Default value is `dpvar_fac = 0.75`.

<img width="1555" height="1091" alt="NOINYOC_T62_tn21_20250823_atl_temp_full_0200-12" src="https://github.com/user-attachments/assets/375727c0-471b-4a7d-9fdf-3f3b385c612b" />

An Atlantic section showing model layers and potential temperature after 200 years with CORE normal year forcing. This simulation is without limiting of layer thickness variation.

<img width="1555" height="1091" alt="NOINY_T62_tn21_dpvarlim_20250829_atl_temp_full_0200-12" src="https://github.com/user-attachments/assets/977f01f6-e009-403c-9c05-ebdf43c3c70f" />

Same as above, but with limiting of layer thickness variation and `dpvar_fac = 0.7`.
