### PR TITLE
Add PE-layouts for CPLHIST and JRA/tn21 forcings

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -394,7 +394,7 @@
   <!-- GRID: TL319_tn14 : end !-->
 
 
-  <!-- Configurations for running with CPLHIST output from NorESM2 !-->
+  <!-- Configurations for running with CPLHIST output from NorESM2/3 !-->
   
   <grid name="a%0.9x1.25.+oi%tnx1v4|a%1.9x2.5.+oi%tnx1v4">
     <mach name="any">
@@ -433,8 +433,84 @@
       </pes>
     </mach>
   </grid>
+  
+  <grid name="a%ne16np4.pg3.+oi%tnx1v4|a%ne30np4.pg3.+oi%tnx1v4">
+    <mach name="betzy">
+      <pes pesize="any" compset="_DATM%CPLHIST.*_BLOM">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>6</ntasks_atm>
+          <ntasks_rof>6</ntasks_rof>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>500</ntasks_ocn>
+          <ntasks_cpl>140</ntasks_cpl>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>128</rootpe_atm>
+          <rootpe_lnd>128</rootpe_lnd>
+          <rootpe_rof>134</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>140</rootpe_ocn>
+          <rootpe_glc>128</rootpe_glc>
+          <rootpe_wav>128</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
 
- 
+  <grid name="a%ne16np4.pg3.+oi%tnx1v4|a%ne30np4.pg3.+oi%tnx1v4">
+    <mach name="betzy">
+      <pes pesize="XL" compset="_DATM%CPLHIST.*_BLOM">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>8</ntasks_atm>
+          <ntasks_rof>8</ntasks_rof>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>623</ntasks_ocn>
+          <ntasks_cpl>145</ntasks_cpl>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>129</rootpe_atm>
+          <rootpe_lnd>128</rootpe_lnd>
+          <rootpe_rof>137</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>145</rootpe_ocn>
+          <rootpe_glc>128</rootpe_glc>
+          <rootpe_wav>128</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+
   <!-- Configurations for the 1/2 degree tripolar (tnx0.5) grid  !-->
 
   <!-- GRID: TL319_tn05 : start !-->
@@ -903,5 +979,45 @@
       </pes>
     </mach>
   </grid>
+
+  <!-- GRID: TL319_tn21 !-->
+  <grid name="a%TL319.+oi%tnx2v1">
+    <mach name="any">
+      <pes pesize="any" compset="_DATM.*_BLOM.*%ECO">
+        <comment>Large pe-layout with 512 pes in total</comment>
+        <ntasks>
+          <ntasks_atm>4</ntasks_atm>
+          <ntasks_rof>4</ntasks_rof>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>406</ntasks_ocn>
+          <ntasks_cpl>106</ntasks_cpl>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>8</rootpe_lnd>
+          <rootpe_rof>4</rootpe_rof>
+          <rootpe_ice>10</rootpe_ice>
+          <rootpe_ocn>106</rootpe_ocn>
+          <rootpe_glc>9</rootpe_glc>
+          <rootpe_wav>9</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
 
 </config_pes>


### PR DESCRIPTION
This PR adds two PE-layouts for CPLHIST forcing (to be used for BLOM/CICE/iHAMOCC NorESM3 offline spinup) and one PE-layout for the tn21-grid and JRA forcing.