### PR TITLE
Add flexibility to brine absorption parameterization and move hard-coded under sea-ice diffusivity parameters to namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -37,7 +37,7 @@
     <values>
       <value>0</value>
     </values>
-    <desc>First day of integration (i)</desc>
+    <desc>First day of integration</desc>
   </entry>
 
   <entry id="nday2">
@@ -47,7 +47,7 @@
     <values>
       <value>0</value>
     </values>
-    <desc>Last day of integration (i)</desc>
+    <desc>Last day of integration</desc>
   </entry>
 
   <entry id="idate">
@@ -57,7 +57,7 @@
     <values>
       <value>9999999</value>
     </values>
-    <desc>Model date in YYYYMMDD (i)</desc>
+    <desc>Model date in YYYYMMDD</desc>
   </entry>
 
   <entry id="idate0">
@@ -67,7 +67,7 @@
     <values>
       <value>9999999</value>
     </values>
-    <desc>Initial experiment date in YYYYMMDD (i)</desc>
+    <desc>Initial experiment date in YYYYMMDD</desc>
   </entry>
 
   <entry id="runid">
@@ -164,7 +164,7 @@
     <values>
       <value>2000.e4</value>
     </values>
-    <desc>Reference pressure for potential density (kg/m/s2) (f)</desc>
+    <desc>Reference pressure for potential density (kg/m/s2)</desc>
   </entry>
 
   <entry id="baclin">
@@ -182,7 +182,7 @@
       <value ocn_grid="tnx0.25v4">900.</value>
       <value ocn_grid="tnx0.125v4">300.</value>
     </values>
-    <desc>Baroclinic time step (sec) (f)</desc>
+    <desc>Baroclinic time step (sec)</desc>
   </entry>
 
   <entry id="batrop">
@@ -200,7 +200,7 @@
       <value ocn_grid="tnx0.25v4">15.</value>
       <value ocn_grid="tnx0.125v4">6.</value>
     </values>
-    <desc>Barotropic time step (sec) (f)</desc>
+    <desc>Barotropic time step (sec)</desc>
   </entry>
 
   <entry id="mdv2hi">
@@ -212,7 +212,7 @@
       <value ocn_grid="tnx0.25v4" >.0015</value>
       <value ocn_grid="tnx0.125v4">.001</value>
     </values>
-    <desc>Laplacian diffusion velocity for momentum dissipation (m/s) (f)</desc>
+    <desc>Laplacian diffusion velocity for momentum dissipation (m/s)</desc>
   </entry>
 
   <entry id="mdv2lo">
@@ -224,7 +224,7 @@
       <value ocn_grid="tnx0.25v4" >.0015</value>
       <value ocn_grid="tnx0.125v4">.001</value>
     </values>
-    <desc>Laplacian diffusion velocity for momentum dissipation (m/s) (f)</desc>
+    <desc>Laplacian diffusion velocity for momentum dissipation (m/s)</desc>
   </entry>
 
   <entry id="mdv4hi">
@@ -234,7 +234,7 @@
     <values>
       <value>0.</value>
     </values>
-    <desc>Biharmonic diffusion velocity for momentum dissipation (m/s) (f)</desc>
+    <desc>Biharmonic diffusion velocity for momentum dissipation (m/s)</desc>
   </entry>
 
   <entry id="mdv4lo">
@@ -244,7 +244,7 @@
     <values>
       <value>0.</value>
     </values>
-    <desc>Biharmonic diffusion velocity for momentum dissipation (m/s) (f)</desc>
+    <desc>Biharmonic diffusion velocity for momentum dissipation (m/s)</desc>
   </entry>
 
   <entry id="mdc2hi">
@@ -256,7 +256,7 @@
       <value ocn_grid="tnx0.25v4" >300.</value>
       <value ocn_grid="tnx0.125v4">300.</value>
     </values>
-    <desc>Laplacian diffusivity for momentum dissipation (m**2/s) (f)</desc>
+    <desc>Laplacian diffusivity for momentum dissipation (m**2/s)</desc>
   </entry>
 
   <entry id="mdc2lo">
@@ -268,7 +268,7 @@
       <value ocn_grid="tnx0.25v4" >300.</value>
       <value ocn_grid="tnx0.125v4">100.</value>
     </values>
-    <desc>Laplacian diffusivity for momentum dissipation (m**2/s) (f)</desc>
+    <desc>Laplacian diffusivity for momentum dissipation (m**2/s)</desc>
   </entry>
 
   <entry id="vsc2hi">
@@ -280,7 +280,7 @@
       <value ocn_grid="tnx0.25v4">.15</value>
       <value ocn_grid="tnx0.125v4">0.</value>
     </values>
-    <desc>Parameter in deformation-dependent Laplacian viscosity (f)</desc>
+    <desc>Parameter in deformation-dependent Laplacian viscosity</desc>
   </entry>
 
   <entry id="vsc2lo">
@@ -292,7 +292,7 @@
       <value ocn_grid="tnx0.25v4">.15</value>
       <value ocn_grid="tnx0.125v4">0.</value>
     </values>
-    <desc>Parameter in deformation-dependent Laplacian viscosity (f)</desc>
+    <desc>Parameter in deformation-dependent Laplacian viscosity</desc>
   </entry>
 
   <entry id="vsc4hi">
@@ -304,7 +304,7 @@
       <value ocn_grid="tnx0.25v4">0.0625</value>
       <value ocn_grid="tnx0.125v4">0.06</value>
     </values>
-    <desc>Parameter in deformation-dependent Biharmonic viscosity (f)</desc>
+    <desc>Parameter in deformation-dependent Biharmonic viscosity</desc>
   </entry>
 
   <entry id="vsc4lo">
@@ -316,7 +316,7 @@
       <value ocn_grid="tnx0.25v4">0.0625</value>
       <value ocn_grid="tnx0.125v4">0.06</value>
     </values>
