### PR TITLE
Use high-order vertical reconstructions for remapping to diagnostic z-levels.

### DIFF
--- a/phy/mod_blom_init.F90
+++ b/phy/mod_blom_init.F90
@@ -38,7 +38,7 @@ module mod_blom_init
   use mod_eos,             only: inieos
   use mod_swabs,           only: iniswa
   use mod_tmsmt,           only: initms
-  use mod_dia,             only: diaini
+  use mod_dia,             only: diaini, diaout_alarms
   use mod_inicon,          only: inicon, woa_nuopc_provided
   use mod_budget,          only: budget_init
   use mod_cmnfld_routines, only: cmnfld1
@@ -428,6 +428,12 @@ contains
     ! --------------------------------------------------------------------------
 
     call extract_sigref
+
+    ! --------------------------------------------------------------------------
+    ! Set output io group alarms.
+    ! --------------------------------------------------------------------------
+
+    call diaout_alarms
 
     ! --------------------------------------------------------------------------
 

--- a/phy/mod_blom_step.F90
+++ b/phy/mod_blom_step.F90
@@ -36,7 +36,7 @@ module mod_blom_step
                                  get_time
   use mod_xc,              only: lp, kk, mnproc, xctilr, xcsum
   use mod_vcoord,          only: vcoord_tag, vcoord_isopyc_bulkml, sigref_adapt
-  use mod_ale_regrid_remap, only: ale_regrid_remap
+  use mod_ale_regrid_remap, only: ale_regrid_remap, ale_remap_diazlv
   use mod_ale_vdiff,       only: ale_vdifft, ale_vdiffm
   use mod_swabs,           only: updswa
   use mod_tmsmt,           only: tmsmt1, tmsmt2
@@ -55,8 +55,7 @@ module mod_blom_step
   use mod_difest,          only: difest_isobml, difest_lateral_hybrid, &
                                  difest_vertical_hybrid
   use mod_chkvar,          only: chkvar
-  use mod_dia,             only: diaacc, diaout, nphy, &
-                                 diagann_phy, diagmon_phy, diagfq_phy, &
+  use mod_dia,             only: diaacc, diaout_alarms, diaout, &
                                  rstann, rstmon, rstfrq
   use mod_diapfl,          only: diapfl
   use mod_state,           only: temp, saln, dp, init_fluxes
@@ -283,13 +282,13 @@ contains
     ! output of BLOM diagnostics
     ! ------------------------------------------------------------------
 
-    do i = 1,nphy
-      if (((diagann_phy(i).and.nday_of_year == 1.or.diagmon_phy(i) &
-           .and.date%day == 1).and.mod(nstep,nstep_in_day) == 0).or. &
-           .not.(diagann_phy(i).or.diagmon_phy(i)).and. &
-           mod(nstep+.5,diagfq_phy(i)) < 1.) &
-           call diaout(i,m,n,mm,nn,k1m,k1n)
-    end do
+    call diaout_alarms
+
+    if (vcoord_tag /= vcoord_isopyc_bulkml) then
+      call ale_remap_diazlv(m,n,mm,nn,k1m,k1n)
+    end if
+
+    call diaout(m,n,mm,nn,k1m,k1n)
 
     ! update total time spent by various tasks
     auxil_total_time = auxil_total_time+auxil_time

--- a/phy/mod_nctools.F90
+++ b/phy/mod_nctools.F90
@@ -3139,6 +3139,12 @@ contains
         else
           dims = 'x y sigma time'
         end if
+      else if (isize  ==  11) then
+        if (cmpflg == 1) then
+          dims = gridid(1:1)//'comp layer time'
+        else
+          dims = 'x y layer time'
+        end if
       else if (isize  ==  2) then
         if (cmpflg == 1) then
           dims = gridid(1:1)//'comp depth time'

--- a/phy/mod_tmsmt.F90
+++ b/phy/mod_tmsmt.F90
@@ -326,22 +326,22 @@ contains
     end do
     !$omp end parallel do
 
