### PR TITLE
Fix CO2 and N-deposition settings in CPLHIST compset

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -64,7 +64,7 @@
       <value compset="_BLOM.*%ECO"           >constant</value>
       <value compset="_BLOM.*%ECO.*_BGC%BPRP">prognostic</value>
       <value compset="_BLOM.*%ECO.*_BGC%BDRD">diagnostic</value>
-      <value compset="_DATM%CPLHIST.*_BLOM.*%ECO">diagnostic</value>
+      <value compset="_DATM%CPLHIST.*_BLOM.*%ECO">constant</value>
       <value compset="20TR_DATM%IAF.*_BLOM.*%ECO">diagnostic</value>
     </values>
     <group>run_component_blom</group>
@@ -155,6 +155,7 @@
       <value compset="2000_.*_BLOM.*%ECO"   >2000</value>
       <value compset="HIST_.*_BLOM.*%ECO"   >hist</value>
       <value compset="20TR_.*_BLOM.*%ECO"   >hist</value>
+      <value compset="CPLHIST_.*_BLOM.*%ECO">1850</value>
       <value compset="SSP119_.*_BLOM.*%ECO" >ssp119</value>
       <value compset="SSP126_.*_BLOM.*%ECO" >ssp126</value>
       <value compset="SSP245_.*_BLOM.*%ECO" >ssp245</value>


### PR DESCRIPTION
This PR fixes two settings in `config_component.xml` that prevented the CPLHIST compset to run correctly out of the box. The first change sets OCN_CO2_TYPE=constant, which is consistent with the coupled spin-up, and the second prevents the N-deposition scenario being set to 'hist'. Note that the second change has no effect in the current setup, because N-deposition is provided through DATM (and not set by BLOM).