### PR TITLE
Set types for real and integer variables

### DIFF
--- a/ben02/mod_ben02.F90
+++ b/ben02/mod_ben02.F90
@@ -321,8 +321,8 @@ contains
     character :: filename*(*)
 
     integer :: status,ncid,varid,i,j
-    real*4 r4lon(atm_idm),r4lat(atm_jdm)
-    integer*2 i2field(atm_idm,atm_jdm)
+    real(r4) :: r4lon(atm_idm),r4lat(atm_jdm)
+    integer(i2) :: i2field(atm_idm,atm_jdm)
 
     ! --- Open netcdf file.
     status = nf90_open(filename,nf90_nowrite,ncid)
@@ -408,7 +408,7 @@ contains
     character :: filename*(*)
 
     integer :: status,ncid,varid,i,j
-    real*4 r4field(atm_idm,atm_jdm)
+    real(r4) :: r4field(atm_idm,atm_jdm)
 
     ! --- Open netcdf file.
     status = nf90_open(filename,nf90_nowrite,ncid)
@@ -468,9 +468,9 @@ contains
 
     integer :: status,ncid,dimid,atm_idm_t,atm_jdm_t,timeid,varid, &
          vartype,start(3),count(3),stride(3),i,j
-    integer*2 i2field(atm_idm,atm_jdm),i2_mval
+    integer(i2) :: i2field(atm_idm,atm_jdm),i2_mval
     real :: time
-    real*4 offset,scale_factor
+    real(r4) :: offset,scale_factor
 
     ! --- open netcdf file
     status = nf90_open(filename,nf90_nowrite,ncid)
@@ -910,7 +910,7 @@ contains
           do n = 1,atm_nwgt
             is = atm_iwgt(n,it,jt)
             js = atm_jwgt(n,it,jt)
-            if (atm_mask(is,js) == 1.and. &
+            if (atm_mask(is,js) == 1 .and. &
                  adata(is,js) /= atm_mval) then
               w = atm_wgt(n,it,jt)
               w_sum = w_sum+w
@@ -1926,7 +1926,7 @@ contains
     ! --- ------------------------------------------------------------------
 
     real, dimension(atm_idm,atm_jdm) :: atm_field
-    real*4, dimension(atm_idm,atm_jdm) :: atm_field_r4
+    real(r4), dimension(atm_idm,atm_jdm) :: atm_field_r4
     real, dimension(itdm,jtdm) :: tmp2d
     integer :: i,j,k,nfu
 
@@ -1978,7 +1978,7 @@ contains
     ! --- ------------------------------------------------------------------
 
     real, dimension(atm_idm,atm_jdm) :: atm_field
-    real*4, dimension(atm_idm,atm_jdm) :: atm_field_r4
+    real(r4), dimension(atm_idm,atm_jdm) :: atm_field_r4
     real, dimension(itdm,jtdm) :: tmp2d
     real :: dx2,dy2
     integer, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: smtmsk
@@ -2088,15 +2088,15 @@ contains
 
     real, allocatable, dimension(:,:,:) :: atm_sktclm
     real, allocatable, dimension(:,:) :: atm_field
-    real*4, allocatable, dimension(:,:) :: atm_field_r4
+    real(r4), allocatable, dimension(:,:) :: atm_field_r4
     real, dimension(itdm,jtdm) :: tmp2d
     integer, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,12) :: smtmsk
     real :: dx2,dy2,prc_sum,eva_sum,rnf_sum,swa_sum,lwa_sum,lht_sum, &
          sht_sum,fwf_fac,dangle,garea,le,albedo,fac,swa_ave,lwa_ave, &
          lht_ave,sht_ave,crnf,cswa
-    real*4 :: rw4
+    real(r4) :: rw4
     integer :: i,j,k,l,il,jl,nfu
