### PR TITLE
Sediment depth flexible via namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4590,6 +4590,30 @@
     </desc>
   </entry>
 
+  <entry id="sed_dzs_flexi">
+    <type>real(:)</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>''</value>
+    </values>
+    <desc>
+      Vertical sediment layer thickness vector (length=ks_flexi+1)
+    </desc>
+  </entry>
+
+  <entry id="sed_porwat_flexi">
+    <type>real(:)</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>''</value>
+    </values>
+    <desc>
+      Vertical sediment porosity vector (length=ks_flexi)
+    </desc>
+  </entry>
+
   <entry id="shelfsea_maskfile" is_inputdata="yes">
     <type>char</type>
     <category>bgcnml</category>
@@ -4776,6 +4800,26 @@
       <value hamocc_sediment_quality="yes">.true.</value>
     </values>
     <desc>activate the HAMOCC sediment quality-based remineralization code</desc>
+  </entry>
+
+  <entry id="use_sedflexi">
+    <type>logical</type>
+    <category>config_bgc</category>
+    <group>config_bgc</group>
+    <values>
+      <value>.false.</value>
+    </values>
+    <desc>enable flexible HAMOCC sediment depth and porosity settings</desc>
+  </entry>
+
+  <entry id="ks_flexi">
+    <type>logical</type>
+    <category>config_bgc</category>
+    <group>config_bgc</group>
+    <values>
+      <value>12</value>
+    </values>
+    <desc>Number of vertical sediment layers - default = 12</desc>
   </entry>
 
   <entry id="use_river2omip">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4578,6 +4578,18 @@
     </desc>
   </entry>
 
+  <entry id="sed_porosity">
+    <type>real</type>
+    <category>bgcnml</category>
+    <group>bgcnml</group>
+    <values>
+      <value>0.85, 0.83, 0.8, 0.79, 0.77,0.75, 0.73, 0.7, 0.68, 0.66, 0.64, 0.62</value>
+    </values>
+    <desc>
+      1D vertical sediment porosity vector (length=ks) - default values used in the sediment, if not l_3Dvarsedpor
+    </desc>
+  </entry>
+
   <entry id="sedqualfile" is_inputdata="yes">
     <type>char</type>
     <category>bgcnml</category>
@@ -4590,7 +4602,7 @@
     </desc>
   </entry>
 
-  <entry id="sed_dzs_flexi">
+  <entry id="dzs">
     <type>real</type>
     <category>bgcnml</category>
     <group>bgcnml</group>
@@ -4598,19 +4610,7 @@
       <value>0.001, 0.003, 0.005, 0.007, 0.009, 0.011, 0.013, 0.015, 0.017, 0.019, 0.021, 0.023, 0.025</value>
     </values>
     <desc>
-      Vertical sediment layer thickness vector (length=ks_flexi+1)  - here default values are given (but not used as long as use_sedflexi=False)
-    </desc>
-  </entry>
-
-  <entry id="sed_porwat_flexi">
-    <type>real</type>
-    <category>bgcnml</category>
-    <group>bgcnml</group>
-    <values>
-      <value>0.85, 0.83, 0.8, 0.79, 0.77,0.75, 0.73, 0.7, 0.68, 0.66, 0.64, 0.62</value>
-    </values>
-    <desc>
-      Vertical sediment porosity vector (length=ks_flexi) - here default values are given (but not used as long as use_sedflexi=False)
+      1D vertical sediment layer thickness vector (length=ks+1)  - default values that are used in the sediment)
     </desc>
   </entry>
 
@@ -4802,17 +4802,7 @@
     <desc>activate the HAMOCC sediment quality-based remineralization code</desc>
   </entry>
 
-  <entry id="use_sedflexi">
-    <type>logical</type>
-    <category>config_bgc</category>
-    <group>config_bgc</group>
-    <values>
-      <value>.false.</value>
-    </values>
-    <desc>enable flexible HAMOCC sediment depth and porosity settings</desc>
-  </entry>
-
-  <entry id="ks_flexi">
+  <entry id="ks">
     <type>integer</type>
     <category>config_bgc</category>
     <group>config_bgc</group>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4591,26 +4591,26 @@
   </entry>
 
   <entry id="sed_dzs_flexi">