-    <desc>Parameter in deformation-dependent Biharmonic viscosity (f)</desc>
+    <desc>Parameter in deformation-dependent Biharmonic viscosity</desc>
   </entry>
 
   <entry id="cbar">
@@ -326,7 +326,7 @@
     <values>
       <value>.05</value>
     </values>
-    <desc>rms flow speed for linear bottom friction law (m/s) (f)</desc>
+    <desc>rms flow speed for linear bottom friction law (m/s)</desc>
   </entry>
 
   <entry id="cb">
@@ -336,7 +336,7 @@
     <values>
       <value>.002</value>
     </values>
-    <desc>Nondimensional coefficient of quadratic bottom friction (f)</desc>
+    <desc>Nondimensional coefficient of quadratic bottom friction</desc>
   </entry>
 
   <entry id="cwbdts">
@@ -351,7 +351,7 @@
       <value ocn_grid="tnx0.25v4" >.75e-4</value>
       <value ocn_grid="tnx0.125v4">.75e-4</value>
     </values>
-    <desc>Coastal wave breaking damping reciprocal time scale (1/s) (f)</desc>
+    <desc>Coastal wave breaking damping reciprocal time scale (1/s)</desc>
   </entry>
 
   <entry id="cwbdls">
@@ -361,7 +361,7 @@
     <values>
       <value>25.</value>
     </values>
-    <desc>Coastal wave breaking damping length scale (m) (f)</desc>
+    <desc>Coastal wave breaking damping length scale (m)</desc>
   </entry>
 
   <entry id="mommth">
@@ -659,7 +659,7 @@
     <values>
       <value>3</value>
     </values>
-    <desc>Number indicating the Jerlov (1968) water type (i)</desc>
+    <desc>Number indicating the Jerlov (1968) water type</desc>
   </entry>
 
   <entry id="chlopt">
@@ -708,7 +708,7 @@
     <values>
       <value>0.</value>
     </values>
-    <desc>e-folding time scale (days) for SST relax., if 0 no relax. (f)</desc>
+    <desc>e-folding time scale (days) for SST relax., if 0 no relax.</desc>
   </entry>
 
   <entry id="srxday">
@@ -720,7 +720,7 @@
       <value blom_coupling="partial">60.</value>
       <value blom_coupling="partial" blom_vcoord="isopyc_bulkml">6.</value>
     </values>
-    <desc>e-folding time scale (days) for SSS relax., if 0 no relax. (f)</desc>
+    <desc>e-folding time scale (days) for SSS relax., if 0 no relax.</desc>
   </entry>
 
   <entry id="trxdpt">
@@ -730,7 +730,7 @@
     <values>
       <value>1.</value>
     </values>
-    <desc>Maximum mixed layer depth for e-folding SST relaxation (m) (f)</desc>
+    <desc>Maximum mixed layer depth for e-folding SST relaxation (m)</desc>
   </entry>
 
   <entry id="srxdpt">
@@ -743,7 +743,7 @@
       <value blom_coupling="partial" blom_vcoord="cntiso_hybrid">10.</value>
       <value blom_coupling="partial" blom_vcoord="plevel"       >10.</value>
     </values>
-    <desc>Maximum mixed layer depth for e-folding SSS relaxation (m) (f)</desc>
+    <desc>Maximum mixed layer depth for e-folding SSS relaxation (m)</desc>
   </entry>
 
   <entry id="trxlim">
@@ -753,7 +753,7 @@
     <values>
       <value>1.5</value>
     </values>
-    <desc>Max. absolute value of SST difference in relaxation (degC) (f)</desc>
+    <desc>Max. absolute value of SST difference in relaxation (degC)</desc>
   </entry>
 
   <entry id="srxlim">
@@ -763,7 +763,7 @@
     <values>
       <value>.5</value>
     </values>
-    <desc>Max. absolute value of SSS difference in relaxation (psu) (f)</desc>
+    <desc>Max. absolute value of SSS difference in relaxation (psu)</desc>
   </entry>
 
   <entry id="aptflx">
@@ -773,7 +773,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Apply diagnosed heat flux flag (l)</desc>
+    <desc>Apply diagnosed heat flux flag</desc>
   </entry>
 
   <entry id="apsflx">
@@ -783,7 +783,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Apply diagnosed freshwater flux flag (l)</desc>
+    <desc>Apply diagnosed freshwater flux flag</desc>
   </entry>
 
   <entry id="ditflx">
@@ -793,7 +793,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Diagnose heat flux flag (l)</desc>
+    <desc>Diagnose heat flux flag</desc>
   </entry>
 
   <entry id="disflx">
@@ -803,7 +803,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Diagnose freshwater flux flag (l)</desc>
+    <desc>Diagnose freshwater flux flag</desc>
   </entry>
 
   <entry id="srxbal">
@@ -814,7 +814,7 @@
       <value>.false.</value>
       <value blom_coupling="partial">.true.</value>
     </values>
-    <desc>Balance the SSS relaxation (l)</desc>
+    <desc>Balance the SSS relaxation</desc>
   </entry>
 
   <entry id="scfile" is_inputdata="yes">
@@ -851,7 +851,7 @@
       <value>.true.</value>
       <value ocn_grid="tnx1v4" ocn_ncpl="24">.false.</value>
     </values>
-    <desc>Smooth NorESM forcing (l)</desc>
+    <desc>Smooth NorESM forcing</desc>
   </entry>
 
   <entry id="sprfac">
@@ -862,7 +862,17 @@
       <value>.false.</value>
       <value blom_coupling="partial">.true.</value>
     </values>
