### PR TITLE
Use NorESMhub fork and noresm tag for GSW-Fortran submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/CVMix/CVMix-src
 	fxtag = v0.98-beta
 	fxrequired = AlwaysRequired
-        fxDONOTUSEurl = https://github.com/CVMix/CVMix-src
+	fxDONOTUSEurl = https://github.com/CVMix/CVMix-src
 [submodule "pkgs/M4AGO-sinking-scheme"]
 	path = pkgs/M4AGO-sinking-scheme
 	url = https://github.com/jmaerz/M4AGO-sinking-scheme
@@ -12,4 +12,7 @@
 	fxDONOTUSEurl = https://github.com/jmaerz/M4AGO-sinking-scheme
 [submodule "pkgs/GSW-Fortran"]
 	path = pkgs/GSW-Fortran
-	url = https://github.com/TEOS-10/GSW-Fortran
+	url = https://github.com/NorESMhub/GSW-Fortran
+	fxtag = gsw-fortran_v3.05-6_noresm_v1
+	fxrequired = AlwaysRequired
+	fxDONOTUSEurl = https://github.com/TEOS-10/GSW-Fortran


### PR DESCRIPTION
This PR replaces the external https://github.com/TEOS-10/GSW-Fortran repository with a locally forked https://github.com/NorESMhub/GSW-Fortran repository, and makes the reference point at a new tag [gsw-fortran_v3.05-6_noresm_v1](https://github.com/NorESMhub/GSW-Fortran/releases/tag/gsw-fortran_v3.05-6_noresm_v1).

This ensures that the git-fleximod tool will check out a static tag version of GSW-Fortran, even if the TEOS-10/GSW-Fortran master branch should evolve.

Closes #602