-    <type>real(:)</type>
+    <type>real</type>
     <category>bgcnml</category>
     <group>bgcnml</group>
     <values>
-      <value>''</value>
+      <value>0.001, 0.003, 0.005, 0.007, 0.009, 0.011, 0.013, 0.015, 0.017, 0.019, 0.021, 0.023, 0.025</value>
     </values>
     <desc>
-      Vertical sediment layer thickness vector (length=ks_flexi+1)
+      Vertical sediment layer thickness vector (length=ks_flexi+1)  - here default values are given (but not used as long as use_sedflexi=False)
     </desc>
   </entry>
 
   <entry id="sed_porwat_flexi">
-    <type>real(:)</type>
+    <type>real</type>
     <category>bgcnml</category>
     <group>bgcnml</group>
     <values>
-      <value>''</value>
+      <value>0.85, 0.83, 0.8, 0.79, 0.77,0.75, 0.73, 0.7, 0.68, 0.66, 0.64, 0.62</value>
     </values>
     <desc>
-      Vertical sediment porosity vector (length=ks_flexi)
+      Vertical sediment porosity vector (length=ks_flexi) - here default values are given (but not used as long as use_sedflexi=False)
     </desc>
   </entry>
 
@@ -4813,7 +4813,7 @@
   </entry>
 
   <entry id="ks_flexi">
-    <type>logical</type>
+    <type>integer</type>
     <category>config_bgc</category>
     <group>config_bgc</group>
     <values>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4342,17 +4342,6 @@
     <desc>Switch to couple NH3 fluxes to atmosphere</desc>
   </entry>
 
-  <entry id="use_m4ago">
-    <type>logical</type>
-    <category>bgcnml</category>
-    <group>bgcnml</group>
-    <values>
-      <value>.false.</value>
-      <value use_m4ago="yes">.true.</value>
-    </values>
-    <desc>Switch for M4AGO settling scheme</desc>
-  </entry>
-
   <entry id="lkwrbioz_off">
     <type>logical</type>
     <category>bgcnml</category>
@@ -4647,6 +4636,17 @@
       <value use_wlin="no">.false.</value>
     </values>
     <desc>Use POC sinking scheme with increasing sinking velocity with depth</desc>
+  </entry>
+
+  <entry id="use_m4ago">
+    <type>logical</type>
+    <category>config_bgc</category>
+    <group>config_bgc</group>
+    <values>
+      <value>.false.</value>
+      <value use_m4ago="yes">.true.</value>
+    </values>
+    <desc>Switch for M4AGO settling scheme</desc>
   </entry>
 
   <entry id="use_cfc">

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -63,7 +63,6 @@ module mo_control_bgc
   logical           :: do_sedspinup           = .false. ! apply sediment spin-up
   logical           :: do_oalk                = .false. ! apply ocean alkalinization
   logical           :: with_dmsph             = .false. ! apply DMS with pH dependence
-  logical           :: use_M4AGO              = .false. ! run with M4AGO settling scheme
   logical           :: lkwrbioz_off           = .true.  ! if true, allow remin and primary prod throughout full water column
   logical           :: lTO2depremin           = .true.  ! Temperature- and O2-dependent remineralization of POM
   logical           :: ldyn_sed_age           = .false. ! switch for dynamic sediment age in combination with use_sediment_quality
@@ -79,6 +78,7 @@ module mo_control_bgc
   logical           :: use_BROMO              = .false. ! Bromoforme code
   logical           :: use_AGG                = .false. ! Aggregation scheme of Iris Kriest
   logical           :: use_WLIN               = .true.  ! Linear increase of sinking velocity with depth - mimicking a Martin curve
