### PR TITLE
Upgrade timing

### DIFF
--- a/drivers/nocoupler/blom.F
+++ b/drivers/nocoupler/blom.F
@@ -26,6 +26,8 @@ c
       use mod_time, only: nstep2, nstep
       use mod_xc
       use mod_state, only: dp
+      use mod_timing, only: timer_start, timer_stop, timer_reset,
+     .                      timer_statistics
       use mod_checksum, only: chksum
       use mod_blom_init, only: blom_init_phase1, blom_init_phase2
       use mod_blom_step, only: blom_step
@@ -36,7 +38,13 @@ c
 c
 c --- initialize the model
       call blom_init_phase1
+      call timer_stop('initialization', 'blom_init_phase1')
       call blom_init_phase2
+      call timer_stop('initialization', 'blom_init_phase2')
+
+      call timer_statistics('initialization')
+      call timer_reset('initialization')
+      call timer_start('total_step_time')
 c
 c --- advance the model from time step nstep1 to nstep2
       blom_loop: do

--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -878,7 +878,6 @@ contains
       call timer_statistics('initialization')
       call timer_reset('initialization')
       call timer_start('ModelAdvance')
-      call timer_start('total_step_time')
 
    end subroutine DataInitialize
 
@@ -970,6 +969,7 @@ contains
 
       call timer_stop('ModelAdvance', 'before blom_loop')
       call timer_start('blom_loop')
+      call timer_start('total_step_time')
 
       blom_loop: do
 
@@ -1077,6 +1077,7 @@ contains
             call timer_statistics('ModelAdvance')
             call timer_statistics('blom_loop')
             call timer_statistics('blom_step')
+            write(lp,*) ''
             exit
          endif
       enddo

--- a/phy/mod_blom_init.F90
+++ b/phy/mod_blom_init.F90
@@ -23,7 +23,8 @@ module mod_blom_init
   use mod_config,          only: expcnf, runtyp
   use mod_time,            only: date, nday1, nday2, nstep1, nstep2, nstep, delt1, &
                                  time0, baclin
-  use mod_timing,          only: init_timing, get_time
+  use mod_timing,          only: timer_init, timer_start, timer_stop, &
+                                 timer_reset, timer_statistics
   use mod_xc,              only: xcspmd, xcbcst, xctilr, xchalt, mnproc, nproc, &
                                  lp, ii, jj, kk, isp, ifp, isu, ifu, ilp, isv, ifv, &
                                  ilu, ilv, jpr, i0, nbdy, &
@@ -85,13 +86,8 @@ contains
     ! Initialize timing.
     ! --------------------------------------------------------------------------
 
-    call init_timing
-
-    ! print seconds elapsed since startup (should be almost zero)
-    if (mnproc == 1) then
-      write (lp,'(f12.4,a,i8)') get_time(),' Time 0 BLOM starting up'
-      call flush(lp)
-    end if
+    call timer_init(8, 2)
+    call timer_start(1)
 
     ! --------------------------------------------------------------------------
     ! Read limits file.
@@ -202,6 +198,8 @@ contains
     call xcbcst(icrest)
 
     if (icrest .and. woa_nuopc_provided) woa_nuopc_provided = .false.
+
+    call timer_stop(1,'blom_init_phase1')
 
   end subroutine blom_init_phase1
 
@@ -435,7 +433,13 @@ contains
 
     call diaout_alarms
 
+    call timer_stop(1,'blom_init_phase2')
+
     ! --------------------------------------------------------------------------
+    ! Write timer diagnostics to stdout.
+    ! --------------------------------------------------------------------------
+
+    call timer_statistics(1)
 
     if (mnproc == 1.and.expcnf /= 'cesm') then
       write (lp,'(/2(a,i6),2(a,i9),a/)') &
@@ -444,11 +448,9 @@ contains
       call flush(lp)
     end if
 
-    ! Print seconds elapsed since last call to system_clock (Time 0).
-    if (mnproc == 1) then
-      write (lp,'(f12.4,a,i8)') get_time(),' Time 1 Just before main loop'
-      call flush(lp)
-    end if
+    call timer_reset(1)
+    call timer_start(1)
+    call timer_start(2)
 
   end subroutine blom_init_phase2
 

--- a/phy/mod_blom_init.F90
+++ b/phy/mod_blom_init.F90
@@ -23,8 +23,7 @@ module mod_blom_init
   use mod_config,          only: expcnf, runtyp
   use mod_time,            only: date, nday1, nday2, nstep1, nstep2, nstep, delt1, &
                                  time0, baclin
-  use mod_timing,          only: timer_init, timer_start, timer_stop, &
-                                 timer_reset, timer_statistics
+  use mod_timing,          only: timer_init, timer_start
   use mod_xc,              only: xcspmd, xcbcst, xctilr, xchalt, mnproc, nproc, &
                                  lp, ii, jj, kk, isp, ifp, isu, ifu, ilp, isv, ifv, &
                                  ilu, ilv, jpr, i0, nbdy, &
@@ -86,8 +85,8 @@ contains
     ! Initialize timing.
     ! --------------------------------------------------------------------------
 
-    call timer_init(8, 2)
-    call timer_start(1)
+    call timer_init(2, 6)
+    call timer_start('initialization')
 
     ! --------------------------------------------------------------------------
     ! Read limits file.
@@ -198,8 +197,6 @@ contains
     call xcbcst(icrest)
 
     if (icrest .and. woa_nuopc_provided) woa_nuopc_provided = .false.
-
-    call timer_stop(1,'blom_init_phase1')
 
   end subroutine blom_init_phase1
 
@@ -433,13 +430,9 @@ contains
 
     call diaout_alarms
 
-    call timer_stop(1,'blom_init_phase2')
-
     ! --------------------------------------------------------------------------
     ! Write timer diagnostics to stdout.
     ! --------------------------------------------------------------------------
