### PR TITLE
Corrects layer thickness tendency in vertical mass flux diagnostics.

### DIFF
--- a/phy/mod_ale_regrid_remap.F90
+++ b/phy/mod_ale_regrid_remap.F90
@@ -35,6 +35,7 @@ module mod_ale_regrid_remap
    use mod_eos,       only: sig, dsigdt, dsigds
    use mod_state,     only: u, v, dp, dpu, dpv, temp, saln, sigma, p, pu, pv, &
                             ub, vb, utflx, vtflx, usflx, vsflx
+   use mod_tmsmt,     only: dpuold, dpvold
    use mod_hor3map,   only: recon_grd_struct, recon_src_struct, remap_struct, &
                             hor3map_plm, hor3map_ppm, hor3map_pqm, &
                             hor3map_monotonic, hor3map_non_oscillatory, &
@@ -1712,6 +1713,7 @@ contains
                   dpu(i,j,kn) = &
                        .5_r8*( (min(q, p(i-1,j,k+1)) - min(q, p(i-1,j,k))) &
                              + (min(q, p(i  ,j,k+1)) - min(q, p(i  ,j,k))))
+                  dpuold(i,j,k) = dpu(i,j,kn)
                enddo
             enddo
             do l = 1, isv(j)
@@ -1720,6 +1722,7 @@ contains
                   dpv(i,j,kn) = &
                        .5_r8*( (min(q, p(i,j-1,k+1)) - min(q, p(i,j-1,k))) &
                              + (min(q, p(i,j  ,k+1)) - min(q, p(i,j  ,k))))
+                  dpvold(i,j,k) = dpv(i,j,kn)
                enddo
             enddo
          enddo

--- a/phy/mod_blom_step.F90
+++ b/phy/mod_blom_step.F90
@@ -144,6 +144,10 @@ contains
 
     getfrc_time = get_time()
 
+    !diag write (lp,*) 'tmsmt1...'
+    call tmsmt1(nn)
+    tmsmt1_time = get_time()
+
     if (vcoord_tag /= vcoord_isopyc_bulkml) then
       call ale_regrid_remap(m,n,mm,nn,k1m,k1n)
       convec_time = get_time()
@@ -151,10 +155,6 @@ contains
     end if
 
     call cmnfld2(m,n,mm,nn,k1m,k1n)
-
-    !diag write (lp,*) 'tmsmt1...'
-    call tmsmt1(nn)
-    tmsmt1_time = get_time()
 
     !diag write (lp,*) 'advdif...'
     if (vcoord_tag == vcoord_isopyc_bulkml) then


### PR DESCRIPTION
As discovered by @YanchunHe, the diagnosed vertical mass flux gives inconsistent results in its current implementation. This is because the previous time-step layer thickness is replaced with current layer thickness before a necessary layer thickness tendency is computed.

Except for changes in `wflx*` diagnostic fields, results are bit-identical with current master.