+  logical           :: use_M4AGO              = .false. ! run with M4AGO settling scheme
   logical           :: use_natDIC             = .false. ! natural DIC tracers
   logical           :: use_CFC                = .false. ! CFCs
   logical           :: use_cisonew            = .false. ! Carbon isotope code

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -92,7 +92,6 @@ module mo_control_bgc
   logical           :: use_pref_tracers       = .true.  ! Run code with pre-formed tracers
   logical           :: use_shelfsea_res_time  = .false. ! Include shelf sea residence time tracer
   logical           :: use_sediment_quality   = .false. ! Use sediment quality code to determine aerobic remineralization rates
-  logical           :: use_sedflexi           = .false. ! enable to set up sediment depths and porosity in a flexible way
   logical           :: use_river2omip         = .false. ! River2ocean MIP protocol
   logical           :: use_DOMclasses         = .false. ! DOM classes (labile, semi-labile,semi-refractory and refractory)
 

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -92,7 +92,7 @@ module mo_control_bgc
   logical           :: use_pref_tracers       = .true.  ! Run code with pre-formed tracers
   logical           :: use_shelfsea_res_time  = .false. ! Include shelf sea residence time tracer
   logical           :: use_sediment_quality   = .false. ! Use sediment quality code to determine aerobic remineralization rates
-  logical           :: use_sedflexi           = .false. ! enable to set up sediment depths and porsoity in a flexible way
+  logical           :: use_sedflexi           = .false. ! enable to set up sediment depths and porosity in a flexible way
   logical           :: use_river2omip         = .false. ! River2ocean MIP protocol
   logical           :: use_DOMclasses         = .false. ! DOM classes (labile, semi-labile,semi-refractory and refractory)
 

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -92,6 +92,7 @@ module mo_control_bgc
   logical           :: use_pref_tracers       = .true.  ! Run code with pre-formed tracers
   logical           :: use_shelfsea_res_time  = .false. ! Include shelf sea residence time tracer
   logical           :: use_sediment_quality   = .false. ! Use sediment quality code to determine aerobic remineralization rates
+  logical           :: use_sedflexi           = .false. ! enable to set up sediment depths and porsoity in a flexible way
   logical           :: use_river2omip         = .false. ! River2ocean MIP protocol
   logical           :: use_DOMclasses         = .false. ! DOM classes (labile, semi-labile,semi-refractory and refractory)
 

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -63,8 +63,8 @@ contains
     use mo_read_ndep,   only: ini_read_ndep,ndepfile
     use mo_read_oafx,   only: ini_read_oafx
     use mo_read_pi_ph,  only: ini_pi_ph,pi_ph_file
-    use mo_read_sedpor, only: read_sedpor,sedporfile
-    use mo_read_sedqual,only: read_sedqual,sedqualfile
+    use mo_read_sedpor, only: read_sedpor,sedporfile,sed_por
+    use mo_read_sedqual,only: read_sedqual,sedqualfile, sed_POCage_init,prorca_mavg_init
     use mo_clim_swa,    only: ini_swa_clim,swaclimfile
     use mo_Gdata_read,  only: inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,inidom
     use mo_intfcblom,   only: alloc_mem_intfcblom,nphys,bgc_dx,bgc_dy,bgc_dp,bgc_rho,omask,        &
@@ -84,9 +84,6 @@ contains
     ! Local variables
     integer  :: i,j,k,l,nt,errstat
     integer  :: iounit
-
-    real(rp), dimension(:,:,:), allocatable :: sed_por,sed_POCage_init
-    real(rp) :: prorca_mavg_init(idm,jdm)   = 0._rp
 
     namelist /bgcnml/ atm_co2,fedepfile,fedep_source,do_rivinpt,rivinfile,do_ndep,ndepfile,do_oalk,&
          &            do_sedspinup,sedspin_yr_s,sedspin_yr_e,sedspin_ncyc,                         &
@@ -121,16 +118,6 @@ contains
     !
     ! --- Memory allocation
     !