-
-    call timer_statistics(1)
 
     if (mnproc == 1.and.expcnf /= 'cesm') then
       write (lp,'(/2(a,i6),2(a,i9),a/)') &
@@ -447,10 +440,6 @@ contains
            nstep1,' --',nstep2,')'
       call flush(lp)
     end if
-
-    call timer_reset(1)
-    call timer_start(1)
-    call timer_start(2)
 
   end subroutine blom_init_phase2
 

--- a/phy/mod_blom_step.F90
+++ b/phy/mod_blom_step.F90
@@ -24,16 +24,8 @@ module mod_blom_step
   use mod_time,            only: date, nday_of_year, nstep1, &
                                  nstep, nstep_in_day, delt1, step_time, &
                                  baclin
-  use mod_timing,          only: total_time, total_xio_time, &
-                                 auxil_total_time, getfrc_total_time, &
-                                 tmsmt1_total_time, advdif_total_time, &
-                                 sfcstr_total_time, momtum_total_time, &
-                                 pgforc_total_time, barotp_total_time, &
-                                 pbcor2_total_time, convec_total_time, &
-                                 diapfl_total_time, thermf_total_time, &
-                                 mxlayr_total_time, tmsmt2_total_time, &
-                                 diaacc_total_time, io_total_time, &
-                                 get_time
+  use mod_timing,          only: timer_start, timer_stop, timer_reset, &
+                                 timer_statistics, timer_group_time
   use mod_xc,              only: lp, kk, mnproc, xctilr, xcsum
   use mod_vcoord,          only: vcoord_tag, vcoord_isopyc_bulkml, sigref_adapt
   use mod_ale_regrid_remap, only: ale_regrid_remap, ale_remap_diazlv
@@ -84,26 +76,9 @@ contains
   ! ------------------------------------------------------------------
 
     ! Local variables
-    real    :: q
+    real    :: total_step_time
     integer :: i,m,n,mm,nn,k1m,k1n
     logical :: update_flux_halos
-    real    :: total_step_time
-    real    :: auxil_time
-    real    :: getfrc_time
-    real    :: tmsmt1_time
-    real    :: advdif_time
-    real    :: sfcstr_time
-    real    :: momtum_time
-    real    :: pgforc_time
-    real    :: barotp_time
-    real    :: pbcor2_time
-    real    :: convec_time
-    real    :: diapfl_time
-    real    :: thermf_time
-    real    :: mxlayr_time
-    real    :: tmsmt2_time
-    real    :: diaacc_time
-    real    :: io_time
 
     ! letter 'm' refers to mid-time level (example: dp(i,j,km) )
     ! letter 'n' refers to old and new time level
@@ -115,7 +90,10 @@ contains
     k1m = 1+mm
     k1n = 1+nn
 
+    call timer_stop(2,'auxil_sg1')
+
     call budget_sums(1,n,nn)
+    call timer_stop(2,'budget_sg1')
 
     call step_time
 
@@ -128,7 +106,7 @@ contains
     update_flux_halos = nreg == 2 .and. mod(nstep,nstep_in_day) == 1
     call init_fluxes(m,n,mm,nn,k1m,k1n,update_flux_halos)
 
-    auxil_time = get_time()
+    call timer_stop(2,'auxil_sg2')
 
     ! ------------------------------------------------------------------
     ! Get forcing
@@ -142,131 +120,136 @@ contains
 
     call updswa
 
-    getfrc_time = get_time()
+    call timer_stop(2,'getfrc')
 
     if (vcoord_tag /= vcoord_isopyc_bulkml) then
       call ale_regrid_remap(m,n,mm,nn,k1m,k1n)
-      convec_time = get_time()
+      call timer_stop(2,'ale_regrid_remap')
       call budget_sums(2,n,nn)
+      call timer_stop(2,'budget_sg2')
     end if
 
     call cmnfld2(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'cmnfld2')
 
-    !diag write (lp,*) 'tmsmt1...'
     call tmsmt1(nn)
-    tmsmt1_time = get_time()
+    call timer_stop(2,'tmsmt1')
 
-    !diag write (lp,*) 'advdif...'
     if (vcoord_tag == vcoord_isopyc_bulkml) then
       call difest_isobml(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'difest_isobml')
     else
       call difest_lateral_hybrid(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'difest_lateral_hybrid')
     end if
     call eddtra(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'eddtra')
     call advect(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'advect')
     call pbcor1(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'pbcor1')
     call diffus(m,n,mm,nn,k1m,k1n)
-    advdif_time = get_time()
+    call timer_stop(2,'diffus')
 
     if (vcoord_tag == vcoord_isopyc_bulkml) then
       call budget_sums(2,n,nn)
+      call timer_stop(2,'budget_sg3')
     else
       call budget_sums(3,n,nn)
+      call timer_stop(2,'budget_sg4')
     end if
-    auxil_time = auxil_time+get_time()
 
-    !diag write (lp,*) 'sfcstr...'
     call sfcstr(m,n,mm,nn,k1m,k1n)
-    sfcstr_time = get_time()
+    call timer_stop(2,'sfcstr')
 
-    !diag write (lp,*) 'pgforc...'
     call pgforc(m,n,mm,nn,k1m,k1n)
-    pgforc_time = get_time()
+    call timer_stop(2,'pgforc')
 
-    !diag write (lp,*) 'momtum...'
     call momtum(m,n,mm,nn,k1m,k1n)
-    momtum_time = get_time()
+    call timer_stop(2,'momtum')
 
     if (vcoord_tag == vcoord_isopyc_bulkml) then
 
-      !diag   write (lp,*) 'convec...'
       call convec(m,n,mm,nn,k1m,k1n)
-      convec_time = get_time()
+      call timer_stop(2,'convec')
 
       call budget_sums(3,n,nn)
-      auxil_time = auxil_time+get_time()
+      call timer_stop(2,'budget_sg5')
 
-      !diag   write (lp,*) 'diapfl...'
       call diapfl(n,nn,k1n)