-    <desc>Send precipitation/runoff factor to NorESM coupler (l)</desc>
+    <desc>Send precipitation/runoff factor to NorESM coupler</desc>
+  </entry>
+
+  <entry id="brine_mlbase_frac">
+    <type>real</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>1.0</value>
+    </values>
+    <desc>Fraction of brine absorption concentrated at mixed layer base</desc>
   </entry>
 
   <entry id="atm_path">
@@ -882,7 +892,7 @@
     <values>
       <value>60</value>
     </values>
-    <desc>Global i-index of point diagnostics (i)</desc>
+    <desc>Global i-index of point diagnostics</desc>
   </entry>
 
   <entry id="jtest">
@@ -892,7 +902,7 @@
     <values>
       <value>60</value>
     </values>
-    <desc>Global j-index of point diagnostics (i)</desc>
+    <desc>Global j-index of point diagnostics</desc>
   </entry>
 
   <entry id="cnsvdi">
@@ -902,7 +912,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Conservation diagnostics flag (l)</desc>
+    <desc>Conservation diagnostics flag</desc>
   </entry>
 
   <entry id="csdiag">
@@ -912,7 +922,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Checksum diagnostics flag (l)</desc>
+    <desc>Checksum diagnostics flag</desc>
   </entry>
 
   <entry id="rstfrq">
@@ -922,7 +932,7 @@
     <values>
       <value>1</value>
     </values>
-    <desc>Restart frequency in days (30=1month,365=1year) (i)</desc>
+    <desc>Restart frequency in days (30=1month,365=1year)</desc>
   </entry>
 
   <entry id="rstfmt">
@@ -944,7 +954,7 @@
     <values>
       <value>0</value>
     </values>
-    <desc>Compression flag for restart file (i)</desc>
+    <desc>Compression flag for restart file</desc>
   </entry>
 
   <entry id="iotype">
@@ -1445,7 +1455,7 @@
     <values>
       <value>.true.</value>
     </values>
-    <desc>If true, eddy diffusivity has a 2d structure (l)</desc>
+    <desc>If true, eddy diffusivity has a 2d structure</desc>
   </entry>
 
   <entry id="edsprs">
@@ -1455,7 +1465,7 @@
     <values>
       <value>.false.</value>
     </values>
-    <desc>Apply eddy mixing suppression away from steering level (l)</desc>
+    <desc>Apply eddy mixing suppression away from steering level</desc>
   </entry>
 
   <entry id="egc">
@@ -1465,7 +1475,7 @@
     <values>
       <value>2.0</value>
     </values>
-    <desc>Parameter c in Eden and Greatbatch (2008) parameterization (f)</desc>
+    <desc>Parameter c in Eden and Greatbatch (2008) parameterization</desc>
   </entry>
 
   <entry id="eggam">
@@ -1475,7 +1485,7 @@
     <values>
       <value>200.</value>
     </values>
-    <desc>Parameter gamma in E. and G. (2008) param. (f)</desc>
+    <desc>Parameter gamma in E. and G. (2008) param.</desc>
   </entry>
 
   <entry id="eglsmn">
@@ -1485,7 +1495,7 @@
     <values>
       <value>4000.</value>
     </values>
-    <desc>Minimum eddy length scale in  E. and G. (2008) param. (m) (f)</desc>
+    <desc>Minimum eddy length scale in  E. and G. (2008) param. (m)</desc>
   </entry>
 
   <entry id="egmndf">
@@ -1496,7 +1506,7 @@
       <value>50.</value>
       <value ocn_grid="tnx0.125v4">0.</value>
     </values>
-    <desc>Minimum diffusivity in E. and G. (2008) param. (m**2/s) (f)</desc>
+    <desc>Minimum diffusivity in E. and G. (2008) param. (m**2/s)</desc>
   </entry>
 
   <entry id="egmxdf">
@@ -1507,7 +1517,7 @@
       <value>2500.</value>
       <value ocn_grid="tnx0.125v4">0.</value>
     </values>
-    <desc>Maximum diffusivity in E. and G. (2008) param. (m**2/s) (f)</desc>
+    <desc>Maximum diffusivity in E. and G. (2008) param. (m**2/s)</desc>
   </entry>
 
   <entry id="egidfq">
@@ -1542,7 +1552,7 @@
     <values>
       <value>5.0</value>
     </values>
-    <desc>Linear scaling parameter for topographic rhines scale () (f)</desc>
+    <desc>Linear scaling parameter for topographic rhines scale ()</desc>
   </entry>
 
   <entry id="edanis">
@@ -1552,7 +1562,7 @@
     <values>
       <value>.true.</value>
     </values>
-    <desc>If true, apply anisotropy correction to eddy diffusivity (l)</desc>
+    <desc>If true, apply anisotropy correction to eddy diffusivity</desc>
   </entry>
 
   <entry id="redi3d">
@@ -1625,7 +1635,7 @@
       <value>1.5e-5</value>
       <value blom_vcoord="isopyc_bulkml">1.e-5</value>
     </values>
-    <desc>Background diapycnal diffusivity (m**2/s) (f)</desc>
+    <desc>Background diapycnal diffusivity (m**2/s)</desc>
   </entry>
 
   <entry id="bdmldp">
@@ -1655,7 +1665,7 @@
     <values>
       <value>.06</value>
     </values>
-    <desc>Internal wave dissipation factor under sea ice () (f)</desc>
+    <desc>Internal wave dissipation factor under sea ice</desc>
   </entry>
 
   <entry id="nubmin">
@@ -1665,7 +1675,7 @@
     <values>
       <value>2.e-6</value>
     </values>
-    <desc>Minimum background diapycnal diffusivity (m**2/s) (f)</desc>
+    <desc>Minimum background diapycnal diffusivity (m**2/s)</desc>
   </entry>
 
   <entry id="tkepf">
@@ -1751,7 +1761,7 @@
       <value ocn_grid="tnx1v4">105,106</value>
       <value ocn_grid="tnx0.5v1">209,210,307,307,274,279</value>
     </values>