-    allocate (sed_por(idm,jdm,ks),stat=errstat)
-    if (mnproc==1 .and. errstat.ne.0) then
-      write(io_stdo_bgc,*) 'Memory allocation failed for sed_por in mo_hamocc_init'
-    endif
-    sed_por(:,:,:)         = 0._rp
-    allocate (sed_POCage_init(idm,jdm,ks),stat=errstat)
-    if (mnproc==1 .and. errstat.ne.0) then
-      write(io_stdo_bgc,*) 'Memory allocation failed for sed_POCage_init in mo_hamocc_init'
-    endif
-    sed_POCage_init(:,:,:) = 0._rp
     call alloc_mem_intfcblom(idm,jdm,kdm)
     call alloc_mem_bgcmean(idm,jdm,kdm)
     call alloc_mem_vgrid(idm,jdm,kdm)
@@ -219,9 +206,9 @@ contains
 
     ! --- Initialize sediment layering
     !     First, read the porosity and potentially apply it in ini_sedmnt
-    call read_sedpor(idm,jdm,ks,omask,sed_por)
+    call read_sedpor(idm,jdm,ks,omask)
     !     Second, read the sediment POC age and climatological prorca and pot. apply it in ini_sedmnt
-    call read_sedqual(idm,jdm,ks,omask,sed_POCage_init,prorca_mavg_init)
+    call read_sedqual(idm,jdm,ks,omask)
     call ini_sedmnt(idm,jdm,omask,sed_por,sed_POCage_init,prorca_mavg_init)
 
     !

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -82,7 +82,7 @@ contains
     character(len=*), intent(in) :: rstfnm_hamocc ! restart filename.
 
     ! Local variables
-    integer  :: i,j,k,l,nt,errstat
+    integer  :: i,j,k,l,nt
     integer  :: iounit
 
     namelist /bgcnml/ atm_co2,fedepfile,fedep_source,do_rivinpt,rivinfile,do_ndep,ndepfile,do_oalk,&

--- a/hamocc/mo_hamocc_init.F90
+++ b/hamocc/mo_hamocc_init.F90
@@ -48,13 +48,14 @@ contains
                               lkwrbioz_off,do_n2o_coupled,do_nh3_coupled,                          &
                               ocn_co2_type, use_sedbypass, use_BOXATM, use_BROMO,use_extNcycle,    &
                               use_coupler_ndep,lTO2depremin,use_sediment_quality,ldyn_sed_age,     &
-                              linit_DOMclasses_sim,use_sedflexi
+                              linit_DOMclasses_sim
     use mo_param1_bgc,  only: ks,init_por2octra_mapping
     use mo_param_bgc,   only: ini_parambgc,claydens,calcdens,calcwei,opaldens,opalwei,ropal,       &
                             & ini_bgctimes,sec_per_day
     use mo_carbch,      only: alloc_mem_carbch,ocetra,atm,atm_co2
     use mo_biomod,      only: alloc_mem_biomod
-    use mo_sedmnt,      only: alloc_mem_sedmnt,sedlay,powtra,burial,ini_sedmnt,prorca_mavg
+    use mo_sedmnt,      only: alloc_mem_sedmnt,sedlay,powtra,burial,ini_sedmnt,prorca_mavg,        &
+                              sed_porosity,dzs
     use mo_vgrid,       only: alloc_mem_vgrid,set_vgrid
     use mo_bgcmean,     only: alloc_mem_bgcmean
     use mo_read_rivin,  only: ini_read_rivin,rivinfile
@@ -85,7 +86,6 @@ contains
     integer  :: iounit
 
     real(rp), dimension(:,:,:), allocatable :: sed_por,sed_POCage_init
-    real(rp), dimension(:),     allocatable :: sed_dzs_flexi,sed_porwat_flexi
     real(rp) :: prorca_mavg_init(idm,jdm)   = 0._rp
 
     namelist /bgcnml/ atm_co2,fedepfile,fedep_source,do_rivinpt,rivinfile,do_ndep,ndepfile,do_oalk,&
@@ -93,7 +93,7 @@ contains
          &            inidic,inialk,inipo4,inioxy,inino3,inisil,inid13c,inid14c,inidom,swaclimfile,&
          &            with_dmsph,pi_ph_file,l_3Dvarsedpor,sedporfile,ocn_co2_type,use_M4AGO,       &
          &            do_n2o_coupled,do_nh3_coupled,lkwrbioz_off,lTO2depremin,shelfsea_maskfile,   &