-      diapfl_time = get_time()
+      call timer_stop(2,'diapfl')
 
       call budget_sums(4,n,nn)
-      auxil_time = auxil_time+get_time()
+      call timer_stop(2,'budget_sg6')
 
     end if
 
-    !diag write (lp,*) 'thermf...'
     call thermf(m,n,mm,nn,k1m,k1n)
-    thermf_time = get_time()
+    call timer_stop(2,'thermf')
 
     if (vcoord_tag == vcoord_isopyc_bulkml) then
-      !diag   write (lp,*) 'mxlayr...'
       call mxlayr(m,n,mm,nn,k1m,k1n)
-      mxlayr_time = get_time()
+      call timer_stop(2,'mxlayr')
     else
       call cmnfld_bfsqi_ale(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'cmnfld_bfsqi_ale')
       call ale_forcing(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'ale_forcing')
       call difest_vertical_hybrid(m,n,mm,nn,k1m,k1n)
-      mxlayr_time = get_time()
+      call timer_stop(2,'difest_vertical_hybrid')
       call ale_vdifft(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'ale_vdifft')
       call ale_vdiffm(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'ale_vdiffm')
       call budget_sums(4,n,nn)
-      diapfl_time = get_time()
+      call timer_stop(2,'budget_sg7')
     end if
 
     if (use_TRC) then
       ! update tracer due to non-passive processes
       call updtrc(m,n,mm,nn,k1m,k1n)
+      call timer_stop(2,'updtrc')
     end if
 
     call budget_sums(5,n,nn)
-    auxil_time = auxil_time+get_time()
+    call timer_stop(2,'budget_sg8')
 
-    !diag write (lp,*) 'barotp...'
     call barotp(m,n,mm,nn,k1m,k1n)
-    barotp_time = get_time()
+    call timer_stop(2,'barotp')
 
-    !diag write (lp,*) 'pbcor2...'
     call pbcor2(m,n,mm,nn,k1m,k1n)
-    pbcor2_time = get_time()
+    call timer_stop(2,'pbcor2')
 
     call budget_sums(6,m,mm)
-    auxil_time = auxil_time+get_time()
+    call timer_stop(2,'budget_sg9')
 
-    !diag write (lp,*) 'tmsmt2...'
     call tmsmt2(m,mm,nn,k1m)
-    tmsmt2_time = get_time()
+    call timer_stop(2,'tmsmt2')
 
     call budget_sums(7,m,mm)
+    call timer_stop(2,'budget_sg10')
 
     call cmnfld1(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'cmnfld1')
 
     call sigref_adapt(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'sigref_adapt')
 
     call diaacc(m,n,mm,nn,k1m,k1n)
-    diaacc_time = get_time()
+    call timer_stop(2,'diaacc')
 
     call fwbbal(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'fwbbal')
 
     call budget_output(m)
-
-    auxil_time = auxil_time+get_time()
+    call timer_stop(2,'budget_sg11')
 
     !-------------------------------------------------------------------
     ! output and diagnostic calculations
     !-------------------------------------------------------------------
 
     call chkvar(m,n,mm,nn,k1m,k1n)
+    call timer_stop(2,'chkvar')
 
     if (mod(nstep,nstep_in_day) == 0.and.nday_of_year == 1) then
 
@@ -290,22 +273,7 @@ contains
 
     call diaout(m,n,mm,nn,k1m,k1n)
 
