### PR TITLE
Bug fix of out of bound issue and uninitialised arrays

### DIFF
--- a/cesm/mod_cesm.F90
+++ b/cesm/mod_cesm.F90
@@ -25,7 +25,7 @@ module mod_cesm
 ! ------------------------------------------------------------------------------
 
    use mod_types,      only: r8
-   use mod_constants,  only: pi
+   use mod_constants,  only: pi, spval
    use mod_time,       only: nstep
    use mod_xc
    use mod_forcing,    only: trxday, srxday, swa, nsf, lip, sop, eva, rnf, rfi, &
@@ -103,25 +103,66 @@ module mod_cesm
    public :: runid_cesm, runtyp_cesm, ocn_cpl_dt_cesm, nstep_in_cpl, hmlt, &
              frzpot, mltpot, swa_da, nsf_da, hmlt_da, lip_da, sop_da, eva_da, &
              rnf_da, rfi_da, fmltfz_da, sfl_da, ztx_da, mty_da, ustarw_da, &
-             slp_da, abswnd_da, ficem_da, lamult_da, lasl_da, flxdms_da, flxbrf_da, &
-             ustokes_da, vstokes_da, atmco2_da, atmbrf_da,atmn2o_da,atmnh3_da,&
-             atmnhxdep_da,atmnoydep_da, &
-             smtfrc, l1ci, l2ci,inicon_cesm, inifrc_cesm, getfrc_cesm
+             slp_da, abswnd_da, ficem_da, lamult_da, lasl_da, flxdms_da, &
+             flxbrf_da, ustokes_da, vstokes_da, atmco2_da, atmbrf_da, &
+             atmn2o_da, atmnh3_da, atmnhxdep_da,atmnoydep_da, smtfrc, &
+             l1ci, l2ci, inivar_cesm, inicon_cesm, inifrc_cesm, getfrc_cesm
 
 contains
+
+   subroutine inivar_cesm
+   ! ---------------------------------------------------------------------------
+   ! Initialize arrays.
+   ! ---------------------------------------------------------------------------
+
+      hmlt(:,:) = spval
+      frzpot(:,:) = spval
+      mltpot(:,:) = spval
+      swa_da(:,:,:) = spval
+      nsf_da(:,:,:) = spval
+      hmlt_da(:,:,:) = spval
+      lip_da(:,:,:) = spval
+      sop_da(:,:,:) = spval
+      eva_da(:,:,:) = spval
+      rnf_da(:,:,:) = spval
+      rfi_da(:,:,:) = spval
+      fmltfz_da(:,:,:) = spval
+      sfl_da(:,:,:) = spval
+      ztx_da(:,:,:) = spval
+      mty_da(:,:,:) = spval
+      ustarw_da(:,:,:) = spval
+      slp_da(:,:,:) = spval
+      abswnd_da(:,:,:) = spval
+      ficem_da(:,:,:) = spval
+      lamult_da(:,:,:) = spval
+      lasl_da(:,:,:) = spval
+      ustokes_da(:,:,:) = spval
+      vstokes_da(:,:,:) = spval
+      atmco2_da(:,:,:) = spval
+      atmbrf_da(:,:,:) = spval
+      flxdms_da(:,:,:) = spval
+      flxbrf_da(:,:,:) = spval
+      atmn2o_da(:,:,:) = spval
+      atmnh3_da(:,:,:) = spval
+      atmnhxdep_da(:,:,:) = spval
+      atmnoydep_da(:,:,:) = spval
+
+   end subroutine inivar_cesm
 
    subroutine inicon_cesm
    ! ---------------------------------------------------------------------------
    ! Set initial conditions for variables specifically when coupled to CESM.
    ! ---------------------------------------------------------------------------
 
-      integer :: i, j
+      integer :: i, j, l
 
-      !$omp parallel do private(i)
-      do j = 1, jj
-         do i = 1, ii
+      !$omp parallel do private(l,i)
+      do j = 1,jj
+         do l = 1,isp(j)
+         do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
             frzpot(i, j) = 0._r8
             mltpot(i, j) = 0._r8
+         enddo
          enddo
       enddo
       !$omp end parallel do
@@ -197,9 +238,9 @@ contains
            ustokes(i, j) = w1*ustokes_da(i, j, l1ci) + w2*ustokes_da(i, j, l2ci)
            vstokes(i, j) = w1*vstokes_da(i, j, l1ci) + w2*vstokes_da(i, j, l2ci)
            atmco2(i, j)  = w1*atmco2_da(i, j, l1ci)  + w2*atmco2_da(i, j, l2ci)
-           atmbrf(i, j)  = w1*atmbrf_da(i, j, l1ci)  + w2*atmbrf_da(i, j, l2ci)
-           atmn2o(i, j)  = w1*atmn2o_da(i, j, l1ci)  + w2*atmn2o_da(i, j, l2ci)
-           atmnh3(i, j)  = w1*atmnh3_da(i, j, l1ci)  + w2*atmnh3_da(i, j, l2ci)
+           atmbrf(i, j)  = - 1._r8
+           atmn2o(i, j)  = - 1._r8
+           atmnh3(i, j)  = - 1._r8
            atmnhxdep(i, j)  = w1*atmnhxdep_da(i, j, l1ci)  + w2*atmnhxdep_da(i, j, l2ci)
            atmnoydep(i, j)  = w1*atmnoydep_da(i, j, l1ci)  + w2*atmnoydep_da(i, j, l2ci)
         enddo

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -812,6 +812,8 @@ contains
                slp_da(i,j,l2ci) = mval
                abswnd_da(i,j,l2ci) = mval
                ficem_da(i,j,l2ci) = mval