-    <desc>Array of grid cell i-indices (i)</desc>
+    <desc>Array of grid cell i-indices</desc>
   </entry>
 
   <entry id="cwmj">
@@ -1764,7 +1774,7 @@
       <value ocn_grid="tnx1v4">273,273</value>
       <value ocn_grid="tnx0.5v1">417,417,353,354,429,431</value>
     </values>
-    <desc>Array of grid cell j-indices (i)</desc>
+    <desc>Array of grid cell j-indices</desc>
   </entry>
 
   <entry id="cwmwth">
@@ -1777,7 +1787,7 @@
       <value ocn_grid="tnx1v4">30.e3,30.e3</value>
       <value ocn_grid="tnx0.5v1">30.e3,30.e3,30.e3,30.e3,5.e3,5.e3</value>
     </values>
-    <desc>Array of modified grid cell widths (m) (f)</desc>
+    <desc>Array of modified grid cell widths (m)</desc>
   </entry>
 
   <!-- ========================= -->
@@ -4163,7 +4173,7 @@
     <values>
       <value>-34.,-34.,-34.,-90.</value>
     </values>
-    <desc>Minimum latitude to be considered for each region (f)</desc>
+    <desc>Minimum latitude to be considered for each region</desc>
   </entry>
 
   <entry id="mer_maxlat">
@@ -4173,7 +4183,7 @@
     <values>
       <value>90.,90.,90.,90.</value>
     </values>
-    <desc>Maximum latitude to be considered for each region (f)</desc>
+    <desc>Maximum latitude to be considered for each region</desc>
   </entry>
 
   <!-- ========================= -->
@@ -8494,7 +8504,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
     </values>
-    <desc>index of point diagnostics (i)</desc>
+    <desc>index of point diagnostics</desc>
   </entry>
 
   <entry id="lyr_wphy">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1638,6 +1638,26 @@
     <desc>Make the background mixing latitude dependent according to</desc>
   </entry>
 
+  <entry id="iwdflg">
+    <type>integer</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>1</value>
+    </values>
+    <desc>If iwdflg=1, reduce background diapycnal diffusivity due to internal wave damping under sea-ice</desc>
+  </entry>
+
+  <entry id="iwdfac">
+    <type>real</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>.06</value>
+    </values>
+    <desc>Internal wave dissipation factor under sea ice () (f)</desc>
+  </entry>
+
   <entry id="nubmin">
     <type>real</type>
     <category>diffusion</category>

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -111,8 +111,8 @@
 ! WAVSRC   : Source of wave fields. Valid source: 'none', 'param', 'extern' (a)
 ! SMTFRC   : Smooth NorESM forcing (l)
 ! SPRFAC   : Send precipitation/runoff factor to NorESM coupler (l)
-! BRINE_MLBASE_FRAC ! Fraction of brine absorption concentrated at mixed
-                    ! layer base (f)
+! BRINE_MLBASE_FRAC : Fraction of brine absorption concentrated at mixed
+!                     layer base (f)
 ! ATM_PATH : Path to forcing fields in case of EXPCNF 'ben02clim' or
 !            'ben02syn' (a)
 ! ITEST    : Global i-index of point diagnostics (i)

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -10,11 +10,12 @@
 ! RUNID    : Experiment name (a)
 ! EXPCNF   : Experiment configuration (a)
 ! RUNTYP   : CESM run type (a)
+! RPOINT   : CESM rpointer file (a)
 ! GRFILE   : Name of file containing grid specification (a)
 ! ICFILE   : Name of file containing initial conditions, that is either
 !            a valid restart file or 'inicon.nc' if climatological based
 !            initial conditions are desired (a)
-! woa_nuopc_provided: If .true., use NUOPC capability to read WOA climatology
+! WOA_NUOPC_PROVIDED: If .true., use NUOPC capability to read WOA climatology
 !                     (l)
 ! PREF     : Reference pressure for potential density (kg/m/s2) (f)
 ! BACLIN   : Baroclinic time step (sec) (f)

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -164,6 +164,9 @@
 ! BDMC2    : Background diapycnal diffusivity (m**2/s) (f)
 ! BDMLDP   : Make the background mixing latitude dependent according to
 !            Gregg et al. (2003) (l)
+! IWDFLG   : If iwdflg=1, reduce background diapycnal diffusivity due to
+!            internal wave damping under sea-ice
+! IWDFAC   : Internal wave dissipation factor under sea ice () (f)
 ! NUBMIN   : Minimum background diapycnal diffusivity (m**2/s) (f)
 ! TKEPF    : Fraction of surface TKE that penetrates beneath mixed layer
 !            () (f)

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -110,6 +110,8 @@
 ! WAVSRC   : Source of wave fields. Valid source: 'none', 'param', 'extern' (a)
 ! SMTFRC   : Smooth NorESM forcing (l)
 ! SPRFAC   : Send precipitation/runoff factor to NorESM coupler (l)
+! BRINE_MLBASE_FRAC ! Fraction of brine absorption concentrated at mixed
+                    ! layer base (f)
 ! ATM_PATH : Path to forcing fields in case of EXPCNF 'ben02clim' or
 !            'ben02syn' (a)
 ! ITEST    : Global i-index of point diagnostics (i)

--- a/phy/mod_ale_forcing.F90
+++ b/phy/mod_ale_forcing.F90
@@ -56,7 +56,7 @@ contains
     real(r8), parameter :: cbra1 = 2._r8**(1._r8/3._r8)
     real(r8), parameter :: cbra2 = cbra1*cbra1/12._r8
     real(r8) :: cpi, gaa, pmax, lei1, lei2, lei, q, q_c, q3, q_c3, pmaxi, &