-    ! update total time spent by various tasks
-    auxil_total_time = auxil_total_time+auxil_time
-    getfrc_total_time = getfrc_total_time+getfrc_time
-    tmsmt1_total_time = tmsmt1_total_time+tmsmt1_time
-    advdif_total_time = advdif_total_time+advdif_time
-    sfcstr_total_time = sfcstr_total_time+sfcstr_time
-    momtum_total_time = momtum_total_time+momtum_time
-    pgforc_total_time = pgforc_total_time+pgforc_time
-    barotp_total_time = barotp_total_time+barotp_time
-    pbcor2_total_time = pbcor2_total_time+pbcor2_time
-    convec_total_time = convec_total_time+convec_time
-    diapfl_total_time = diapfl_total_time+diapfl_time
-    thermf_total_time = thermf_total_time+thermf_time
-    mxlayr_total_time = mxlayr_total_time+mxlayr_time
-    tmsmt2_total_time = tmsmt2_total_time+tmsmt2_time
-    diaacc_total_time = diaacc_total_time+diaacc_time
+    call timer_stop(2,'diaout')
 
     if (((rstann.and.nday_of_year == 1.or.rstmon.and.date%day == 1) &
          .and.mod(nstep,nstep_in_day) == 0).or. &
@@ -321,62 +289,31 @@ contains
 
       end if
 
-      io_time = get_time()
+      call timer_stop(2,'restart_write')
 
       ! ------------------------------------------------------------------
-      ! write timing diagnostics to standard out
+      ! write timer diagnostics to standard out
       ! ------------------------------------------------------------------
 
-      io_total_time = io_total_time+io_time
-      total_step_time = auxil_time +getfrc_time+tmsmt1_time+advdif_time &
-                       +sfcstr_time+momtum_time+pgforc_time+barotp_time &
-                       +pbcor2_time+convec_time+diapfl_time+thermf_time &
-                       +mxlayr_time+tmsmt2_time+diaacc_time+io_time
-      total_time = total_time+total_step_time
-      total_xio_time = total_xio_time+total_step_time-io_time
-
-      if (mnproc == 1) then
-        write (lp,'(f12.4,a,i8)') total_step_time, '  sec for step ', nstep
-        write (lp,'(f12.4,a,i8)') total_time/(nstep-nstep1),' Avg Time'
-        write (lp,'(f12.4,a,i8)') total_xio_time/(nstep-nstep1),' Avg Time excluding IO'
-        write (lp,'(f12.4,a,i8)') total_time,' Tot Time with contributions:'
-        q = 100./total_time
-        write (lp,'(f12.4,a,i8)') auxil_total_time*q ,'% auxil '
-        write (lp,'(f12.4,a,i8)') getfrc_total_time*q,'% getfrc'
-        write (lp,'(f12.4,a,i8)') tmsmt1_total_time*q,'% tmsmt1'
-        write (lp,'(f12.4,a,i8)') advdif_total_time*q,'% advdif'
-        write (lp,'(f12.4,a,i8)') sfcstr_total_time*q,'% sfcstr'
-        write (lp,'(f12.4,a,i8)') momtum_total_time*q,'% momtum'
-        write (lp,'(f12.4,a,i8)') pgforc_total_time*q,'% pgforc'
-        write (lp,'(f12.4,a,i8)') barotp_total_time*q,'% barotp'
-        write (lp,'(f12.4,a,i8)') pbcor2_total_time*q,'% pbcor2'
-        write (lp,'(f12.4,a,i8)') convec_total_time*q,'% convec'
-        write (lp,'(f12.4,a,i8)') diapfl_total_time*q,'% diapfl'
-        write (lp,'(f12.4,a,i8)') thermf_total_time*q,'% thermf'
-        write (lp,'(f12.4,a,i8)') mxlayr_total_time*q,'% mxlayr'
-        write (lp,'(f12.4,a,i8)') tmsmt2_total_time*q,'% tmsmt2'
-        write (lp,'(f12.4,a,i8)') diaacc_total_time*q,'% diaacc'
-        write (lp,'(f12.4,a,i8)') io_total_time*q    ,'% IO'
-      end if
+      call timer_statistics(2)
 
     else
+
+      call timer_stop(2,'restart_write')
 
       ! ------------------------------------------------------------------
       ! write time spent for current time step
       ! ------------------------------------------------------------------
 
-      io_time = get_time()
-      io_total_time = io_total_time+io_time
-      total_step_time = auxil_time  + getfrc_time + tmsmt1_time + advdif_time &
-                        + sfcstr_time + momtum_time + pgforc_time + barotp_time &
-                        + pbcor2_time + convec_time + diapfl_time + thermf_time &
-                        + mxlayr_time + tmsmt2_time + diaacc_time + io_time
-      total_time = total_time + total_step_time
-      total_xio_time = total_xio_time + total_step_time-io_time
+      call timer_stop(1)
+      call timer_group_time(1,total_step_time)
 
       if (mnproc == 1) then
-        write (lp,'(f12.4,a,i8)') total_step_time, '  sec for step ', nstep
+        write (lp,'(f12.4,a,i8)') total_step_time, ' sec for step ', nstep
       end if
+
+      call timer_reset(1)
+      call timer_start(1)
 
     end if
 

--- a/phy/mod_calendar.F90
+++ b/phy/mod_calendar.F90
@@ -18,71 +18,71 @@
 ! ------------------------------------------------------------------------------
 
 module mod_calendar
-  ! ------------------------------------------------------------------------------
-  ! This module contains calendar routines.
-  !
-  ! The supported calendars are the same as in the NetCDF Climate and Forecast
-  ! (CF) Metadata Conventions:
-  !
-  !    - 'gregorian' or 'standard': Mixed Gregorian/Julian calendar as defined by
-  !                                 UDUNITS.
-  !    - 'proleptic_gregorian':     A Gregorian calendar extended to dates before
-  !                                 15 Oct 1582. That is, a year is a leap year if
-  !                                 either (i) it is divisible by 4 but not by 100
-  !                                 or (ii) it is divisible by 400.
-  !    - 'julian':                  Julian calendar.
-  !    - 'noleap' or '365_day':     Gregorian calendar without leap years, i.e.,
-  !                                 all years are 365 days long.
-  !    - 'all_leap' or '366_day':   Gregorian calendar with every year being a
-  !                                 leap year, i.e., all years are 366 days long.
-  !    - '360_day':                 All years are 360 days divided into 30 day
-  !                                 months.
-  !
-  ! For Julian and Gregorian calendars, the Chronological Julian Day Number (CJDN)
-  ! is used (algorithms at https://www.aa.quae.nl/en/reken/juliaansedag.html).
-  ! Zero CJDN corresponds to 1 Jan -4712 and in the Julian calendar and 24 Nov
-  ! -4713 in the proleptic Gregorian calendar. The other calendars uses a day
-  ! number where zero day number corresponds to 1 Jan 1.
-  !
-  ! The available functions are invoked by:
-  !
-  !    errstat = date_to_daynum(calendar, date, daynum)
-  !    errstat = daynum_to_date(calendar, daynum, date)
-  !    errstat = daynum_diff(calendar, date1, date2, dndiff)
-  !    errstat = date_offset(calendar, date, dnoffset)
-  !    errstat = date_check(calendar, date)
-  !    errstr = calendar_errstr(errstat)
-  !
-  ! The 'calendar' argument (character(len = *)) gives the calendar type. The
-  ! arguments 'date', 'date1', 'date2' are of type 'date_type' defined by the
-  ! module. All other arguments are of default integer type. The first 5 functions
-  ! returns an integer error status value which is equal to 'calendar_noerr' in
-  ! case of no error. The function 'calendar_errstr' returns a static reference to
-  ! an error message string (character(len = 80)) corresponding to an integer
-  ! error status.
-  !
-  ! With default 4-byte integer type, the valid range of the various calendar
-  ! types are:
-  !
-  !    - 'gregorian' or 'standard':
-  !       - Day number range: [     -535149630,      538592031]
-  !       - Date range:       [ 1 Mar -1469872, 18 Oct 1469902]
-  !    - 'proleptic_gregorian':
-  !       - Day number range: [     -535148831,      538592031]
-  !       - Date range:       [ 1 Mar -1469900, 18 Oct 1469902]
-  !    - 'julian':
-  !       - Day number range: [     -535149630,      538592029]
-  !       - Date range:       [ 1 Mar -1469872,  8 Nov 1469872]
-  !    - 'noleap' or '365_day':
-  !       - Day number range: [    -2147483648,     2147483341]
-  !       - Date range:       [27 Feb -5883516,  2 Jan 5883517]
-  !    - 'all_leap' or '366_day':
-  !       - Day number range: [    -2147483648,     2147483341]
-  !       - Date range:       [ 4 May -5867441, 28 Oct 5867441]
-  !    - '360_day':
-  !       - Day number range: [    -2147483648,     2147483647]
-  !       - Date range:       [23 Aug -5965232,  8 May 5965233]
-  ! ------------------------------------------------------------------------------
+! ------------------------------------------------------------------------------
+! This module contains calendar routines.
+!
+! The supported calendars are the same as in the NetCDF Climate and Forecast
+! (CF) Metadata Conventions:
+!
+!    - 'gregorian' or 'standard': Mixed Gregorian/Julian calendar as defined by
+!                                 UDUNITS.
+!    - 'proleptic_gregorian':     A Gregorian calendar extended to dates before
+!                                 15 Oct 1582. That is, a year is a leap year if
+!                                 either (i) it is divisible by 4 but not by 100
+!                                 or (ii) it is divisible by 400.
+!    - 'julian':                  Julian calendar.
+!    - 'noleap' or '365_day':     Gregorian calendar without leap years, i.e.,
+!                                 all years are 365 days long.
+!    - 'all_leap' or '366_day':   Gregorian calendar with every year being a
+!                                 leap year, i.e., all years are 366 days long.
+!    - '360_day':                 All years are 360 days divided into 30 day
+!                                 months.
+!
+! For Julian and Gregorian calendars, the Chronological Julian Day Number (CJDN)
+! is used (algorithms at https://www.aa.quae.nl/en/reken/juliaansedag.html).
+! Zero CJDN corresponds to 1 Jan -4712 and in the Julian calendar and 24 Nov
+! -4713 in the proleptic Gregorian calendar. The other calendars uses a day
+! number where zero day number corresponds to 1 Jan 1.
+!
+! The available functions are invoked by:
+!
+!    errstat = date_to_daynum(calendar, date, daynum)
+!    errstat = daynum_to_date(calendar, daynum, date)
+!    errstat = daynum_diff(calendar, date1, date2, dndiff)
+!    errstat = date_offset(calendar, date, dnoffset)
+!    errstat = date_check(calendar, date)
+!    errstr = calendar_errstr(errstat)
+!
+! The 'calendar' argument (character(len = *)) gives the calendar type. The
+! arguments 'date', 'date1', 'date2' are of type 'date_type' defined by the
+! module. All other arguments are of default integer type. The first 5 functions
+! returns an integer error status value which is equal to 'calendar_noerr' in
+! case of no error. The function 'calendar_errstr' returns a static reference to
+! an error message string (character(len = 80)) corresponding to an integer
+! error status.
+!
+! With default 4-byte integer type, the valid range of the various calendar
+! types are:
+!
+!    - 'gregorian' or 'standard':
+!       - Day number range: [     -535149630,      538592031]
+!       - Date range:       [ 1 Mar -1469872, 18 Oct 1469902]
+!    - 'proleptic_gregorian':
+!       - Day number range: [     -535148831,      538592031]
+!       - Date range:       [ 1 Mar -1469900, 18 Oct 1469902]
+!    - 'julian':
+!       - Day number range: [     -535149630,      538592029]
+!       - Date range:       [ 1 Mar -1469872,  8 Nov 1469872]
+!    - 'noleap' or '365_day':
+!       - Day number range: [    -2147483648,     2147483341]
+!       - Date range:       [27 Feb -5883516,  2 Jan 5883517]
+!    - 'all_leap' or '366_day':
+!       - Day number range: [    -2147483648,     2147483341]
+!       - Date range:       [ 4 May -5867441, 28 Oct 5867441]
+!    - '360_day':
+!       - Day number range: [    -2147483648,     2147483647]
+!       - Date range:       [23 Aug -5965232,  8 May 5965233]
+! ------------------------------------------------------------------------------
 
   implicit none
   private
@@ -133,9 +133,9 @@ module mod_calendar
   end interface operator(>=)
 
   public :: date_type, date_to_daynum, daynum_to_date, daynum_diff, &
-       date_offset, date_check, calendar_noerr, calendar_errstr, &
-       operator(==), operator(<), operator(>), operator(/=), &
-       operator(<=), operator(>=)
+            date_offset, date_check, calendar_noerr, calendar_errstr, &
+            operator(==), operator(<), operator(>), operator(/=), &
+            operator(<=), operator(>=)
 
 contains
 
@@ -428,9 +428,9 @@ contains
   end function date_to_daynum
 
   function daynum_to_date(calendar, daynum, date) result(errstat)
-    ! ---------------------------------------------------------------------------
-    ! Convert from day number to calendar date.
-    ! ---------------------------------------------------------------------------
+  ! ---------------------------------------------------------------------------
+  ! Convert from day number to calendar date.
+  ! ---------------------------------------------------------------------------
 
     character(len = *), intent(in) :: calendar ! Calendar type.
     integer, intent(in) :: daynum              ! Day number.
@@ -599,10 +599,10 @@ contains
 
     date1_lt_date2 =  date1%year  <  date2%year   .or.  &
                      (date1%year  == date2%year   .and. &
-                     date1%month <  date2%month) .or.  &
+                      date1%month <  date2%month) .or.  &
                      (date1%year  == date2%year   .and. &
-                     date1%month == date2%month  .and. &
-                     date1%day   <  date2%day)
+                      date1%month == date2%month  .and. &
+                      date1%day   <  date2%day)
 
   end function date1_lt_date2
 
@@ -615,10 +615,10 @@ contains
 
     date1_gt_date2 =  date1%year  >  date2%year   .or.  &
                      (date1%year  == date2%year   .and. &
-                     date1%month >  date2%month) .or.  &
+                      date1%month >  date2%month) .or.  &
                      (date1%year  == date2%year   .and. &
-                     date1%month == date2%month  .and. &
-                     date1%day   >  date2%day)
+                      date1%month == date2%month  .and. &
+                      date1%day   >  date2%day)
 
   end function date1_gt_date2
 

