### PR TITLE
Make compset regex to match start of the string for ndep

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -154,7 +154,7 @@
       <value compset="^1850_.*_BLOM.*%ECO"   >1850</value>
       <value compset="^2000_.*_BLOM.*%ECO"   >2000</value>
       <value compset="^HIST_.*_BLOM.*%ECO"   >hist</value>
-      <value compset="^20TR_.*_BLOM.*%ECO"   >1850</value>
+      <value compset="^20TR_.*_BLOM.*%ECO"   >hist</value>
       <value compset="^SSP119_.*_BLOM.*%ECO" >ssp119</value>
       <value compset="^SSP126_.*_BLOM.*%ECO" >ssp126</value>
       <value compset="^SSP245_.*_BLOM.*%ECO" >ssp245</value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -154,7 +154,7 @@
       <value compset="^1850_.*_BLOM.*%ECO"   >1850</value>
       <value compset="^2000_.*_BLOM.*%ECO"   >2000</value>
       <value compset="^HIST_.*_BLOM.*%ECO"   >hist</value>
-      <value compset="^20TR_.*_BLOM.*%ECO"   >hist</value>
+      <value compset="^20TR_.*_BLOM.*%ECO"   >1850</value>
       <value compset="^SSP119_.*_BLOM.*%ECO" >ssp119</value>
       <value compset="^SSP126_.*_BLOM.*%ECO" >ssp126</value>
       <value compset="^SSP245_.*_BLOM.*%ECO" >ssp245</value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -151,20 +151,19 @@
     <valid_values>UNSET,1850,2000,hist,ssp119,ssp126,ssp245,ssp370,ssp434,ssp460,ssp534os,ssp585</valid_values>
     <default_value>1850</default_value>
     <values>
-      <value compset="1850_.*_BLOM.*%ECO"   >1850</value>
-      <value compset="2000_.*_BLOM.*%ECO"   >2000</value>
-      <value compset="HIST_.*_BLOM.*%ECO"   >hist</value>
-      <value compset="20TR_.*_BLOM.*%ECO"   >hist</value>
-      <value compset="CPLHIST_.*_BLOM.*%ECO">1850</value>
-      <value compset="SSP119_.*_BLOM.*%ECO" >ssp119</value>
-      <value compset="SSP126_.*_BLOM.*%ECO" >ssp126</value>
-      <value compset="SSP245_.*_BLOM.*%ECO" >ssp245</value>
-      <value compset="SSP370_.*_BLOM.*%ECO" >ssp370</value>
-      <value compset="SSP434_.*_BLOM.*%ECO" >ssp434</value>
-      <value compset="SSP460_.*_BLOM.*%ECO" >ssp460</value>
-      <value compset="SSP534_.*_BLOM.*%ECO" >ssp534os</value>
-      <value compset="SSP585_.*_BLOM.*%ECO" >ssp585</value>
-      <value compset="SSP370.*_BLOM.*%ECO"  >ssp370</value>
+      <value compset="^1850_.*_BLOM.*%ECO"   >1850</value>
+      <value compset="^2000_.*_BLOM.*%ECO"   >2000</value>
+      <value compset="^HIST_.*_BLOM.*%ECO"   >hist</value>
+      <value compset="^20TR_.*_BLOM.*%ECO"   >hist</value>
+      <value compset="^SSP119_.*_BLOM.*%ECO" >ssp119</value>
+      <value compset="^SSP126_.*_BLOM.*%ECO" >ssp126</value>
+      <value compset="^SSP245_.*_BLOM.*%ECO" >ssp245</value>
+      <value compset="^SSP370_.*_BLOM.*%ECO" >ssp370</value>
+      <value compset="^SSP434_.*_BLOM.*%ECO" >ssp434</value>
+      <value compset="^SSP460_.*_BLOM.*%ECO" >ssp460</value>
+      <value compset="^SSP534_.*_BLOM.*%ECO" >ssp534os</value>
+      <value compset="^SSP585_.*_BLOM.*%ECO" >ssp585</value>
+      <value compset="^SSP370.*_BLOM.*%ECO"  >ssp370</value>
      </values>
     <group>run_component_blom</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Hot fix for the regexp in the BLOM_NDEP_SCENARIO.
Adding `^` beginning of the string flag in the regexp for the compset string

Tested:
checkout `noresm3_0_beta05`

run baseline namelists:
```
./create_test SMS.ne30pg3_tn14.1850_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel SMS.ne30pg3_tn14.HIST_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel SMS.T62_tn14.NOINY.betzy_gnu  --baseline-root /cluster/work/users/mdeb/blombsl -t v13 -g beta05 -n --project nn9560k --test-root /cluster/work/users/mdeb/blom_tests
```

checkout this branch and run compare:
```
./create_test SMS.ne30pg3_tn14.1850_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel SMS.ne30pg3_tn14.HIST_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel SMS.T62_tn14.NOINY.betzy_gnu  --baseline-root /cluster/work/users/mdeb/blombsl -t rfi -c beta05 -n --project nn9560k --test-root /cluster/work/users/mdeb/blom_tests
```

Results:
```
PASS SMS.T62_tn14.NOINY.betzy_gnu SETUP
    Case dir: /cluster/work/users/mdeb/blom_tests/SMS.T62_tn14.NOINY.betzy_gnu.C.rfi
NLFAIL SMS.ne30pg3_tn14.1850_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel (but otherwise OK) SETUP
    Case dir: /cluster/work/users/mdeb/blom_tests/SMS.ne30pg3_tn14.1850_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel.C.rfi
NLFAIL SMS.ne30pg3_tn14.HIST_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel (but otherwise OK) SETUP
    Case dir: /cluster/work/users/mdeb/blom_tests/SMS.ne30pg3_tn14.HIST_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel.C.rfi
```

Checking the NLFAILs:
`SMS.ne30pg3_tn14.HIST_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel.C.rfi`:
no mention of diff in `NDEPFILE`.

`SMS.ne30pg3_tn14.1850_DATM%CPLHIST_SLND_CICE_BLOM%HYB%ECO_DROF%CPLHIST_SGLC_SWAV.betzy_intel.C.rfi
`:
```
  BASE: NDEPFILE = ndeposition_185001-201412_tnx1v4_20250207.nc'
  COMP: NDEPFILE = ndeposition_1850_CMIP6_tnx1v4_20250207.nc'
```

You can tests other symyears and cplhist.

@gold2718 @JorgSchwinger @TomasTorsvik 