-                nlbot, & dsgdt, dsgds
+                nlbot, dsgdt, dsgds
     real(r8) :: hf, hfsw, hfns, sf, sfbr, sfnb
     integer  :: i, j, k, l, kmax, kn
 

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -33,11 +33,11 @@ module mod_difest
                                    pbu, pbv, ubflxs_p, vbflxs_p, kfpla
   use mod_diffusion,         only: egc, eggam, eglsmn, egmndf, egmxdf, &
                                    egidfq, rhiscf, ri0, bdmc1, bdmc2, bdmldp, &
-                                   nubmin, tkepf, bdmtyp, eddf2d, edsprs, &
-                                   edanis, redi3d, rhsctp, edfsmo, smobld, &
-                                   lngmtp, edritp_opt, edritp_shear, &
-                                   edritp_large_scale, edwmth_opt, &
-                                   edwmth_smooth, edwmth_step, &
+                                   iwdflg, iwdfac, nubmin, tkepf, bdmtyp, &
+                                   eddf2d, edsprs, edanis, redi3d, rhsctp, &
+                                   edfsmo, smobld, lngmtp, edritp_opt, &
+                                   edritp_shear, edritp_large_scale, &
+                                   edwmth_opt, edwmth_smooth, edwmth_step, &
                                    ltedtp_opt, ltedtp_neutral, &
                                    difint, difiso, difdia, difmxp, difwgt, &
                                    Kvisc_m, Kdiff_t, Kdiff_s, &
@@ -115,8 +115,6 @@ module mod_difest
   !            iidtyp=2 the diffusivities are parameterized according
   !            to Eden and Greatbatch (2008).
   !   tdmflg - If tdmflg=1, apply tidally driven diapycnal mixing.
-  !   iwdflg - If iwdflg=1, reduce background diapycnal diffusivity
-  !            due to internal wave damping under sea-ice.
   !   dpbmin - smallest layer thickness allowed in evaluating
   !            local gradient richardson number [kg/m/s^2].
   !   drhomn - minimum density difference in evaluations the
@@ -131,7 +129,6 @@ module mod_difest
   !   drho0  - critical local interface density difference [kg/m^3]
   !   nuls0  - maximum diapycnal diffusivity applied when local
   !            stability is weak [m^2/s].
-  !   iwdfac - internal wave dissipation factor under sea ice [].
   !   dmxeff - diapycnal mixing efficiency [].
   !   tdmq   - tidal dissipation efficiency [].
   !   tdmls0 - tidal driven mixing length scale below critical
@@ -169,7 +166,6 @@ module mod_difest
   !            [m/s].
   integer , parameter :: iidtyp=2
   integer , parameter :: tdmflg=1
-  integer , parameter :: iwdflg=1
   integer , parameter :: dptmin = onem
   real    , parameter ::  dpbmin=onecm
   real    , parameter :: drhomn = 6.e-3
@@ -180,7 +176,6 @@ module mod_difest
   real    , parameter :: nug0 = 2.5e-1
   real    , parameter :: drho0 = 6.e-3
   real    , parameter :: nuls0=5.e-2
-  real    , parameter :: iwdfac = .06
   real    , parameter :: dmxeff=.2
   real    , parameter :: tdmq=1./3.
   real    , parameter :: tdmls0 = 500.*onem

--- a/phy/mod_diffusion.F90
+++ b/phy/mod_diffusion.F90
@@ -53,14 +53,17 @@ module mod_diffusion
       bdmc1, &  ! Background diapycnal diffusivity times buoyancy frequency
                 ! [m2 s-2].
       bdmc2, &  ! Background diapycnal diffusivity [m2 s-1].
+      iwdfac, & ! Internal wave dissipation factor under sea ice [].
       nubmin, & ! Minimum background diapycnal diffusivity [m2 s-1].
       tkepf     ! Fraction of surface TKE that penetrates beneath mixed layer
                 ! [].
    integer :: &
-      bdmtyp    ! Type of background diapycnal mixing. If bdmtyp = 1 the
+      bdmtyp, & ! Type of background diapycnal mixing. If bdmtyp = 1 the
                 ! background diffusivity is a constant divided by the
                 ! Brunt-Vaisala frequency, if bdmtyp = 2 the background
                 ! diffusivity is constant [].
+      iwdflg    ! If iwdflg=1, reduce background diapycnal diffusivity due to
+                ! internal wave damping under sea-ice.
    logical :: &
       eddf2d, & ! If true, eddy diffusivity has a 2d structure.
       edsprs, & ! If true, apply eddy mixing suppression away from steering
@@ -175,11 +178,11 @@ module mod_diffusion
 
    ! Public variables
    public :: egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-             bdmc1, bdmc2, bdmldp, nubmin, tkepf, bdmtyp, eddf2d, edsprs, &
-             edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, &
-             eitmth_opt, eitmth_intdif, eitmth_gm, edritp_opt, edritp_shear, &
-             edritp_large_scale, edwmth_opt, edwmth_smooth, edwmth_step, &
-             ltedtp_opt, ltedtp_layer, ltedtp_neutral, &
+             bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, bdmtyp, &
+             eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, &
+             lngmtp, eitmth_opt, eitmth_intdif, eitmth_gm, edritp_opt, &
+             edritp_shear, edritp_large_scale, edwmth_opt, edwmth_smooth, &
+             edwmth_step, ltedtp_opt, ltedtp_layer, ltedtp_neutral, &
              difint, difiso, difdia, difmxp, difmxq, difwgt, &
              umfltd, vmfltd, umflsm, vmflsm, utfltd, vtfltd, &
              utflsm, vtflsm, utflld, vtflld, usfltd, vsfltd, &
@@ -204,9 +207,9 @@ contains
 
       namelist /diffusion/ &
          egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-         bdmc1, bdmc2, bdmldp, nubmin, tkepf, bdmtyp, eddf2d, edsprs, edanis, &