--- a/phy/mod_timing.F90
+++ b/phy/mod_timing.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2006-2022 Mats Bentsen, Alok Kumar Gupta
+! Copyright (C) 2025 Mats Bentsen
 !
 ! This file is part of BLOM.
 !
@@ -18,84 +18,384 @@
 ! ------------------------------------------------------------------------------
 
 module mod_timing
-  ! ------------------------------------------------------------------------------
-  ! This module contains variables and procedures related to timing.
-  ! ------------------------------------------------------------------------------
+! ------------------------------------------------------------------------------
+! This module contains routines and data structures for timers.
+! ------------------------------------------------------------------------------
 
-  use mod_types, only: r8
-  use mod_xc   , only: mnproc
-  use mod_wtime, only: wtime
+   use, intrinsic :: iso_fortran_env, only: int32
+   use mod_types, only: r8
+   use mod_crc32, only: crc32
+   use mod_wtime, only: wtime
+   use mod_xc   , only: xchalt, xcstop, xcmax, mnproc, lp
 
-  implicit none
-  private
+   implicit none
 
-  real(r8), public ::     &
-       total_time,        &
-       total_xio_time,    &
-       auxil_total_time,  &
-       getfrc_total_time, &
-       tmsmt1_total_time, &
-       advdif_total_time, &
-       sfcstr_total_time, &
-       momtum_total_time, &
-       pgforc_total_time, &
-       barotp_total_time, &
-       pbcor2_total_time, &
-       convec_total_time, &
-       diapfl_total_time, &
-       thermf_total_time, &
-       mxlayr_total_time, &
-       tmsmt2_total_time, &
-       diaacc_total_time, &
-       io_total_time,     &
-       wtimeold             ! time at initialisation
+   private
 
