### PR TITLE
Set woa_nuopc_provided FALSE by default

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -151,7 +151,7 @@
     <group>limits</group>
     <values>
       <value>.false.</value>
-      <value comp_interface="nuopc">.true.</value>
+      <value comp_interface="nuopc">.false.</value>
       <value comp_interface="nuopc" blom_vcoord="isopyc_bulkml">.false.</value>
     </values>
     <desc>if .true., use NUOPC capability to read WOA climatology</desc>


### PR DESCRIPTION
I would like to disable the ` woa_nuopc_provided` option for now. I still get tests that hang on creation of the `woa18_s_an.nc` file. See e.g. https://github.com/NorESMhub/NorESM/issues/722