### PR TITLE
Remove NOIIAOC20TR from list of standard tests

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -44,13 +44,6 @@
     </phase>
   </test>
 
-  <test name="SMS_D_Ld1.T62_tn14.NOIIAOC20TR.betzy_intel">
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>BLOM#510</issue>
-    </phase>
-  </test>
-
   <test name="SMS_D_Ld1.T62_tn14_wtn14nw.NOINYOC_WW3.betzy_gnu.blom-wavice">
     <phase name="RUN">
       <status>FAIL</status>
@@ -71,6 +64,17 @@
     <phase name="RUN">
       <status>FAIL</status>
       <issue>BLOM#645</issue>
+    </phase>
+  </test>
+
+  <!-- failing outdated tests -->
+
+  <!-- The NOIIAOC20TR compset is currently not working with NorESM3.
+       This test can be re-activated if we decide to update the compset. -->
+  <test name="SMS_D_Ld1.T62_tn14.NOIIAOC20TR.betzy_intel">
+    <phase name="RUN">
+      <status>FAIL</status>
+      <issue>BLOM#510</issue>
     </phase>
   </test>
 </expectedFails>

--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -47,15 +47,6 @@
       <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 1850 clim</option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAJRAOC20TR">
-    <machines>
-      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:20:00</option>
-      <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 20TR historical</option>
-    </options>
-  </test>
   <test name="SMS_D_Ld1" grid="TL319_tn14" compset="NOIIAJRARYF6162OC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>


### PR DESCRIPTION
The test based on the NOIIAOC20TR compset does not work with NorESM3. I propose to remove this test, and close the corresponding bug issue.

Close #510 (will-not-fix)