-    if (vcoord_tag == vcoord_isopyc_bulkml) then
+    call xctilr(dp(1-nbdy,1-nbdy,k1m), 1,kk, 3,3, halo_ps)
 
-      call xctilr(dp(1-nbdy,1-nbdy,k1m), 1,kk, 3,3, halo_ps)
-
-      !$omp parallel do private(k,km,l,i)
-      do j = -2,jj+2
-        do k = 1,kk
-          km = k+mm
-          do l = 1,isp(j)
-            do i = max(-2,ifp(j,l)),min(ii+2,ilp(j,l))
-              p(i,j,k+1) = p(i,j,k)+dp(i,j,km)
-            end do
+    !$omp parallel do private(k,km,l,i)
+    do j = -2,jj+2
+      do k = 1,kk
+        km = k+mm
+        do l = 1,isp(j)
+          do i = max(-2,ifp(j,l)),min(ii+2,ilp(j,l))
+            p(i,j,k+1) = p(i,j,k)+dp(i,j,km)
           end do
         end do
       end do
-      !$omp end parallel do
+    end do
+    !$omp end parallel do
+
+    if (vcoord_tag == vcoord_isopyc_bulkml) then
 
       !$omp parallel do private(k,km,l,i,q)
       do j = -1,jj+2
@@ -361,21 +361,6 @@ contains
               dpv(i,j,km)= &
                    .5*((min(q,p(i,j-1,k+1))-min(q,p(i,j-1,k))) &
                       +(min(q,p(i,j  ,k+1))-min(q,p(i,j  ,k))))
-            end do
-          end do
-        end do
-      end do
-      !$omp end parallel do
-
-    else
-
-      !$omp parallel do private(k,km,l,i)
-      do j = 1,jj
-        do k = 1,kk
-          km = k+mm
-          do l = 1,isp(j)
-            do i = max(1,ifp(j,l)),min(ii,ilp(j,l))
-              p(i,j,k+1) = p(i,j,k)+dp(i,j,km)
             end do
           end do
         end do


### PR DESCRIPTION
In the PR, the already computed high-order vertical reconstructions for ALE regridding/remapping are reused to remap potential temperature, salinity, ideal age and velocity components to diagnostic z-levels.

To illustrate the impact, monthly average potential temperature in a Pacific South-North section is shown below. The upper panel is with the current 1. order remapping the z-levels, the middle panel is using the proposed high-order vertical reconstructions, and the lower panel is the difference. With the 1. order remapping, piecewise constant imprints of layers are visible in the z-level diagnostics.

<img width="717" height="211" alt="Screenshot 2025-10-06 at 08 52 36" src="https://github.com/user-attachments/assets/d67bb7be-541a-4ab9-ab86-8e1f34a661e7" />
<img width="716" height="209" alt="Screenshot 2025-10-06 at 08 52 39" src="https://github.com/user-attachments/assets/705e9de1-1c7b-4356-8050-4603634c3855" />
<img width="717" height="210" alt="Screenshot 2025-10-06 at 08 52 11" src="https://github.com/user-attachments/assets/abe808fc-9277-464a-abee-42a1c94643fe" />

Also, when using the ALE method, the vertical dimension of layer diagnostic is changed from `sigma` to `layer`. This is because `sigma` may vary in time and is therefore not well suited as a dimension, causing issues when concatenating layer diagnostic variables in e.g. xarray. This will require some changes to the NorESM standard diagnostics and I have a workaround for this that I will discuss with @YanchunHe.

In the implementation of using high-order reconstructions for remapping to diagnostic z-levels, changed results beyond the modified diagnostics are expected. This is due to roundoff differences in the computation of the column pressure range, that reduces code complexity and improves performance.

I have not detected any consistent performance degradation with the code changes introduced in this PR. However, during testing on Betzy, computational performance with and without these changes have been quite variable, so any performance impact should be further monitored.