+               atmnhxdep_da(i,j,l2ci) = mval
+               atmnoydep_da(i,j,l2ci) = mval
             elseif (cplmsk(i,j) == 0) then
                lip_da(i,j,l2ci) = 0._r8
                sop_da(i,j,l2ci) = 0._r8
@@ -826,6 +828,8 @@ contains
                slp_da(i,j,l2ci) = fval
                abswnd_da(i,j,l2ci) = fval
                ficem_da(i,j,l2ci) = fval
+               atmnhxdep_da(i,j,l2ci) = 0._r8
+               atmnoydep_da(i,j,l2ci) = 0._r8
             else
                n = (j - 1)*ii + i
                afac = med2mod_areacor(n)
@@ -973,6 +977,27 @@ contains
          enddo
          !$omp end parallel do
 
+      else
+         !$omp parallel do private(i)
+         do j = 1, jj
+            do i = 1, ii
+               if (ip(i,j) == 0) then
+                  lamult_da(i,j,l2ci) = mval
+                  lasl_da(i,j,l2ci) = mval
+                  ustokes_da(i,j,l2ci) = mval
+                  vstokes_da(i,j,l2ci) = mval
+               else
+                  lamult_da(i,j,l2ci) = 0._r8
+                  lasl_da(i,j,l2ci) = 0._r8
+                  ustokes_da(i,j,l2ci) = 0._r8
+                  vstokes_da(i,j,l2ci) = 0._r8
+               endif
+            enddo
+         enddo
+         !$omp end parallel do
+         if (mnproc == 1 .and. first_call)  then
+            write(lp,*) subname//': wave fields not obtained from mediator'
+         endif
       end if
 
       ! CO2 flux
@@ -1011,7 +1036,7 @@ contains
                if (ip(i,j) == 0) then
                   atmco2_da(i,j,l2ci) = mval
                else
-                  atmco2_da(i,j,l2ci) = -1
+                  atmco2_da(i,j,l2ci) = -1._r8
                endif
             enddo
          enddo

--- a/phy/mod_inivar.F90
+++ b/phy/mod_inivar.F90
@@ -36,6 +36,7 @@ module mod_inivar
   use mod_niw,         only: inivar_niw
   use mod_tidaldissip, only: inivar_tidaldissip
   use mod_tracers,     only: inivar_tracers
+  use mod_cesm,        only: inivar_cesm
 
   implicit none
   private
@@ -67,6 +68,7 @@ contains
     call inivar_cmnfld
     call inivar_niw
     call inivar_tidaldissip
+    call inivar_cesm
 
   end subroutine inivar
 

--- a/phy/mod_ndiff.F90
+++ b/phy/mod_ndiff.F90
@@ -825,22 +825,24 @@ contains
         if (p_nslp_dst > p_nslp_src(1)) exit
         nslpxy(i_p,j_p,kd) = nslp_src(1)
       enddo
-      ks = 1
-      interp_loop: do
-        do while (p_nslp_dst > p_nslp_src(ks))
-          if (ks == nns) exit interp_loop
-          ks = ks + 1
+      if (kd <= kk) then
+        ks = 1
+        interp_loop: do
+          do while (p_nslp_dst > p_nslp_src(ks))
+            if (ks == nns) exit interp_loop
+            ks = ks + 1
+          enddo
+          q = (p_nslp_src(ks) - p_nslp_dst) &
+               /max(p_nslp_src(ks) - p_nslp_src(ks-1), epsilp)
+          nslpxy(i_p,j_p,kd) = q*nslp_src(ks-1) + (1._r8 - q)*nslp_src(ks)
+          kd = kd + 1
+          if (kd > kk) exit
+          p_nslp_dst = .5_r8*(p_dst_m(kd) + p_dst_p(kd))
+        enddo interp_loop
+        do kd = kd, kk
+          nslpxy(i_p,j_p,kd) = nslp_src(nns)
         enddo
-        q = (p_nslp_src(ks) - p_nslp_dst) &
-             /max(p_nslp_src(ks) - p_nslp_src(ks-1), epsilp)
-        nslpxy(i_p,j_p,kd) = q*nslp_src(ks-1) + (1._r8 - q)*nslp_src(ks)
-        kd = kd + 1
-        if (kd > kk) exit
-        p_nslp_dst = .5_r8*(p_dst_m(kd) + p_dst_p(kd))
-      enddo interp_loop
-      do kd = kd, kk
-        nslpxy(i_p,j_p,kd) = nslp_src(nns)
-      enddo
+      endif
     endif
 
   end subroutine ndiff_flx


### PR DESCRIPTION
An out of bound issue in the neutral diffusion routine has been corrected. Further, numerous arrays are now initialised, where uninitialised values was accessed.

Comparing one month simulations using compset NOIIAJRARYF8485OC, BLOM v1.12.0 and BLOM with this PR included gave bit-identical results for both BLOM and iHAMOCC. The out of bound issue was triggered in recent NorESM testing (https://github.com/NorESMhub/NorESM/issues/716), and the changes in this PR made the failing test pass. Likely, out of bound occurrences have been rare, but of course important to correct. Most of the access to uninitialised array elements has happened in masked regions with no expected impact on results. Other uninitialised access might have had impact such the filling of arrays `atmbrf`, `atmn2o` and `atmnh3` in `mod_cesm.F90`. Great if @JorgSchwinger, @jmaerz and @TomasTorsvik check if my changes of how values to these arrays are assigned makes sense.