### PR TITLE
Bugfix of non-reproducibility after restart for lateral diffusivity smoothing

### DIFF
--- a/phy/mod_ale_regrid_remap.F90
+++ b/phy/mod_ale_regrid_remap.F90
@@ -43,7 +43,7 @@ module mod_ale_regrid_remap
                             extract_polycoeff, regrid, &
                             prepare_remapping, remap, &
                             hor3map_noerr, hor3map_errstr
-   use mod_diffusion, only: ltedtp_opt, ltedtp_neutral, difiso, difmxp
+   use mod_diffusion, only: ltedtp_opt, ltedtp_neutral, difmxp
    use mod_ndiff,     only: ndiff_prep_jslice, ndiff_uflx_jslice, &
                             ndiff_vflx_jslice, ndiff_update_trc_jslice
    use mod_checksum,  only: csdiag, chksum
@@ -975,7 +975,7 @@ contains
          do i = max(ilb, ifp(j,l)), min(iub, ilp(j,l))
             do k = 2, kk
                p_dst_js(k,i,js2) = p_dst_js(k,i,js2) &
-                                   - smtflxconv_js(k,i,js2)*scp2i(i,j)
+                                 - smtflxconv_js(k,i,js2)*scp2i(i,j)
             enddo
          enddo
       enddo
@@ -1353,8 +1353,9 @@ contains
 
       integer, parameter :: p_ord = 4
 
+      real(r8), dimension(kdm,1-nbdy:idm+nbdy,3) :: smtflxconv_js
       real(r8), dimension(kdm+1,1-nbdy:idm+nbdy,3) :: &
-         p_src_js, p_dst_js, smooth_fac_js, smtflxconv_js
+         p_src_js, p_dst_js, smooth_fac_js
       real(r8), dimension(p_ord+1,kdm,ntr_loc,1-nbdy:idm+nbdy,3) :: tpc_src_js
       real(r8), dimension(2,kdm,ntr_loc,1-nbdy:idm+nbdy,3) :: t_srcdi_js
       real(r8), dimension(2,kdm,1-nbdy:idm+nbdy,3) :: &

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -984,17 +984,13 @@ contains
             ww = .125*ip(i-1,j  )*min(onem,dp(i-1,j  ,kn))/onem
             we = .125*ip(i+1,j  )*min(onem,dp(i+1,j  ,kn))/onem
             wn = .125*ip(i  ,j+1)*min(onem,dp(i  ,j+1,kn))/onem
-            wc = 1. - (ws + ww + we + wn)
-            rig_lf(i,j,k) =   ws*rig(i  ,j-1,k) &
-                            + ww*rig(i-1,j  ,k) &
-                            + wc*rig(i  ,j  ,k) &
-                            + we*rig(i+1,j  ,k) &
-                            + wn*rig(i  ,j+1,k)
-            bfsqi_lf(i,j,k) =   ws*bfsqi(i  ,j-1,k) &
-                              + ww*bfsqi(i-1,j  ,k) &
-                              + wc*bfsqi(i  ,j  ,k) &
-                              + we*bfsqi(i+1,j  ,k) &
-                              + wn*bfsqi(i  ,j+1,k)
+            wc = - ((ws + ww) + (we + wn)) + 1.
+            rig_lf(i,j,k) = (ws*rig(i  ,j-1,k) + ww*rig(i-1,j  ,k)) &
+                          + (we*rig(i+1,j  ,k) + wn*rig(i  ,j+1,k)) &
+                          + wc*rig(i,j,k)
+            bfsqi_lf(i,j,k) = (ws*bfsqi(i  ,j-1,k) + ww*bfsqi(i-1,j  ,k)) &
+                            + (we*bfsqi(i+1,j  ,k) + wn*bfsqi(i  ,j+1,k)) &
+                            + wc*bfsqi(i,j,k)
           end do
         end do
       end do
@@ -1173,12 +1169,10 @@ contains
             ww = .125*ip(i-1,j  )
             we = .125*ip(i+1,j  )
             wn = .125*ip(i  ,j+1)
-            wc = 1. - (ws + ww + we + wn)
-            OBLdepth(i,j) = ws*util1(i  ,j-1) &
-                          + ww*util1(i-1,j  ) &
-                          + wc*util1(i  ,j  ) &
-                          + we*util1(i+1,j  ) &
-                          + wn*util1(i  ,j+1)
+            wc = - ((ws + ww) + (we + wn)) + 1._r8
+            OBLdepth(i,j) = (ws*util1(i  ,j-1) + ww*util1(i-1,j  )) &
+                          + (we*util1(i+1,j  ) + wn*util1(i  ,j+1)) &
+                          + wc*util1(i,j)
             OBLdepth(i,j) = min(OBLdepth(i,j), -z_int(i,j,kk+1))
           end do
         end do