-    integer*2 :: rn2,ri2,rj2
+    integer(i2) :: rn2,ri2,rj2
 
     ! --- Allocate memory for additional monthly forcing fields.
     allocate(taud  (1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,12), &
@@ -2921,9 +2921,9 @@ contains
     ! --- ------------------------------------------------------------------
 
     real :: dx2,dy2
-    real*4 :: rw4
+    real(r4) :: rw4
     integer :: errstat,i,j,k,l,nfu
-    integer*2 :: rn2,ri2,rj2
+    integer(i2) :: rn2,ri2,rj2
 
     ! --- Allocate memory for daily forcing fields.
     allocate(taud  (1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy,5), &

--- a/hamocc/mo_aufr_bgc.F90
+++ b/hamocc/mo_aufr_bgc.F90
@@ -105,6 +105,7 @@ CONTAINS
     use mo_param_bgc,       only: bifr13_ini,bifr14_ini,c14fac,re1312,re14to,prei13,prei14
     use mo_netcdf_bgcrw,    only: read_netcdf_var
 #ifdef PNETCDF
+    use mod_types,          only: i4
     use mod_xc,             only: mpicomm
 #endif
 
@@ -139,7 +140,7 @@ CONTAINS
 #ifdef PNETCDF
 #   include <pnetcdf.inc>
 #   include <mpif.h>
-    integer*4, save  :: info=MPI_INFO_NULL
+    integer(i4), save  :: info=MPI_INFO_NULL
 #endif
     character(len=3) :: stripestr
     character(len=9) :: stripestr2

--- a/hamocc/mo_aufr_bgc.F90
+++ b/hamocc/mo_aufr_bgc.F90
@@ -105,7 +105,6 @@ CONTAINS
     use mo_param_bgc,       only: bifr13_ini,bifr14_ini,c14fac,re1312,re14to,prei13,prei14
     use mo_netcdf_bgcrw,    only: read_netcdf_var
 #ifdef PNETCDF
-    use mod_types,          only: i4
     use mod_xc,             only: mpicomm
 #endif
 
@@ -140,7 +139,7 @@ CONTAINS
 #ifdef PNETCDF
 #   include <pnetcdf.inc>
 #   include <mpif.h>
-    integer(i4), save  :: info=MPI_INFO_NULL
+    integer, save    :: info=MPI_INFO_NULL
 #endif
     character(len=3) :: stripestr
     character(len=9) :: stripestr2

--- a/hamocc/mo_aufw_bgc.F90
+++ b/hamocc/mo_aufw_bgc.F90
@@ -94,7 +94,6 @@ contains
                               iprefdoc,iprefdocsl,iprefdocsr,iprefdocr
     use mo_netcdf_bgcrw,only: write_netcdf_var,netcdf_def_vardb
 #ifdef PNETCDF
-    use mod_types,      only: i4
     use mod_xc,         only: mpicomm
 #endif
 
@@ -130,7 +129,7 @@ contains
 #   include <pnetcdf.inc>
 #   include <mpif.h>
     integer(kind=MPI_OFFSET_KIND) :: clen
-    integer(i4) ,save             :: info=MPI_INFO_NULL
+    integer, save                 :: info=MPI_INFO_NULL
 #endif
 
     ! pass tracer fields in from ocean model, note that both timelevels

--- a/hamocc/mo_aufw_bgc.F90
+++ b/hamocc/mo_aufw_bgc.F90
@@ -94,6 +94,7 @@ contains
                               iprefdoc,iprefdocsl,iprefdocsr,iprefdocr
     use mo_netcdf_bgcrw,only: write_netcdf_var,netcdf_def_vardb
 #ifdef PNETCDF
+    use mod_types,      only: i4
     use mod_xc,         only: mpicomm
 #endif
 
@@ -129,7 +130,7 @@ contains
 #   include <pnetcdf.inc>
 #   include <mpif.h>
     integer(kind=MPI_OFFSET_KIND) :: clen
-    integer*4 ,save               :: info=MPI_INFO_NULL
+    integer(i4) ,save             :: info=MPI_INFO_NULL
 #endif
 
     ! pass tracer fields in from ocean model, note that both timelevels

--- a/phy/mod_nctools.F90
+++ b/phy/mod_nctools.F90
@@ -97,6 +97,7 @@ module mod_nctools
   use mod_calendar, only: date_type, daynum_diff, calendar_noerr, &
                           calendar_errstr
   use netcdf
+  use mod_types,    only: i2, i4, r4
 
   implicit none
   public
@@ -128,9 +129,9 @@ module mod_nctools
 #ifdef PNETCDF
   integer(kind = mpi_offset_kind) :: clen,istart(5),icount(5),tkd
 #endif
-  integer*2, parameter :: i2fill=-32768,i2max = 32767
+  integer(kind = i2), parameter :: i2fill=-32768,i2max = 32767
   real, parameter :: fillr8 = 9.9692099683868690e+36
-  real(kind=4), parameter :: fillr4 = 9.9692099683868690e+36
+  real(kind = r4), parameter :: fillr4 = 9.9692099683868690e+36
   integer :: ndouble,nchar,nfint
 
 contains
@@ -160,7 +161,7 @@ contains
     integer, parameter :: nf90__64bit_offset = 512
     integer, parameter :: nf90__hdf5 = 4096
 #ifdef PNETCDF
-    integer*4, save :: info = MPI_INFO_NULL
+    integer(i4), save  :: info = MPI_INFO_NULL
     character(len = 3) :: stripestr
     character(len = 9) :: stripestr2
     integer :: ierr
@@ -1216,7 +1217,7 @@ contains
     real :: scf,ofs,arng(2),fldmin,fldmax
     logical :: uvflg
     integer, dimension(maxdm) :: start,count
-    integer*2, allocatable, dimension(:,:,:) :: fldout,fld_out
+    integer(i2), allocatable, dimension(:,:,:) :: fldout,fld_out
     real, allocatable, dimension(:,:,:) ::rfld
     integer :: dimid,dimids(maxdm),strn,strind(2,maxdm)
     real, dimension(itdm,jtdm) :: rfldt
@@ -1621,7 +1622,7 @@ contains
     real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: rfld,rmsk
     real, dimension(itdm,jtdm) :: rfldt,rmskt
     real, dimension(itdm*jtdm) :: fldout
-    real(kind = 4), dimension(itdm*jtdm) :: fldoutr4
+    real(kind = r4), dimension(itdm*jtdm) :: fldoutr4
     character(len=4) :: c4
     integer :: i,j,ij,ijk,k,n,kd
     integer, dimension(maxdm) :: start,count
@@ -1814,7 +1815,7 @@ contains
     real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: rfld,rmsk
     real, dimension(itdm,jtdm) :: rfldt,rmskt
     real :: scf,ofs,arng(2),fldmin,fldmax
-    integer*2, dimension(itdm*jtdm) :: fldout
+    integer(i2), dimension(itdm*jtdm) :: fldout
     logical :: uvflg
     integer, dimension(maxdm) :: start,count
 
@@ -2203,8 +2204,8 @@ contains
     integer, parameter :: maxdm=5
     integer, parameter :: ijdm = (idm+2*nbdy)*(jdm+2*nbdy)
     integer :: dimid,dimids(maxdm),strn,strind(2,maxdm)
-    real(kind = 4), allocatable, dimension(:,:,:) :: r4fldt
-    real(kind = 4), allocatable, dimension(:,:,:) :: wr4fldt
+    real(kind = r4), allocatable, dimension(:,:,:) :: r4fldt
+    real(kind = r4), allocatable, dimension(:,:,:) :: wr4fldt
     real, allocatable, dimension(:,:,:) :: rfld,wrfld
     real, allocatable, dimension(:,:) :: rmsk,rfldt,rmskt
     integer, dimension(maxdm) :: start,count
@@ -3113,7 +3114,7 @@ contains
     integer, dimension(maxdm) :: dimids
 
     real :: arng(2)
-    integer*2 i2min,vrng(2)
+    integer(i2) :: i2min,vrng(2)
     if (rec == 1) then
       i2min = -i2max
       vrng(1) = i2min

--- a/phy/mod_wtime.F90
+++ b/phy/mod_wtime.F90
@@ -31,7 +31,7 @@ contains
 
   real(r8) function wtime()
     ! use the function  rtc  to return wall time.
-    real(r8) rtc
+    real(r8) :: rtc
     wtime = rtc()
   end function wtime
 
@@ -39,7 +39,7 @@ contains
 
   real(r8) function wtime()
     ! use the mpi function  mpi_wtime  to return wall time.
-    real(r8) mpi_wtime
+    real(r8) :: mpi_wtime
     wtime = mpi_wtime()
   end function wtime
 

--- a/phy/mod_wtime.F90
+++ b/phy/mod_wtime.F90
@@ -20,6 +20,8 @@
 
 module mod_wtime
 
+  use mod_types,  only: r8
+
   implicit none
   public
 
@@ -27,31 +29,31 @@ contains
 
 #if defined(AIX)
 
-  real*8 function wtime()
+  real(r8) function wtime()
     ! use the function  rtc  to return wall time.
-    real*8 rtc
+    real(r8) rtc
     wtime = rtc()
   end function wtime
 
 #elif defined(MPI)
 
-  real*8 function wtime()
+  real(r8) function wtime()
     ! use the mpi function  mpi_wtime  to return wall time.
-    real*8 mpi_wtime
+    real(r8) mpi_wtime
     wtime = mpi_wtime()
   end function wtime
 
 #else
 
-  real*8 function wtime()
+  real(r8) function wtime()
     ! use the f90 intrinsic  system_clock  to return wall time.
     ! will fail if the count is ever negative, but the standard
     ! says that it is aways non-negative if a clock exists.
     ! not thread-safe, unless lcount and iover are threadprivate.
-    real*8, parameter :: zero= 0.0
-    real*8, parameter :: one = 1.0
+    real(r8), parameter :: zero= 0.0
+    real(r8), parameter :: one = 1.0
     integer :: count, mcount, rate
-    real*8 , save :: offsec, offset, persec
+    real(r8) , save :: offsec, offset, persec
     integer, save :: icount, iover,  lcount, ncount
     data iover, lcount / -1, -1 /
     !

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -774,7 +774,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine xclput4(aline,nl, a, i1,j1,iinc,jinc)
 
-    integer, intent(in)    ::  nl,i1,j1,iinc,jinc
+    integer,   intent(in)    ::  nl,i1,j1,iinc,jinc
     real(r4),  intent(in)    ::  aline(nl)
     real(r4),  intent(inout) ::  a(ii,jj)
 

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -22,6 +22,7 @@
 module mod_xc
 
   ! Note that dimensions.F is auto-generated
+  use mod_types,  only: i2, r4
   use dimensions, only: idm,jdm,kdm,itdm,jtdm,iqr,jqr,ijqr,&
                         ii_pe,jj_pe,i0_pe,j0_pe,nreg
   use mod_wtime,  only: wtime
@@ -774,8 +775,8 @@ contains
   subroutine xclput4(aline,nl, a, i1,j1,iinc,jinc)
 
     integer, intent(in)    ::  nl,i1,j1,iinc,jinc
-    real*4,  intent(in)    ::  aline(nl)
-    real*4,  intent(inout) ::  a(ii,jj)
+    real(r4),  intent(in)    ::  aline(nl)
+    real(r4),  intent(inout) ::  a(ii,jj)
 
     !-----------
     !  1) fill a line of elements in the non-tiled 2-D grid.
@@ -3296,17 +3297,17 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine xcgetrow4(outm,inm, kt)
-    integer, intent(in)      :: kt
-    real*4,    intent(out)   :: outm(itdm,jj,kt)
-    real*4,    intent(in)    :: inm(ii,jj,kt)
+    integer,   intent(in)    :: kt
+    real(r4),  intent(out)   :: outm(itdm,jj,kt)
+    real(r4),  intent(in)    :: inm(ii,jj,kt)
 
     !-----------
     !  convert an entire 2-D array from tiled to non-tiled layout.
     !-----------
 
-    integer :: mpireqb(ipr)
-    real*4  :: at(idm*jdm*2*kk),ata(idm*jdm*2*kk,iqr)
-    integer :: i,j,k,l,mp
+    integer  :: mpireqb(ipr)
+    real(r4) :: at(idm*jdm*2*kk),ata(idm*jdm*2*kk,iqr)
+    integer  :: i,j,k,l,mp
 
     !  gather each row of tiles onto the first tile in the row.
     if (mproc == mpe_1(nproc)) then
@@ -3356,17 +3357,17 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine xcgetrowint2(outm,inm, kt)
-    integer,   intent(in)  :: kt
-    integer*2, intent(out) :: outm(itdm,jj,kt)
-    integer*2, intent(in)  :: inm(ii,jj,kt)
+    integer,   intent(in)    :: kt
+    integer(i2), intent(out) :: outm(itdm,jj,kt)
+    integer(i2), intent(in)  :: inm(ii,jj,kt)
 
     !-----------
     ! convert an entire 2-D array from tiled to non-tiled layout.
     !-----------
 
-    integer   :: mpireqb(ipr)
-    integer*2 :: at(idm*jdm*kt),ata(idm*jdm*kt,iqr)
-    integer   :: i,j,k,l,mp,np
+    integer     :: mpireqb(ipr)
+    integer(i2) :: at(idm*jdm*kt),ata(idm*jdm*kt,iqr)
+    integer     :: i,j,k,l,mp,np
 
     !     gather each row of tiles onto the first tile in the row.
 


### PR DESCRIPTION
I came across some instances that used `integer*2`, `real*4` and `real*8` instead of the type settings `i2`, `r4` and `r8`. I'm not sure if these were intentionally set this way, in particular for interface with external libraries and MIP, so I'm setting this as a draft PR for now.

The `aux_blom_noresm` tests pass with this PR, except for expected fails.