### PR TITLE
fixes for eri test failures in prealpha testing

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -278,6 +278,7 @@ def buildnml(case, caseroot, compname):
         if is_test:
             testcase = case.get_value("TESTCASE")
             test_argv = case.get_value("TEST_ARGV")
+            config["is_test_pfs"] = "yes" if testcase == "PFS" else "no"
             if (testcase == "PFS") or (testcase == "ERI" and "defaultio" not in test_argv):
                 config["empty_hist"] = "yes"
 

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1815,7 +1815,8 @@
     <group>diaphy</group>
     <values>
       <value>30,30,365</value>
-      <value is_test="yes" empty_hist="no" >1,30,365</value>
+      <value is_test="yes" >1,30,365</value>
+      <value is_test="yes" is_test_pfs="yes">30,30,365</value>
       <value blom_output_size="spinup">30,30,365</value>
     </values>
     <desc>A positive integer for glb_filefreq indicates number of days
@@ -6031,8 +6032,9 @@
     <group>diabgc</group>
     <values>
       <value>30,30,365</value>
-      <value is_test="yes" empty_hist="no">1,30,365</value>
-      <value hamocc_output_size="spinup">30,365</value>
+      <value is_test="yes" >1,30,365</value>
+      <value is_test="yes" is_test_pfs="yes">30,30,365</value>
+      <value blom_output_size="spinup">30,30,365</value>
     </values>
     <desc>Frequency for writing the BGC output. A positive integer for
     glb_filefreq indicates number of days between new files while a


### PR DESCRIPTION
With these changes verified that ERI.ne3pg3_tn21.N1850fates-nocomp.betzy_intel now passes.