-         redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, eitmth, edritp, &
-         edwmth, ltedtp
+         bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, bdmtyp, eddf2d, &
+         edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, &
+         eitmth, edritp, edwmth, ltedtp
 
       ! Read variables in the namelist group 'diffusion'.
       if (mnproc == 1) then
@@ -247,6 +250,8 @@ contains
         call xcbcst(bdmc1)
         call xcbcst(bdmc2)
         call xcbcst(bdmldp)
+        call xcbcst(iwdflg)
+        call xcbcst(iwdfac)
         call xcbcst(nubmin)
         call xcbcst(tkepf)
         call xcbcst(bdmtyp)
@@ -277,6 +282,8 @@ contains
          write (lp,*) '  bdmc1  = ', bdmc1
          write (lp,*) '  bdmc2  = ', bdmc2
          write (lp,*) '  bdmldp = ', bdmldp
+         write (lp,*) '  iwdflg = ', iwdflg
+         write (lp,*) '  iwdfac = ', iwdfac
          write (lp,*) '  nubmin = ', nubmin
          write (lp,*) '  tkepf  = ', tkepf
          write (lp,*) '  bdmtyp = ', bdmtyp

--- a/phy/mod_forcing.F90
+++ b/phy/mod_forcing.F90
@@ -40,29 +40,33 @@ module mod_forcing
 
    ! Variables to be set in namelist:
    logical :: &
-      aptflx, &       ! If true, apply diagnosed heat flux.
-      apsflx, &       ! If true, apply diagnosed freshwater flux.
-      ditflx, &       ! If true, diagnose heat flux.
-      disflx, &       ! If true, diagnose freshwater flux.
-      srxbal, &       ! If true, globally balance the SSS relaxation flux.
-      sprfac          ! If true, apply factor to precipitation and runoff for
-                      ! balancing the freshwater forcing budget. In case of
-                      ! coupling to CESM, this implies sending the factor to the
-                      ! coupler for application.
+      aptflx, &         ! If true, apply diagnosed heat flux.
+      apsflx, &         ! If true, apply diagnosed freshwater flux.
+      ditflx, &         ! If true, diagnose heat flux.
+      disflx, &         ! If true, diagnose freshwater flux.
+      srxbal, &         ! If true, globally balance the SSS relaxation flux.
+      sprfac            ! If true, apply factor to precipitation and runoff for
+                        ! balancing the freshwater forcing budget. In case of
+                        ! coupling to CESM, this implies sending the factor to
+                        ! the coupler for application.
    real(r8) :: &
-      trxday, &       ! e-folding relaxation time scale for SST [days].
-      srxday, &       ! e-folding relaxation time scale for SSS [days].
-      trxdpt, &       ! Maximum mixed layer depth nudged by SST relaxation [m].
-      srxdpt, &       ! Maximum mixed layer depth nudged by SSS relaxation [m].
-      trxlim, &       ! Maximum absolute value of SST difference in relaxation
-                      ! [deg C].
-      srxlim          ! Maximum absolute value of SSS difference in relaxation
-                      ! [g kg-1].
+      trxday, &         ! e-folding relaxation time scale for SST [days].
+      srxday, &         ! e-folding relaxation time scale for SSS [days].
+      trxdpt, &         ! Maximum mixed layer depth nudged by SST relaxation
+                        ! [m].
+      srxdpt, &         ! Maximum mixed layer depth nudged by SSS relaxation
+                        ! [m].
+      trxlim, &         ! Maximum absolute value of SST difference in relaxation
+                        ! [deg C].
+      srxlim, &         ! Maximum absolute value of SSS difference in relaxation
+                        ! [g kg-1].
+      brine_mlbase_frac ! Fraction of brine absorption concentrated at mixed
+                        ! layer base [].
 
    character(len = fnmlen) :: &
-      scfile, &       ! Name of file containing monthly SSS climatology.
-      wavsrc          ! Source of wave fields. Valid source: 'none', 'param',
-                      ! 'extern'.
+      scfile, &         ! Name of file containing monthly SSS climatology.
+      wavsrc            ! Source of wave fields. Valid source: 'none', 'param',
+                        ! 'extern'.
 
    ! Options derived from string options.
    integer :: &
@@ -190,7 +194,7 @@ module mod_forcing
    public :: aptflx, apsflx, ditflx, disflx, srxbal, sprfac, &
              trxday, srxday, trxdpt, srxdpt, trxlim, srxlim, scfile, &
              wavsrc, wavsrc_opt, wavsrc_none, wavsrc_param, wavsrc_extern, &
-             sref, tflxap, sflxap, tflxdi, sflxdi, nflxdi, &
+             brine_mlbase_frac, sref, tflxap, sflxap, tflxdi, sflxdi, nflxdi, &
              sstclm, ricclm, sssclm, prfac, eiacc, pracc, &
              swa, nsf, hmltfz, hmat, lip, sop, eva, rnf, rfi, fmltfz, sfl, &
              ztx, mty, ustarw, slp, abswnd, lamult, lasl, ustokes, vstokes, &

--- a/phy/mod_rdlim.F90
+++ b/phy/mod_rdlim.F90
@@ -45,8 +45,8 @@ module mod_rdlim
                              wavsrc, wavsrc_opt, wavsrc_none, &
                              wavsrc_param, wavsrc_extern, &
                              trxday, srxday, trxdpt, srxdpt, trxlim, &
-                             srxlim, srxbal, sprfac, use_stream_relaxation, &
-                             use_stream_dust
+                             srxlim, srxbal, sprfac, brine_mlbase_frac, &
+                             use_stream_relaxation, use_stream_dust
   use mod_swabs,       only: swamth, jwtype, chlopt, ccfile, svfile
   use mod_diffusion,   only: readnml_diffusion
   use mod_eddtra,      only: mlrmth, ce, cl, tau_mlr, tau_growing_hbl, &