-  ! Public routines
-  public :: init_timing, get_time
+   integer, parameter :: &
+      maxlen_name = 52
+
+   type :: timer_struct
+      logical :: used
+      integer(int32) :: checksum
+      character(len = maxlen_name) :: name
+      integer :: acc_num
+      real(r8) :: acc_time
+   end type timer_struct
+
+   type(timer_struct), allocatable, dimension(:,:) :: timer
+   integer, allocatable, dimension(:,:) :: timer_idx_list
+   integer, allocatable, dimension(:) :: timer_num, timer_mode
+   real(r8), allocatable, dimension(:) :: last_time
+   integer :: maxnum_timers, maxnum_groups, hash_mask
+   logical :: initialized = .false.
+
+   public :: timer_init, timer_start, timer_stop, timer_reset, &
+             timer_group_time, timer_statistics
 
 contains
 
-  subroutine init_timing
-    ! ---------------------------------------------------------------------------
-    ! Initializes variables used for timing. Must be called before call to
-    ! 'get_time'.
-    ! ---------------------------------------------------------------------------
+   subroutine timer_init(maxnum_timers_log2, maxnum_groups_arg)
+   ! ---------------------------------------------------------------------------
+   ! Initialize timers. Arguments:
+   ! - maxnum_timers_log2: Number of timers will be 2**maxnum_timers_log2.
+   ! - maxnum_groups_arg : Maximum number of timer groups.
+   ! ---------------------------------------------------------------------------
 
-    if (mnproc == 1) wtimeold = wtime()
+      integer, intent(in) :: maxnum_timers_log2, maxnum_groups_arg
 
-    total_time        = 0._r8
-    total_xio_time    = 0._r8
-    auxil_total_time  = 0._r8
-    getfrc_total_time = 0._r8
-    tmsmt1_total_time = 0._r8
-    advdif_total_time = 0._r8
-    sfcstr_total_time = 0._r8
-    momtum_total_time = 0._r8
-    pgforc_total_time = 0._r8
-    barotp_total_time = 0._r8
-    pbcor2_total_time = 0._r8
-    convec_total_time = 0._r8
-    diapfl_total_time = 0._r8
-    thermf_total_time = 0._r8
-    mxlayr_total_time = 0._r8
-    tmsmt2_total_time = 0._r8
-    diaacc_total_time = 0._r8
-    io_total_time     = 0._r8
+      integer :: errstat
+      integer :: checksum, hash
 
-  end subroutine init_timing
+      maxnum_groups = maxnum_groups_arg
+      maxnum_timers = 2**maxnum_timers_log2
+      hash_mask = maskr(maxnum_timers_log2)
 
-  real(r8) function get_time()
-    ! ---------------------------------------------------------------------------
-    ! Return time in seconds since last call to either init_timing or get_time.
-    ! ---------------------------------------------------------------------------
+      allocate(timer(maxnum_timers,maxnum_groups), &
+               timer_idx_list(maxnum_timers,maxnum_groups), &
+               timer_num(maxnum_groups), &
+               timer_mode(maxnum_groups), &
+               last_time(maxnum_groups), &
+               stat = errstat)
+      if (errstat /= 0) then
+         write(lp,*) 'Failed to allocate timing arrays!'
+         call xchalt('(timer_init)')
+                stop '(timer_init)'
+      endif
 
-    if (mnproc == 1) then
-      get_time = wtime() - wtimeold
-      wtimeold = get_time + wtimeold
-    else
-      get_time = 1._r8
-    endif
+      timer(:,:)%used = .false.
+      timer_num(:) = 0
+      timer_mode(:) = 0
 
