### PR TITLE
Remove test for IAF forcing instead of JRA forcing

### DIFF
--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -29,15 +29,6 @@
       <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; IAF forcing</option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAOC20TR">
-    <machines>
-      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:20:00</option>
-      <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; IAF forcing; 20TR historical</option>
-    </options>
-  </test>
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAJRAOC1850">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
@@ -45,6 +36,15 @@
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 1850 clim</option>
+    </options>
+  </test>
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAJRAOC20TR">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 20TR historical</option>
     </options>
   </test>
   <test name="SMS_D_Ld1" grid="TL319_tn14" compset="NOIIAJRARYF6162OC">


### PR DESCRIPTION
I removed the `NOIIAJRAOC20TR` test instead of the `NOIIAOC20TR` test in PR #676 
This PR recovers the `NOIIAJRAOC20TR` and removes the `NOIIAOC20TR` test.