### PR TITLE
Initialize arrays that where accessed with uninitialized values

### DIFF
--- a/drivers/nuopc/ocn_map_woa.F90
+++ b/drivers/nuopc/ocn_map_woa.F90
@@ -131,6 +131,8 @@ contains
          call xchalt('(ocn_map_woa)')
          stop '(ocn_map_woa)'
       endif
+      t_woa(:,:,:) = t_woa_fval
+      s_woa(:,:,:) = s_woa_fval
 
       ! ---------------------------
       ! Create input data mesh

--- a/phy/mod_eddtra.F90
+++ b/phy/mod_eddtra.F90
@@ -47,7 +47,7 @@ module mod_eddtra
    private
 
    real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-      hbl_tf, wpup_tf, hml_tf1, hml_tf
+      hbl_tf, wpup_tf, hml_tf1, hml_tf, hml_tfbnd
 
    ! Options with default values, modifiable by namelist.
    character(len = 80) :: &
@@ -1016,7 +1016,7 @@ contains
          c5_21 = 5._r8/21._r8
 
       real(r8), dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
-         hml_tfbnd, upssmx, upssmy, ptu, ptv
+         upssmx, upssmy, ptu, ptv
       real(r8), dimension(kdm+1) :: puv, mflgm, mflsm, mfl
       real(r8), dimension(kdm) :: dlm, dlp
       real(r8) :: wf_growing_hbl, wf_decaying_hbl, &
@@ -1753,6 +1753,7 @@ contains
       wpup_tf(:,:) = spval
       hml_tf1(:,:) = spval
       hml_tf(:,:) = spval
+      hml_tfbnd(:,:) = spval
 
       !$omp parallel do private(l, i)
       do j = 1, jj

--- a/phy/mod_inivar.F90
+++ b/phy/mod_inivar.F90
@@ -34,6 +34,7 @@ module mod_inivar
   use mod_forcing,     only: inivar_forcing
   use mod_cmnfld,      only: inivar_cmnfld
   use mod_niw,         only: inivar_niw
+  use mod_swabs,       only: inivar_swabs
   use mod_tidaldissip, only: inivar_tidaldissip
   use mod_tracers,     only: inivar_tracers
   use mod_cesm,        only: inivar_cesm
@@ -67,6 +68,7 @@ contains
     call inivar_forcing
     call inivar_cmnfld
     call inivar_niw
+    call inivar_swabs
     call inivar_tidaldissip
     call inivar_cesm
 

--- a/phy/mod_momtum.F90
+++ b/phy/mod_momtum.F90
@@ -1271,9 +1271,6 @@ contains
       if (mnproc == 1) then
         write (lp,*) 'momtum:'
       end if
-      call chksum(drag , 1   , halo_ps, 'drag' )
-      call chksum(ubrhs, 1   , halo_uv, 'ubrhs')
-      call chksum(vbrhs, 1   , halo_vv, 'vbrhs')
       call chksum(dpu  , 2*kk, halo_us, 'dpu'  )
       call chksum(dpv  , 2*kk, halo_vs, 'dpv'  )
       call chksum(u    , 2*kk, halo_uv, 'u'    )

--- a/phy/mod_swabs.F90
+++ b/phy/mod_swabs.F90
@@ -47,15 +47,16 @@ module mod_swabs
 !     1103-1118.
 ! ------------------------------------------------------------------------------
 
-   use mod_types,    only: r8
-   use dimensions,   only: idm, jdm, itdm, jtdm
-   use mod_xc,       only: xcstop, xchalt, xcaput, xctilr, &
-                           nbdy, ii, jj, ip, isp, ifp, ilp, lp, &
-                           halo_ps, mnproc
-   use mod_time,     only: xmi, l1mi, l2mi, l3mi, l4mi, l5mi
-   use mod_checksum, only: csdiag, chksum
-   use mod_intp1d,   only: intp1d
-   use mod_utility,  only: fnmlen
+   use mod_types,     only: r8
+   use mod_constants, only: spval
+   use dimensions,    only: idm, jdm, itdm, jtdm
+   use mod_xc,        only: xcstop, xchalt, xcaput, xctilr, &
+                            nbdy, ii, jj, ip, isp, ifp, ilp, lp, &
+                            halo_ps, mnproc
+   use mod_time,      only: xmi, l1mi, l2mi, l3mi, l4mi, l5mi
+   use mod_checksum,  only: csdiag, chksum
+   use mod_intp1d,    only: intp1d
+   use mod_utility,   only: fnmlen
    use netcdf
 
    implicit none
@@ -135,7 +136,7 @@ module mod_swabs
 
   public :: swamth, chlopt, ccfile, svfile, jwtype, &
             swamxd, swfc1, swfc2, swal1, swal2, &
-            iniswa, updswa
+            inivar_swabs, iniswa, updswa
 
 contains
 
@@ -143,7 +144,21 @@ contains
    ! Public procedures.
    ! ---------------------------------------------------------------------------
 
-   subroutine iniswa()
+   subroutine inivar_swabs
+   ! ---------------------------------------------------------------------------
+   ! Initialize arrays.
+   ! ---------------------------------------------------------------------------
+
+      chl10c(:,:,:) = spval
+      chl10(:,:) = spval
+      swfc1(:,:) = spval
+      swfc2(:,:) = spval
+      swal1(:,:) = spval
+      swal2(:,:) = spval
+
+   end subroutine inivar_swabs
+
+   subroutine iniswa
    ! ---------------------------------------------------------------------------
    ! Initialize shortwave radiation absorption functionality.
    ! ---------------------------------------------------------------------------
@@ -501,7 +516,7 @@ contains
 
    end subroutine iniswa
 
-   subroutine updswa()
+   subroutine updswa
    ! ---------------------------------------------------------------------------
    ! Update arrays related to shortwave radiation absorption.
    ! ---------------------------------------------------------------------------


### PR DESCRIPTION
With the updated checksum functionality (https://github.com/NorESMhub/BLOM/pull/660), halo update (call to `xctilr`) is carried out for a copy of the array to be checksummed. This led to access of uninitialized array elements, which this PR corrects. 

The call to `xctilr` in subroutine `map_woa` also led to access to uninitialized array elements, which is also corrected. I do not think this should impact the issues in https://github.com/NorESMhub/BLOM/pull/666 and https://github.com/NorESMhub/BLOM/pull/667, but might be good be aware of, @mvertens.

The PR should not change any results. Note also that these accesses to uninitalized array elements are not trapped by the regular NorESM debug options. For the Intel compiler, the compiler option `-init=snan,arrays` is needed to trap these accesses and we should consider to make them default for BLOM debug options.