-  end function get_time
+      initialized = .true.
+
+   end subroutine timer_init
+
+   subroutine timer_start(group)
+   ! ---------------------------------------------------------------------------
+   ! Record the current time for the timer group, provided as argument.
+   ! ---------------------------------------------------------------------------
+
+      integer, intent(in) :: group
+
+      if (.not.initialized) then
+         if (mnproc == 1) &
+            write(lp,*) 'Timer not initialized, call timer_init first!'
+         call xcstop('(timer_start)')
+                stop '(timer_start)'
+      endif
+      if (group < 1 .or. group > maxnum_groups) then
+         if (mnproc == 1) write(lp,*) 'Group number out of bounds!'
+         call xcstop('(timer_start)')
+                stop '(timer_start)'
+      endif
+
+      last_time(group) = wtime()
+
+   end subroutine timer_start
+
+   subroutine timer_stop(group, name)
+   ! ---------------------------------------------------------------------------
+   ! Record the elapsed time since previous call to either timer_start or
+   ! timer_stop for the timer group, provided as argument. If the optional name
+   ! argument is not provided, the timer group is in single-timer mode. In
+   ! multi-timer mode, each unique name is associated with its own timer within
+   ! the group. For additional calls to timer_stop with previously used group
+   ! and name arguments, elapsed time is accumulated in the existing timer. For
+   ! multiple timers where a combined timer statistic output is preferred, it is
+   ! possible to use names of the form "<prefix>_sg<suffix>", which defines a
+   ! subgroup within the timer group. The <prefix> must be the same for all
+   ! timers in the subgroup, while the <suffix> must be unique.
+   ! ---------------------------------------------------------------------------
+
+      integer, intent(in) :: group
+      character(len = *), optional, intent(in) :: name
+
+      real(r8) :: curr_time
+      integer :: checksum, idx_start, idx
+
+      if (.not.initialized) then
+         if (mnproc == 1) &
+            write(lp,*) 'Timer not initialized, call timer_init first!'
+         call xcstop('(timer_stop)')
+                stop '(timer_stop)'
+      endif
+      if (group < 1 .or. group > maxnum_groups) then
+         if (mnproc == 1) write(lp,*) 'Group number out of bounds!'
+         call xcstop('(timer_stop)')
+                stop '(timer_stop)'
+      endif
+
+      if (present(name)) then
+
+         if (timer_mode(group) == 1) then
+            if (mnproc == 1) &
+               write(lp,*) 'Timer is already in single-timer mode!'
+            call xcstop('(timer_stop)')
+                   stop '(timer_stop)'
+            
+         endif
+
+         checksum = crc32(name)
+         idx_start = iand(checksum, hash_mask) + 1
+
+         idx = idx_start
+         do
+            if (timer(idx,group)%used) then
+               if (timer(idx,group)%checksum == checksum) then
+                  timer(idx,group)%acc_num = timer(idx,group)%acc_num + 1
+                  curr_time = wtime()
+                  timer(idx,group)%acc_time = timer(idx,group)%acc_time &
+                                            + curr_time - last_time(group)
+                  last_time(group) = curr_time
+                  return
+               endif
+            else
+               timer(idx,group)%used = .true.
+               timer(idx,group)%checksum = checksum
+               timer(idx,group)%name = name
+               timer(idx,group)%acc_num = 1
+               timer_num(group) = timer_num(group) + 1
+               timer_mode(group) = 2
+               timer_idx_list(timer_num(group),group) = idx
+               curr_time = wtime()
+               timer(idx,group)%acc_time = curr_time - last_time(group)
+               last_time(group) = curr_time
+               return
+            endif
+            idx = iand(idx, hash_mask) + 1
+            if (idx == idx_start) then
+               if (mnproc == 1) &
+                  write(lp,*) &
+                     'Too many timers! Increase maxnum_timers_log2 in call '// &
+                     'to timers_init'
+               call xcstop('(timer_stop)')
+                      stop '(timer_stop)'
+            endif
+         enddo
+
+      else
+
+         if (timer_mode(group) == 2) then
+            if (mnproc == 1) &
+               write(lp,*) 'Timer is already in multi-timer mode!'
+            call xcstop('(timer_stop)')
+                   stop '(timer_stop)'
+            
+         endif
+
+         idx = 1
+         if (timer(idx,group)%used) then
+            timer(idx,group)%acc_num = timer(idx,group)%acc_num + 1
+            curr_time = wtime()
+            timer(idx,group)%acc_time = timer(idx,group)%acc_time &
+                                      + curr_time - last_time(group)
+            last_time(group) = curr_time
+         else
+            timer(idx,group)%used = .true.
+            timer(idx,group)%acc_num = 1
+            timer_num(group) = 1
+            timer_mode(group) = 1
+            timer_idx_list(timer_num(group),group) = idx
+            curr_time = wtime()
+            timer(idx,group)%acc_time = curr_time - last_time(group)
+            last_time(group) = curr_time
+            return
+         endif
+
+      endif
+
+   end subroutine timer_stop
+
+   subroutine timer_reset(group)
+   ! ---------------------------------------------------------------------------
+   ! Reset the timer group, provided as argument.
+   ! ---------------------------------------------------------------------------
+
+      integer, intent(in) :: group
+
+      if (.not.initialized) then
+         if (mnproc == 1) &
+            write(lp,*) 'Timer not initialized, call timer_init first!'
+         call xcstop('(timer_reset)')
+                stop '(timer_reset)'
+      endif
+      if (group < 1 .or. group > maxnum_groups) then
+         if (mnproc == 1) write(lp,*) 'Group number out of bounds!'
+         call xcstop('(timer_reset)')
+                stop '(timer_reset)'
+      endif
+
+      timer(:,group)%used = .false.
+      timer_num(group) = 0
+      timer_mode(group) = 0
+
+   end subroutine timer_reset
+
+   subroutine timer_statistics(group)
+   ! ---------------------------------------------------------------------------
+   ! Output statistics of the timer group, provided as argument, to stdout.
+   ! ---------------------------------------------------------------------------
+
+      integer, intent(in) :: group
+
+      real(r8), dimension(timer_num(group)+1) :: cumsum_time
+      logical, dimension(timer_num(group)+1) :: contributed
+      real(r8) :: group_time, sg_time
+      integer :: i, idx, acc_num, sg_index, j, jdx
+      logical :: equal_acc_nums
+
+      if (.not.initialized) then
+         if (mnproc == 1) &
+            write(lp,*) 'Timer not initialized, call timer_init first!'
+         call xcstop('(timer_statistics)')
+                stop '(timer_statistics)'
+      endif
+      if (group < 1 .or. group > maxnum_groups) then
+         if (mnproc == 1) write(lp,*) 'Group number out of bounds!'
+         call xcstop('(timer_statistics)')
+                stop '(timer_statistics)'
+      endif
+
+      if (timer_num(group) == 0) then
+         if (mnproc == 1) write(lp,*) 'No timer statistics of group:', group
+         return
+      endif
+
+      if (mnproc == 1) then
+         write(lp,*) ''
+         write(lp,'(a,i3,a)') 'Timer statistics of group ', group, ':'
+      endif
+
+      if (timer_mode(group) == 1) then
+
+         idx = 1
+         group_time = timer(idx,group)%acc_time
+         acc_num = timer(idx,group)%acc_num
+         call xcmax(group_time)
+
+         if (mnproc == 1) then
+            if (acc_num > 1) &
+               write(lp,'(f12.4,a,i6,a)') &
+                  group_time/acc_num, '  sec average time for ', &
+                  acc_num, ' accumulations'
+            write(lp,'(f12.4,a)') group_time, '  sec total time'
+            write(lp,*) ''
+         endif
+
+      else
+
+         cumsum_time(1) = 0._r8
+         acc_num = 0
+         equal_acc_nums = .true.
+         do i = 1, timer_num(group)
+            idx = timer_idx_list(i,group)
+            cumsum_time(i+1) = cumsum_time(i) + timer(idx,group)%acc_time
+            if (i > 1 .and. timer(idx,group)%acc_num /= acc_num) &
+               equal_acc_nums = .false.
+            acc_num = timer(idx,group)%acc_num
+         enddo
+         call xcmax(cumsum_time)
+
+         if (mnproc == 1) then
+            group_time = cumsum_time(timer_num(group)+1)
+            if (acc_num > 1 .and. equal_acc_nums) &
+               write(lp,'(f12.4,a,i6,a)') &
+                  group_time/acc_num, ' sec average time for ', &
+                  acc_num, ' accumulations'
+            write(lp,'(f12.4,a)') group_time, &
+                                  ' sec total time with contributions:'
+            contributed(:) = .false.
+            do i = 1, timer_num(group)
+               if (.not.contributed(i)) then
+                  idx = timer_idx_list(i,group)
+                  sg_index = index(timer(idx,group)%name, '_sg')
+                  if (sg_index <= 1) then
+                     write(lp,'(f12.4,a,f8.4,a)') &
+                         cumsum_time(i+1) - cumsum_time(i),' sec ', &
+                        (cumsum_time(i+1) - cumsum_time(i)) &
+                        /group_time*100._r8, &
+                        '%  '//trim(timer(idx,group)%name)
+                     contributed(i) = .true.
+                  else
+                     sg_time = cumsum_time(i+1) - cumsum_time(i)
+                     contributed(i) = .true.
+                     do j = i + 1, timer_num(group)
+                        jdx = timer_idx_list(j,group)
+                        if (timer(jdx,group)%name(1:sg_index+2) == &
+                            timer(idx,group)%name(1:sg_index+2)) then
+                           sg_time = sg_time + cumsum_time(j+1) - cumsum_time(j)
+                           contributed(j) = .true.
+                        endif
+                     enddo
+                     write(lp,'(f12.4,a,f8.4,a)') &
+                        sg_time, ' sec ', &
+                        sg_time/group_time*100._r8, &
+                        '%  '//timer(idx,group)%name(1:sg_index-1)
+                  endif
+               endif
+            enddo
+            write(lp,*) ''
+         endif
+
+      endif
+
+   end subroutine timer_statistics
+
+   subroutine timer_group_time(group, group_time)
+   ! ---------------------------------------------------------------------------
+   ! Provide the total accumulated time for the timer group, provided as
+   ! argument, in group_time.
+   ! ---------------------------------------------------------------------------
+
+      integer, intent(in) :: group
+      real(r8), intent(out) :: group_time
+
+      real(r8), dimension(timer_num(group)+1) :: cumsum_time
+      logical, dimension(timer_num(group)+1) :: contributed
+      real(r8) :: sg_time
+      integer :: i, idx, acc_num, sg_index, j, jdx
+      logical :: equal_acc_nums
+
+      if (.not.initialized) then
+         if (mnproc == 1) &
+            write(lp,*) 'Timer not initialized, call timer_init first!'
+         call xcstop('(timer_group_time)')
+                stop '(timer_group_time)'
+      endif
+      if (group < 1 .or. group > maxnum_groups) then
+         if (mnproc == 1) write(lp,*) 'Group number out of bounds!'
+         call xcstop('(timer_group_time)')
+                stop '(timer_group_time)'
+      endif
+
+      group_time = 0._r8
+      do i = 1, timer_num(group)
+         idx = timer_idx_list(i,group)
+         group_time = group_time + timer(idx,group)%acc_time
+      enddo
+      call xcmax(group_time)
+
+   end subroutine timer_group_time
 
 end module mod_timing


### PR DESCRIPTION
The current implementation of the timing of various tasks is cumbersome to maintain and extend. Further, it only provides timing statistics of the master process, which might not give reliable results in parallel execution. This PR simplifies the interface to the timing module, which now handles all the bookkeeping and statistical output of various timers. During parallel execution, timers for all processes are now active allowing for more reliable timing statistics. The timing of various tasks during a BLOM time step has been revised and, particularly when the ALE method is used, more precise timing statistics are provided.

This PR does not change results and only modifies time statistics to stdout (ocn.log.* in NorESM).