@@ -2017,22 +2011,18 @@ contains
         util2(:,:) = difiso(:,:,k)
         do j = 1 - mrg, jj + mrg
           do l = 1, isp(j)
-          do i = max(1 - mrg, ifp(j, l)), min(ii + mrg, ilp(j, l))
+          do i = max(1 - mrg, ifp(j,l)), min(ii + mrg, ilp(j,l))
             ws = .125_r8*ip(i  ,j-1)*min(onem,dp(i  ,j-1,kn))/onem
             ww = .125_r8*ip(i-1,j  )*min(onem,dp(i-1,j  ,kn))/onem
             we = .125_r8*ip(i+1,j  )*min(onem,dp(i+1,j  ,kn))/onem
             wn = .125_r8*ip(i  ,j+1)*min(onem,dp(i  ,j+1,kn))/onem
-            wc = 1._r8 - (ws + ww + we + wn)
-            difint(i,j,k) = ws*util1(i  ,j-1) &
-                          + ww*util1(i-1,j  ) &
-                          + wc*util1(i  ,j  ) &
-                          + we*util1(i+1,j  ) &
-                          + wn*util1(i  ,j+1)
-            difiso(i,j,k) = ws*util2(i  ,j-1) &
-                          + ww*util2(i-1,j  ) &
-                          + wc*util2(i  ,j  ) &
-                          + we*util2(i+1,j  ) &
-                          + wn*util2(i  ,j+1)
+            wc = 1._r8 - ((ws + ww) + (we + wn))
+            difint(i,j,k) = (ws*util1(i  ,j-1) + ww*util1(i-1,j  )) &
+                          + (we*util1(i+1,j  ) + wn*util1(i  ,j+1)) &
+                          + wc*util1(i,j)
+            difiso(i,j,k) = (ws*util2(i  ,j-1) + ww*util2(i-1,j  )) &
+                          + (we*util2(i+1,j  ) + wn*util2(i  ,j+1)) &
+                          + wc*util2(i,j)
           enddo
           enddo
         enddo
@@ -2610,22 +2600,18 @@ contains
         util2(:,:) = difiso(:,:,k)
         do j = 1 - mrg, jj + mrg
           do l = 1, isp(j)
-          do i = max(1 - mrg, ifp(j, l)), min(ii + mrg, ilp(j, l))
+          do i = max(1 - mrg, ifp(j,l)), min(ii + mrg, ilp(j,l))
             ws = .125_r8*ip(i  ,j-1)*min(onem,dp(i  ,j-1,kn))/onem
             ww = .125_r8*ip(i-1,j  )*min(onem,dp(i-1,j  ,kn))/onem
             we = .125_r8*ip(i+1,j  )*min(onem,dp(i+1,j  ,kn))/onem
             wn = .125_r8*ip(i  ,j+1)*min(onem,dp(i  ,j+1,kn))/onem
-            wc = 1._r8 - (ws + ww + we + wn)
-            difint(i,j,k) = ws*util1(i  ,j-1) &
-                          + ww*util1(i-1,j  ) &
-                          + wc*util1(i  ,j  ) &
-                          + we*util1(i+1,j  ) &
-                          + wn*util1(i  ,j+1)
-            difiso(i,j,k) = ws*util2(i  ,j-1) &
-                          + ww*util2(i-1,j  ) &
-                          + wc*util2(i  ,j  ) &
-                          + we*util2(i+1,j  ) &
-                          + wn*util2(i  ,j+1)
+            wc = - ((ws + ww) + (we + wn)) + 1._r8
+            difint(i,j,k) = (ws*util1(i  ,j-1) + ww*util1(i-1,j  )) &
+                          + (we*util1(i+1,j  ) + wn*util1(i  ,j+1)) &
+                          + wc*util1(i,j)
+            difiso(i,j,k) = (ws*util2(i  ,j-1) + ww*util2(i-1,j  )) &
+                          + (we*util2(i+1,j  ) + wn*util2(i  ,j+1)) &
+                          + wc*util2(i,j)
           enddo
           enddo
         enddo