@@ -142,7 +142,7 @@ contains
          swamth,jwtype,chlopt,ccfile,svfile, &
          trxday,srxday,trxdpt,srxdpt,trxlim,srxlim, &
          aptflx,apsflx,ditflx,disflx,srxbal,scfile, &
-         wavsrc,smtfrc,sprfac, &
+         wavsrc,smtfrc,sprfac,brine_mlbase_frac, &
          atm_path, &
          itest,jtest, &
          cnsvdi, &
@@ -251,6 +251,7 @@ contains
       write (lp,*) 'WAVSRC ',trim(WAVSRC)
       write (lp,*) 'SMTFRC',SMTFRC
       write (lp,*) 'SPRFAC',SPRFAC
+      write (lp,*) 'BRINE_MLBASE_FRAC',brine_mlbase_frac
       write (lp,*) 'ATM_PATH ',trim(ATM_PATH)
       write (lp,*) 'ITEST',ITEST
       write (lp,*) 'JTEST',JTEST
@@ -343,6 +344,7 @@ contains
     call xcbcst(wavsrc)
     call xcbcst(smtfrc)
     call xcbcst(sprfac)
+    call xcbcst(brine_mlbase_frac)
     call xcbcst(atm_path)
     call xcbcst(itest)
     call xcbcst(jtest)

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -110,8 +110,8 @@
 ! WAVSRC   : Source of wave fields. Valid source: 'none', 'param', 'extern' (a)
 ! SMTFRC   : Smooth NorESM forcing (l)
 ! SPRFAC   : Send precipitation/runoff factor to NorESM coupler (l)
-! BRINE_MLBASE_FRAC ! Fraction of brine absorption concentrated at mixed
-                    ! layer base (f)
+! BRINE_MLBASE_FRAC : Fraction of brine absorption concentrated at mixed
+!                     layer base (f)
 ! ATM_PATH : Path to forcing fields in case of EXPCNF 'ben02clim' or
 !            'ben02syn' (a)
 ! ITEST    : Global i-index of point diagnostics (i)

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -14,6 +14,8 @@
 ! ICFILE   : Name of file containing initial conditions, that is either
 !            a valid restart file or 'inicon.nc' if climatological based
 !            initial conditions are desired (a)
+! WOA_NUOPC_PROVIDED: If .true., use NUOPC capability to read WOA climatology
+!                     (l)
 ! PREF     : Reference pressure for potential density (kg/m/s2) (f)
 ! BACLIN   : Baroclinic time step (sec) (f)
 ! BATROP   : Barotropic time step (sec) (f)
@@ -43,14 +45,40 @@
 ! ADVMTH   : Advection method. Valid methods: 'remap', 'cppm' (a)
 ! CPPM_LIMITING : CPPM limiting. Valid methods: 'monotonic',
 !                 'non_oscillatory' (a)
+! MLRMTH   : Mixed layer restratification method. Valid methods: 'none',
+!            'fox08','bod23' (a)
+! CE       : Efficiency factor for the restratification by mixed layer
+!            eddies (Fox-Kemper et al., 2008) () (f)
+! CL       : Scaling of the efficiency factor for the restratification
+!            by mixed layer eddies (Bodner et al., 2023) () (f)
+! TAU_MLR  : Timescale for momentum mixing across mixed layer (s) (f).
+! TAU_GROWING_HBL  : Time-scale for running mean filter when signal is
+!                    greater than filtered value (used for boundary
+!                    layer thickness and vertical momentum flux) (s) (f)
+! TAU_DECAYING_HBL : Time-scale for running mean filter when signal is
+!                    less than filtered value (used for boundary layer
+!                    thickness and vertical momentum flux) (s) (f)
+! TAU_GROWING_HML  : Time-scale for running mean filter when signal is
+!                    greater than filtered value (used for mixed layer
+!                    thickness) (s) (f)
+! TAU_DECAYING_HML : Time-scale for running mean filter when signal is
+!                    less than filtered value (used for mixed layer
+!                    thickness) (s) (f)
+! LFMIN    : Minimum length scale of mixed layer fronts (m) (f)
+! MSTAR    : Scaling of boundary layer turbulence due to friction
+!            velocity (Bodner et al., 2023) () (f)
+! NSTAR    : Scaling of boundary layer turbulence due to convective
+!            velocity (Bodner et al., 2023) () (f)
+! WPUP_MIN : Minimum vertical momentum flux (Bodner et al., 2023)
+!            (m**2/s**2) (f)
+! MLBL_MAX_RATIO   : Maximum ratio between mixed and boundary layer
+!                    depths in restratification parameterizations () (f)
 ! MLRTTP   : Type of mixed layer restratification time scale. Valid
 !            types: 'variable', 'constant', 'limited' (a)
 ! RM0      : Efficiency factor of wind TKE generation in the Oberhuber
 !            (1993) TKE closure () (f)
 ! RM5      : Efficiency factor of TKE generation by momentum
 !            entrainment in the Oberhuber (1993) TKE closure () (f)
-! CE       : Efficiency factor for the restratification by mixed layer
-!            eddies (Fox-Kemper et al., 2008) () (f)
 ! TDFILE   : Name of file containing tidal wave energy dissipation
 !            divided by by bottom buoyancy frequency (a)
 ! NIWGF    : Global factor applied to the energy input by near-intertial
@@ -60,11 +88,13 @@
 ! NIWLF    : Fraction of near-inertial energy dissipated locally beneath
 !            the boundary layer () (f)
 ! SWAMTH   : Shortwave radiation absorption method. Valid methods:
-!            'top-layer', 'jerlov', 'chlorophyll' (a)
+!            'top-layer', 'jerlov', 'chlorophyll', 'spatial_frac_attlen' (a)
 ! JWTYPE   : Number indicating the Jerlov (1968) water type (i)
 ! CHLOPT   : Chlorophyll concentration option. Valid options:
 !            'climatology' (a)
 ! CCFILE   : Name of file containing chlorophyll concentration climatology (a)
