### PR TITLE
turn off mapping plots that cause problems with hangs in testing

### DIFF
--- a/drivers/nuopc/ocn_map_woa.F90
+++ b/drivers/nuopc/ocn_map_woa.F90
@@ -30,6 +30,8 @@ module ocn_map_woa
 
    public :: map_woa
 
+   logical :: plot_woa_data = .false.
+
    character(len=*), parameter :: u_FILE_u = &
       __FILE__
 
@@ -165,12 +167,14 @@ contains
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       ! Plot mapped fldbun temperature
-      if (mnproc == 1) then
-         write(lp,*)
-         write(lp,'(a)') trim(subname) //' plotting mapped data for '//trim(woa_varname_t)
+      if (plot_woa_data) then
+         if (mnproc == 1) then
+            write(lp,*)
+            write(lp,'(a)') trim(subname) //' plotting mapped data for '//trim(woa_varname_t)
+         end if
+         call io_write(filename="woa18_t_an.nc", fldbun=fldbun_blom, use_float=.false., rc=rc)
+         if (chkerr(rc,__LINE__,u_FILE_u)) return
       end if
-      call io_write(filename="woa18_t_an.nc", fldbun=fldbun_blom, use_float=.false., rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       ! Extract the data from the field bundle
       call ESMF_FieldBundleGet(fldbun_blom, fieldName='field_blom', field=field_blom, rc=rc)
@@ -213,12 +217,14 @@ contains
       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       ! Plot mapped fldbun salinity
-      if (mnproc == 1) then
-         write(lp,*)
-         write(lp,'(a)') trim(subname) // ' plotting mapped data for '//trim(woa_varname_s)
+      if (plot_woa_data) then
+         if (mnproc == 1) then
+            write(lp,*)
+            write(lp,'(a)') trim(subname) // ' plotting mapped data for '//trim(woa_varname_s)
+         end if
+         call io_write(filename="woa18_s_an.nc", fldbun=fldbun_blom, use_float=.false., rc=rc)
+         if (chkerr(rc,__LINE__,u_FILE_u)) return
       end if
-      call io_write(filename="woa18_s_an.nc", fldbun=fldbun_blom, use_float=.false., rc=rc)
-      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
       ! Extract the data from the field bundle
       call ESMF_FieldBundleGet(fldbun_blom, fieldName='field_blom', field=field_blom, rc=rc)

--- a/hamocc/mo_read_fedep.F90
+++ b/hamocc/mo_read_fedep.F90
@@ -198,7 +198,7 @@ contains
     real(rp), optional, intent(in)  :: dust_stream(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,ndust)
 
     integer :: i,j,n
-    logical :: debug = .true.
+    logical :: debug = .false.
     logical :: first_time = .true.
 
     if (present(dust_stream)) then


### PR DESCRIPTION
This PR turns off the default creation of woa18_t_an.nc and woa18_s_an.nc. This is disabled via a module variable plot_woa_data = .false. that can be modified to be .true.
I will come up with a more sophisticated method that only turns this off for testing and turns it on for longer production runs. But for now I think this is the simples way forwards.
