### PR TITLE
Functionality to bound the mixed layer depth applied in the restratification parameterizations

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -476,7 +476,7 @@
     <category>limits</category>
     <group>limits</group>
     <values>
-      <value>0.</value>
+      <value>300.</value>
     </values>
     <desc>Time-scale for running mean filter when signal is greater than filtered value (used for boundary layer thickness and vertical momentum flux)</desc>
   </entry>
@@ -486,7 +486,7 @@
     <category>limits</category>
     <group>limits</group>
     <values>
-      <value>0.</value>
+      <value>86400.</value>
     </values>
     <desc>Time-scale for running mean filter when signal is less than filtered value (used for boundary layer thickness and vertical momentum flux)</desc>
   </entry>
@@ -549,6 +549,16 @@
       <value>1.e-7</value>
     </values>
     <desc>Minimum vertical momentum flux (Bodner et al., 2023)</desc>
+  </entry>
+
+  <entry id="mlbl_max_ratio">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>3.</value>
+    </values>
+    <desc>Maximum ratio between mixed and boundary layer depths in restratification parameterizations []</desc>
   </entry>
 
   <entry id="mlrttp">

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -71,6 +71,8 @@
 !            velocity (Bodner et al., 2023) () (f)
 ! WPUP_MIN : Minimum vertical momentum flux (Bodner et al., 2023)
 !            (m**2/s**2) (f)
+! MLBL_MAX_RATIO   : Maximum ratio between mixed and boundary layer
+!                    depths in restratification parameterizations () (f)
 ! MLRTTP   : Type of mixed layer restratification time scale. Valid
 !            types: 'variable', 'constant', 'limited' (a)
 ! RM0      : Efficiency factor of wind TKE generation in the Oberhuber

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -52,7 +52,7 @@ module mod_rdlim
   use mod_eddtra,      only: mlrmth, ce, cl, tau_mlr, tau_growing_hbl, &
                              tau_decaying_hbl, tau_growing_hml, &
                              tau_decaying_hml, lfmin, mstar, nstar, &
-                             wpup_min
+                             wpup_min, mlbl_max_ratio
   use mod_mxlayr,      only: rm0, rm5, mlrttp
   use mod_niw,         only: niwgf, niwbf, niwlf
   use mod_tidaldissip, only: tdfile
@@ -138,7 +138,7 @@ contains
          mommth,pgfmth,bmcmth,advmth,cppm_compatibility,cppm_limiting, &
          mlrmth,ce,cl,tau_mlr,tau_growing_hbl,tau_decaying_hbl, &
          tau_growing_hml,tau_decaying_hml,lfmin,mstar,nstar,wpup_min, &
-         mlrttp,rm0,rm5,tdfile,niwgf,niwbf,niwlf, &
+         mlbl_max_ratio,mlrttp,rm0,rm5,tdfile,niwgf,niwbf,niwlf, &
          swamth,jwtype,chlopt,ccfile,svfile, &
          trxday,srxday,trxdpt,srxdpt,trxlim,srxlim, &
          aptflx,apsflx,ditflx,disflx,srxbal,scfile, &
@@ -223,6 +223,7 @@ contains
       write (lp,*) 'MSTAR',MSTAR
       write (lp,*) 'NSTAR',NSTAR
       write (lp,*) 'WPUP_MIN',WPUP_MIN
+      write (lp,*) 'MLBL_MAX_RATIO',MLBL_MAX_RATIO
       write (lp,*) 'MLRTTP ',trim(MLRTTP)
       write (lp,*) 'RM0',RM0
       write (lp,*) 'RM5',RM5
@@ -314,6 +315,7 @@ contains
     call xcbcst(mstar)
     call xcbcst(nstar)
     call xcbcst(wpup_min)
+    call xcbcst(mlbl_max_ratio)
     call xcbcst(mlrttp)
     call xcbcst(rm0)
     call xcbcst(rm5)


### PR DESCRIPTION
The strength of mixed layer restratification by the Fox-Kemper et al. (2008) and Bodner et al. (2023) parameterizations is highly dependent on the mixed layer depth (MLD). Large lateral restratifying fluxes were found in association with localised deep MLDs, leading to unsatisfactory layer structure. This PR adds functionality to bound the MLD used in the parameterizations by introducing a namelist variable `mlbl_max_ratio` that sets a maximum ratio between MLD and boundary layer depth (BLD). Default value is `mlbl_max_ratio = 3.0`. To reduce diurnal variation of BLD, time filter scales have been set to `tau_growing_hbl = 300.0` and `tau_decaying_hbl = 86400.0` seconds.