-         &            sedqualfile,ldyn_sed_age,linit_DOMclasses_sim,sed_dzs_flexi,sed_porwat_flexi
+         &            sedqualfile,ldyn_sed_age,linit_DOMclasses_sim,dzs,sed_porosity
     !
     ! --- Set io units and some control parameters
     !
@@ -117,13 +117,12 @@ contains
       write(io_stdo_bgc,*) 'time step',dtbgc
       write(io_stdo_bgc,*) 'nday_in_year ',nday_in_year
     endif
+
+    ! holds dzs and sed_porosity allocation, which needs to be alocated before reading the namelist
+    call alloc_mem_sedmnt(idm,jdm)
     !
     ! --- Read the HAMOCC BGCNML namelist and check the value of some variables.
     !
-    allocate (sed_dzs_flexi(ks+1), stat=errstat)
-    allocate (sed_porwat_flexi(ks),stat=errstat)
-    sed_dzs_flexi    = 0._rp
-    sed_porwat_flexi = 0._rp
 
     if(.not. allocated(bgc_namelist)) call get_bgc_namelist
     open (newunit=iounit, file=bgc_namelist, status='old', action='read')
@@ -167,7 +166,6 @@ contains
     call alloc_mem_bgcmean(idm,jdm,kdm)
     call alloc_mem_vgrid(idm,jdm,kdm)
     call alloc_mem_biomod(idm,jdm,kdm)
-    call alloc_mem_sedmnt(idm,jdm)
     call alloc_mem_carbch(idm,jdm,kdm)
     if (use_M4AGO) then
       call alloc_mem_M4AGO(idm,jdm,kdm)
@@ -225,7 +223,7 @@ contains
     call read_sedpor(idm,jdm,ks,omask,sed_por)
     !     Second, read the sediment POC age and climatological prorca and pot. apply it in ini_sedmnt
     call read_sedqual(idm,jdm,ks,omask,sed_POCage_init,prorca_mavg_init)
-    call ini_sedmnt(idm,jdm,omask,sed_por,sed_POCage_init,prorca_mavg_init,sed_dzs_flexi,sed_porwat_flexi)
+    call ini_sedmnt(idm,jdm,omask,sed_por,sed_POCage_init,prorca_mavg_init)
 
     !
     ! --- Initialise reading of input data (dust, n-deposition, river, etc.)

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -33,11 +33,12 @@ module mo_param1_bgc
   use mo_control_bgc, only: use_BROMO, use_AGG, use_WLIN, use_natDIC, use_CFC,                     &
                             use_cisonew, use_PBGC_OCNP_TIMESTEP, use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE, use_BOXATM, use_sedbypass, use_extNcycle,              &
-                            use_pref_tracers,use_sediment_quality
+                            use_pref_tracers,use_sediment_quality,use_sedflexi
   implicit none
   public
 
-  integer, parameter :: ks=12,ksp=ks+1       ! ks: nb of sediment layers
+  integer, protected :: ks=12
+  integer, protected :: ksp=12+1       ! ks: nb of sediment layers
   real(rp),parameter :: safediv = 1.0e-25_rp ! added to the denominator of isotopic ratios (avoid div. by zero)
 
   ! ------------------
@@ -285,12 +286,13 @@ contains
                               use_coupler_ndep,use_shelfsea_res_time,use_river2omip,use_DOMclasses
 
     integer :: iounit
+    integer :: ks_flexi
 
     namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &
                             use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers,              &
                             use_coupler_ndep,use_shelfsea_res_time,use_sediment_quality,           &
-                            use_river2omip,use_DOMclasses
+                            use_river2omip,use_DOMclasses,use_sedflexi,ks_flexi
 
     io_stdo_bgc = lp              !  standard out.
 
@@ -303,6 +305,11 @@ contains
       write(io_stdo_bgc,*)
       write(io_stdo_bgc,*) 'iHAMOCC: reading namelist CONFIG_BGC'
       write(io_stdo_bgc,nml=config_bgc)