+! SVFILE   : Name of file containing spatially varying spectral band fractions
+!            and attenuation lengths (a)
 ! TRXDAY   : e-folding time scale (days) for SST relax., if 0 no relax. (f)
 ! SRXDAY   : e-folding time scale (days) for SSS relax., if 0 no relax. (f)
 ! TRXDPT   : Maximum mixed layer depth for e-folding SST relaxation (m) (f)
@@ -78,8 +108,10 @@
 ! SRXBAL   : Balance the SSS relaxation (l)
 ! SCFILE   : Name of file containing SSS climatology used for relaxation (a)
 ! WAVSRC   : Source of wave fields. Valid source: 'none', 'param', 'extern' (a)
-! SMTFRC   : Smooth CESM forcing (l)
-! SPRFAC   : Send precipitation/runoff factor to CESM coupler (l)
+! SMTFRC   : Smooth NorESM forcing (l)
+! SPRFAC   : Send precipitation/runoff factor to NorESM coupler (l)
+! BRINE_MLBASE_FRAC ! Fraction of brine absorption concentrated at mixed
+                    ! layer base (f)
 ! ATM_PATH : Path to forcing fields in case of EXPCNF 'ben02clim' or
 !            'ben02syn' (a)
 ! ITEST    : Global i-index of point diagnostics (i)
@@ -151,6 +183,7 @@
   WAVSRC   = 'none'
   SMTFRC   = .false.
   SPRFAC   = .false.
+  BRINE_MLBASE_FRAC = 1.
   ATM_PATH = 'unset'
   ITEST    = 78
   JTEST    = 16
@@ -173,8 +206,6 @@
 ! EDWMTH   : Method to estimate eddy diffusivity weight as a function of
 !            the ration of Rossby radius of deformation to the
 !            horizontal grid spacing. Valid methods: 'smooth', 'step' (a)
-! MLRTTP   : Type of mixed layer restratification time scale. Valid
-!            types: 'variable', 'constant', 'limited' (a)
 ! EDDF2D   : If true, eddy diffusivity has a 2d structure (l)
 ! EDSPRS   : Apply eddy mixing suppression away from steering level (l)
 ! EGC      : Parameter c in Eden and Greatbatch (2008) parameterization (f)
@@ -192,6 +223,8 @@
 !            structure based in the 3D structure of anisotropy (l)
 ! RHSCTP   : If true, use the minimum of planetary and topographic beta
 !            to define the Rhines scale (l)
+! EDFSMO   : If true, apply lateral smoothing of isopycnal and interface
+!            diffusivities.
 ! RI0      : Critical gradient richardson number for shear driven
 !            vertical mixing () (f)
 ! BDMTYP   : Type of background diapycnal mixing. If bdmtyp=1 the
@@ -203,6 +236,9 @@
 ! BDMC2    : Background diapycnal diffusivity (m**2/s) (f)
 ! BDMLDP   : Make the background mixing latitude dependent according to
 !            Gregg et al. (2003) (l)
+! IWDFLG   : If iwdflg=1, reduce background diapycnal diffusivity due to
+!            internal wave damping under sea-ice
+! IWDFAC   : Internal wave dissipation factor under sea ice () (f)
 ! NUBMIN   : Minimum background diapycnal diffusivity (m**2/s) (f)
 ! TKEPF    : Fraction of surface TKE that penetrates beneath mixed layer
 !            () (f)
@@ -234,6 +270,8 @@
   BDMC1    = 5.e-8
   BDMC2    = 1.e-5
   BDMLDP   = .false.
+  IWDFLG   = 1
+  IWDFAC   = .06
   NUBMIN   = 1.e-6
   TKEPF    = 0.
   SMOBLD   = .true.
@@ -326,10 +364,10 @@
 !   MSC_     - miscellanous, non-gridded fields
 !
 ! Global parameters:
-!   FNAMETAG - tag used in file name (c10) 
-!   AVEPERIO - average period in days (i) 
-!   FILEFREQ - how often to start a new file in days (i) 
-!   COMPFLAG - switch for compressed/uncompressed output (i) 
+!   FNAMETAG - tag used in file name (c10)
+!   AVEPERIO - average period in days (i)
+!   FILEFREQ - how often to start a new file in days (i)
+!   COMPFLAG - switch for compressed/uncompressed output (i)
 !   NCFORMAT - netcdf format (valid arguments are 0 for classic,
 !              1 for 64-bit offset and 2 for netcdf4/hdf5 format)
 !


### PR DESCRIPTION
This PR achives two things:
1. Adds flexibility to the surface brine flux absorption parameterization. A namelist parameter `brine_mlbase_frac` has now been introduced, controlling how much of the brine absorption that is concentrated at the mixed layer base. With `brine_mlbase_frac = 1`, the currently implemented parameterization is recovered, concentrating all absorption of brine in a region close to the mixed layer base. The other extreme choice, `brine_mlbase_frac = 0`, absorbs brine more evenly in the mixed layer. This modification with `brine_mlbase_frac = 0.25` has been tested in experiment https://github.com/NorESMhub/noresm3_dev_simulations/issues/251.
2. The parameters controlling if (`iwdflg`) and by which fraction (`iwdfac`) background diffusivity is reduced with sea-ice present are now available as namelist parameters. The previous hard-coded behaviour was to enable diffusivity reduction, `iwdflg = 1`, and reducing background diffusivity by a factor `iwdfac = 0.06`. A test not reducing background diffusivity under sea-ice was done in experiment https://github.com/NorESMhub/noresm3_dev_simulations/issues/252.

The namelist settings in the PR will not change results (tested in a NOINYOC compset with T62_tn14 grids).