### PR TITLE
speed up eri tests

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -277,7 +277,8 @@ def buildnml(case, caseroot, compname):
         if is_test:
             testcase = case.get_value("TESTCASE")
             config["is_test_pfs"] = "yes" if testcase == "PFS" else "no"
-            config["empty_hist"] = "yes" if testcase == "PFS" else "no"
+            config["is_test_eri"] = "yes" if testcase == "ERI" else "no"
+            config["empty_hist"] = "yes" if (testcase == "PFS" or testcase == "ERI") else "no"
 
         #---------------------------------
         # Set all ParamGen namelist values:

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -246,7 +246,6 @@ def buildnml(case, caseroot, compname):
         config["hamocc_sedspinup_yr_end"] = hamocc_sedspinup_yr_end
         config["hamocc_sedspinup_ncycle"] = hamocc_sedspinup_ncycle
         config["hamocc_sediment_quality"] = "yes" if hamocc_sediment_quality else "no"
-        config["is_test"] = "yes" if is_test else "no"
         config["comp_interface"] = comp_interface
         config["hamocc_shelf_res_time"] = "yes" if hamocc_shelf_res_time else "no"
 
@@ -274,11 +273,13 @@ def buildnml(case, caseroot, compname):
            print('Unknown sinking scheme option in BLOM buildnml- exit now')
            exit
 
+        config["is_test"] = "yes" if is_test else "no"
+        config["empty_hist"] = "no"
         if is_test:
             testcase = case.get_value("TESTCASE")
-            config["is_test_pfs"] = "yes" if testcase == "PFS" else "no"
-            config["is_test_eri"] = "yes" if testcase == "ERI" else "no"
-            config["empty_hist"] = "yes" if (testcase == "PFS" or testcase == "ERI") else "no"
+            test_argv = case.get_value("TEST_ARGV")
+            if (testcase == "PFS") or (testcase == "ERI" and "defaultio" not in test_argv):
+                config["empty_hist"] = "yes"
 
         #---------------------------------
         # Set all ParamGen namelist values:

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1796,9 +1796,18 @@
       <value>30,30,365</value>
       <value is_test="yes">1,30,365</value>
       <value is_test="yes" is_test_pfs="yes">30,30,365</value>
+      <value is_test="yes" is_test_eri="yes">30,30,365</value>
       <value blom_output_size="spinup">30,30,365</value>
     </values>
-    <desc>how often to start a new file in days</desc>
+    <desc>A positive integer for glb_filefreq indicates number of days
+    between new files while a negative integer indicates number of
+    files per day (glb_filefreq = -4 gives output files every 6
+    hours). Special cases are that glb_filefreq = 30 is interpreted as
+    monthly files (no matter which calendar is used) and 360 &lt;=
+    glb_filefreq &lt;= 366 is interpreted as yearly files (no matter
+    which calendar is used). There is currently no way to turn off
+    writing of hd,hm or hy files.
+    </desc>
   </entry>
 
   <entry id="glb_compflag@diaphy">
@@ -6007,7 +6016,16 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">30,365</value>
     </values>
-    <desc>Frequency for writing the BGC output</desc>
+    <desc>Frequency for writing the BGC output. A positive integer for
+    glb_filefreq indicates number of days between new files while a
+    negative integer indicates number of files per day (glb_filefreq =
+    -4 gives output files every 6 hours). Special cases are that
+    glb_filefreq = 30 is interpreted as monthly files (no matter which
+    calendar is used) and 360 &lt;= glb_filefreq &lt;= 366 is
+    interpreted as yearly files (no matter which calendar is
+    used). There is currently no way to turn off writing of hd,hm or
+    hy files.
+    </desc>
   </entry>
 
   <entry id="glb_compflag@diabgc">
@@ -6925,6 +6943,7 @@
       <value blom_n_deposition="yes">0,2,2</value>
       <value blom_n_deposition="yes" is_test="yes">4,2,2</value>
       <value hamocc_output_size="spinup">2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
     <desc>NOy nitrogen deposition flux [mol N m-2 s-1]</desc>
   </entry>
@@ -6938,6 +6957,7 @@
       <value blom_n_deposition="yes">0,2,2</value>
       <value blom_n_deposition="yes" is_test="yes">4,2,2</value>
       <value hamocc_output_size="spinup">2,2</value>
+      <value is_test="yes" empty_hist="yes">0,0,0</value>
     </values>
     <desc>NHx nitrogen deposition flux [mol N m-2 s-1] - extended N cycle only</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1794,9 +1794,7 @@
     <group>diaphy</group>
     <values>
       <value>30,30,365</value>
-      <value is_test="yes">1,30,365</value>
-      <value is_test="yes" is_test_pfs="yes">30,30,365</value>
-      <value is_test="yes" is_test_eri="yes">30,30,365</value>
+      <value is_test="yes" empty_hist="no" >1,30,365</value>
       <value blom_output_size="spinup">30,30,365</value>
     </values>
     <desc>A positive integer for glb_filefreq indicates number of days
@@ -6012,8 +6010,7 @@
     <group>diabgc</group>
     <values>
       <value>30,30,365</value>
-      <value is_test="yes">1,30,365</value>
-      <value is_test="yes" empty_hist="yes">0,0,0</value>
+      <value is_test="yes" empty_hist="no">1,30,365</value>
       <value hamocc_output_size="spinup">30,365</value>
     </values>
     <desc>Frequency for writing the BGC output. A positive integer for
@@ -6023,8 +6020,8 @@
     glb_filefreq = 30 is interpreted as monthly files (no matter which
     calendar is used) and 360 &lt;= glb_filefreq &lt;= 366 is
     interpreted as yearly files (no matter which calendar is
-    used). There is currently no way to turn off writing of hd,hm or
-    hy files.
+    which calendar is used). There is currently no way to turn off
+    writing of hd,hm or hy files.
     </desc>
   </entry>
 


### PR DESCRIPTION
An ERI test has 4 phases:
- ref1case
Do an initial run for 3 days writing restarts at day 3. ref1case is a clone of the main case. Short term archiving is on.

- ref2case (Suffix hybrid)
Do a hybrid run for default 19 days running with ref1 restarts from day 3, and writing restarts at day 10. ref2case is a clone of the main case. Short term archiving is on.

- case
Do a branch run, starting from restarts written in ref2case, for 9 days and writing restarts at day 5. Short term archiving is off.

- case (Suffix base)
Do a restart run from the branch run restarts for 4 days. Compare component history files ‘.base’ and ‘.hybrid’ at day 19. Short term archiving is off.

In the above cases BLOM writes out daily hd and hbgcd - whereas all other components do not write out these files UNLESS the `testmods="allactive/defaultio"`. This PR brings BLOM closer to behaving like the other components, decreases the time for ERI tests and also decreases the number of files created in these tests. This is particularly problematic when file system problems occur (such as has been the case with Betzy latetly).