### PR TITLE
Add expected fail entry for ERS_Ld3.TL319_tn05.NOIIAJRA

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -44,6 +44,13 @@
     </phase>
   </test>
 
+  <test name="ERS_Ld3.TL319_tn05.NOIIAJRA.betzy_intel">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>BLOM#664</issue>
+    </phase>
+  </test>
+
   <test name="SMS_D_Ld1.T62_tn14.NOIIAOC20TR.betzy_intel">
     <phase name="RUN">
       <status>FAIL</status>


### PR DESCRIPTION
For documentation:
I would like to add an entry for `ERS_Ld3.TL319_tn05.NOIIAJRA` in the list of expected fail tests, as I do not expect we will resolve issues with the `TL319_tn05` grid for the `noresm3_0_beta03` tag.