+    endif
+
+    if (use_sedflexi) then
+      ks  = ks_flexi
+      ksp = ks+1
     endif
 
     ! Tracer indices

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -33,12 +33,12 @@ module mo_param1_bgc
   use mo_control_bgc, only: use_BROMO, use_AGG, use_WLIN, use_natDIC, use_CFC,                     &
                             use_cisonew, use_PBGC_OCNP_TIMESTEP, use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE, use_BOXATM, use_sedbypass, use_extNcycle,              &
-                            use_pref_tracers,use_sediment_quality,use_sedflexi
+                            use_pref_tracers,use_sediment_quality
   implicit none
   public
 
-  integer, protected :: ks=12
-  integer, protected :: ksp=12+1       ! ks: nb of sediment layers
+  integer, protected :: ks        ! ks: nb of sediment layers (default=12)
+  integer, protected :: ksp
   real(rp),parameter :: safediv = 1.0e-25_rp ! added to the denominator of isotopic ratios (avoid div. by zero)
 
   ! ------------------
@@ -286,13 +286,12 @@ contains
                               use_coupler_ndep,use_shelfsea_res_time,use_river2omip,use_DOMclasses
 
     integer :: iounit
-    integer :: ks_flexi
 
     namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &
                             use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers,              &
                             use_coupler_ndep,use_shelfsea_res_time,use_sediment_quality,           &
-                            use_river2omip,use_DOMclasses,use_sedflexi,ks_flexi
+                            use_river2omip,use_DOMclasses,ks
 
     io_stdo_bgc = lp              !  standard out.
 
@@ -307,10 +306,8 @@ contains
       write(io_stdo_bgc,nml=config_bgc)
     endif
 
-    if (use_sedflexi) then
-      ks  = ks_flexi
-      ksp = ks+1
-    endif
+    ! ks provided through config_bgc - init ksp here
+    ksp = ks+1
 
     ! Tracer indices
     i_base   = 18

--- a/hamocc/mo_param1_bgc.F90
+++ b/hamocc/mo_param1_bgc.F90
@@ -283,11 +283,12 @@ contains
     use mo_control_bgc, only: use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,           &
                               use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,           &
                               use_FB_BGC_OCE, use_BOXATM,use_extNcycle,use_pref_tracers,           &
-                              use_coupler_ndep,use_shelfsea_res_time,use_river2omip,use_DOMclasses
+                              use_coupler_ndep,use_shelfsea_res_time,use_river2omip,use_DOMclasses,&
+                              use_M4AGO
 
     integer :: iounit
 
-    namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_natDIC,use_CFC,use_cisonew,             &
+    namelist / config_bgc / use_BROMO,use_AGG,use_WLIN,use_M4AGO,use_natDIC,use_CFC,use_cisonew,   &
                             use_sedbypass,use_PBGC_OCNP_TIMESTEP,use_PBGC_CK_TIMESTEP,             &
                             use_FB_BGC_OCE,use_BOXATM,use_extNcycle,use_pref_tracers,              &
                             use_coupler_ndep,use_shelfsea_res_time,use_sediment_quality,           &

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -44,7 +44,7 @@ module mo_param_bgc
                             lkwrbioz_off,lTO2depremin,use_shelfsea_res_time,use_sediment_quality,  &
                             use_pref_tracers,use_coupler_ndep,use_river2omip,use_DOMclasses,       &
                             linit_DOMclasses_sim,ldyn_sed_age,sedspin_yr_s,sedspin_yr_e,           &
-                            sedspin_ncyc,ldtbgc
+                            sedspin_ncyc,ldtbgc,use_sedflexi
   use mod_xc,         only: mnproc,xchalt
 
   implicit none
@@ -954,6 +954,7 @@ contains
       call cinfo_add_entry('use_FB_BGC_OCE',         use_FB_BGC_OCE)
       call cinfo_add_entry('use_BOXATM',             use_BOXATM)
       call cinfo_add_entry('use_sedbypass',          use_sedbypass)