--- a/phy/mod_ndiff.F90
+++ b/phy/mod_ndiff.F90
@@ -795,9 +795,9 @@ contains
           do nt = 3, ntr_loc
             dt = t_nl_m(nt) - t_nl_p(nt)
             if (dt*( trc(i_m,j_m,ks_m+nn,nt-2) &
-                 - trc(i_p,j_p,ks_p+nn,nt-2)) >= 0._r8 .and. &
-                 dt*( t_ni_m(nt,nip) - t_ni_p(nt,nip)) >= 0._r8 .and. &
-                 dt*( t_ni_m(nt,nic) - t_ni_p(nt,nic)) >= 0._r8) then
+                   - trc(i_p,j_p,ks_p+nn,nt-2)) >= 0._r8 .and. &
+                dt*( t_ni_m(nt,nip) - t_ni_p(nt,nip)) >= 0._r8 .and. &
+                dt*( t_ni_m(nt,nic) - t_ni_p(nt,nic)) >= 0._r8) then
               tflx = q*dt
               flxconv_js(kd_m,nt,i_m,js_m) = flxconv_js(kd_m,nt,i_m,js_m) + tflx
               flxconv_js(kd_p,nt,i_p,js_p) = flxconv_js(kd_p,nt,i_p,js_p) - tflx
@@ -833,7 +833,7 @@ contains
             ks = ks + 1
           enddo
           q = (p_nslp_src(ks) - p_nslp_dst) &
-               /max(p_nslp_src(ks) - p_nslp_src(ks-1), epsilp)
+              /max(p_nslp_src(ks) - p_nslp_src(ks-1), epsilp)
           nslpxy(i_p,j_p,kd) = q*nslp_src(ks-1) + (1._r8 - q)*nslp_src(ks)
           kd = kd + 1
           if (kd > kk) exit
@@ -869,7 +869,7 @@ contains
     integer :: l, i, nt, k, km, errstat
 
     do l = 1, isp(j)
-      do i = max(ilb, ifp(j, l)), min(iub, ilp(j, l))
+      do i = max(ilb, ifp(j,l)), min(iub, ilp(j,l))
 
         ! Find index of deepest destination layer with non-zero thickness.
         kdmx_js(i,js) = kk
@@ -905,13 +905,13 @@ contains
     do k = 1, kk
       km = k + mm
       do l = 1, isu(j)
-        do i = max(ilb, ifu(j, l)), min(iub, ilu(j, l))
+        do i = max(ilb, ifu(j,l)), min(iub, ilu(j,l))
           utflld(i,j,km) = 0._r8
           usflld(i,j,km) = 0._r8
         enddo
       enddo
       do l = 1, isv(j)
-        do i = max(ilb, ifv(j, l)), min(iub, ilv(j, l))
+        do i = max(ilb, ifv(j,l)), min(iub, ilv(j,l))
           vtflld(i,j,km) = 0._r8
           vsflld(i,j,km) = 0._r8
         enddo
@@ -946,7 +946,7 @@ contains
     integer :: l, i, ksmx_m, ksmx_p, kdmx_m, kdmx_p
 
     do l = 1, isu(j)
-      do i = max(ilb, ifu(j, l)), min(iub, ilu(j, l))
+      do i = max(ilb, ifu(j,l)), min(iub, ilu(j,l))
 
         p_srcdi_m => p_srcdi_js(:,:,i-1,js)
         p_srcdi_p => p_srcdi_js(:,:,i  ,js)
@@ -1008,7 +1008,7 @@ contains
     integer :: l, i, ksmx_m, ksmx_p, kdmx_m, kdmx_p
 
     do l = 1, isv(j)
-      do i = max(ilb, ifv(j, l)), min(iub, ilv(j, l))
+      do i = max(ilb, ifv(j,l)), min(iub, ilv(j,l))
 
         p_srcdi_m => p_srcdi_js(:,:,i,js_m)
         p_srcdi_p => p_srcdi_js(:,:,i,js_p)
@@ -1056,7 +1056,7 @@ contains
     integer :: k, l, i, nt
 
     do l = 1, isp(j)
-      do i = max(ilb, ifp(j, l)), min(iub, ilp(j, l))
+      do i = max(ilb, ifp(j,l)), min(iub, ilp(j,l))
         do k = 1, kk
           q = 1._r8/(scp2(i,j)*max( p_dst_js(k+1,i,js) &
                                   - p_dst_js(k  ,i,js), dp_eps))


### PR DESCRIPTION
This PR corrects the non-reproducibility after restart described in https://github.com/NorESMhub/BLOM/issues/662. The lateral smoothing of diffusivity led to roundoff difference between directly computing diffusivity at the Arctic seam of tripolar grids (non-restart) and halo update (restart). This PR will change results at roundoff level when smoothing of diffusivity is requested.

Other changes (minor code clean-up, memory saving) that do not impact results are also included in this PR.