+      call cinfo_add_entry('use_sedflexi',           use_sedflexi)
       write(io_stdo_bgc,*) '*   ocn_co2_type           = ',ocn_co2_type
       call cinfo_add_entry('do_ndep',                do_ndep)
       call cinfo_add_entry('do_rivinpt',             do_rivinpt)

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -44,7 +44,7 @@ module mo_param_bgc
                             lkwrbioz_off,lTO2depremin,use_shelfsea_res_time,use_sediment_quality,  &
                             use_pref_tracers,use_coupler_ndep,use_river2omip,use_DOMclasses,       &
                             linit_DOMclasses_sim,ldyn_sed_age,sedspin_yr_s,sedspin_yr_e,           &
-                            sedspin_ncyc,ldtbgc,use_sedflexi
+                            sedspin_ncyc,ldtbgc
   use mod_xc,         only: mnproc,xchalt
 
   implicit none
@@ -954,7 +954,6 @@ contains
       call cinfo_add_entry('use_FB_BGC_OCE',         use_FB_BGC_OCE)
       call cinfo_add_entry('use_BOXATM',             use_BOXATM)
       call cinfo_add_entry('use_sedbypass',          use_sedbypass)
-      call cinfo_add_entry('use_sedflexi',           use_sedflexi)
       write(io_stdo_bgc,*) '*   ocn_co2_type           = ',ocn_co2_type
       call cinfo_add_entry('do_ndep',                do_ndep)
       call cinfo_add_entry('do_rivinpt',             do_rivinpt)

--- a/hamocc/mo_sedmnt.F90
+++ b/hamocc/mo_sedmnt.F90
@@ -81,12 +81,6 @@ module mo_sedmnt
 
   real(rp), protected, public :: calfa, oplfa, orgfa, clafa
 
- ! real(rp), parameter :: porwat_def(12) = (/ 0.85_rp, 0.83_rp, 0.8_rp, 0.79_rp, 0.77_rp,0.75_rp,   &
- !                                            0.73_rp, 0.7_rp, 0.68_rp, 0.66_rp, 0.64_rp, 0.62_rp /)
- ! real(rp), parameter :: dzs_def(13) = (/ 0.001_rp, 0.003_rp, 0.005_rp, 0.007_rp, 0.009_rp,        &
- !                                         0.011_rp, 0.013_rp, 0.015_rp, 0.017_rp, 0.019_rp,        &
- !                                         0.021_rp, 0.023_rp, 0.025_rp /)
-
 CONTAINS
 
   subroutine ini_sedmnt(kpie,kpje,omask,sed_por,sed_POCage_init,prorca_mavg_init)


### PR DESCRIPTION
The aim of this PR is to make the number of sediment layers, their vertical extensions and the porosity flexibly settable via the namelist. This is thus far only for test purposes, but can lead for a more sediment-oxygen-deficit layers-oriented setup (i.e. testing, if this improves the nitrogen cycle representation in sediments). I hope to make this work in combination with the  still in progress offline sediment spinup (#560). 

An example `user_nl_blom` snippet to make use of the flexible number of sediment layers looks like:
```
KS = 4
DZS = 0.001 0.003 0.005 0.007 0.009
SED_POROSITY = 0.85 0.83 0.6 0.5
```
Here, the number of sediment layers is reduced to 4 and a changed porosity of the third and fourth layer. Note that the length of `DZS` is by one longer than `SED_POROSITY`.

**NOTE** that due to numerics, there is a lower limit of sediment layers to be used. 

Changing the sediment initialization came with a small restructuring of `mo_hamocc_init` - placing now the memory allocation of fields before reading `bgcnml` - which made it necessary to move `use_M4AGO` out of `bgcnml` and instead put it into `config_nml` (where it is actually better placed as well). 

Changes required in the 1D vertical columns setup `limits` file:

`USE_M4AGO` needs to be moved from `bgcnml` into nml section `config_nml`
`KS=12` needs to be added to `config_nml`
and
```
 DZS = 0.001 0.003 0.005 0.007 0.009 0.011 0.013 0.015 0.017 0.019 0.021 0.023 0.025 
 SED_POROSITY= 0.85 0.83 0.8 0.79 0.77 0.75 0.73 0.7 0.68 0.66 0.64 0.62
```
needs to be put into `bgcnml`.