### PR TITLE
Reducing s_bot oscillations in reference density adaptation

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1124,14 +1124,24 @@
     <desc>e-folding time scale (years) for adjusting mixed layer climatology</desc>
   </entry>
 
-  <entry id="sra_param_ts">
+  <entry id="sra_param_ts1">
     <type>real</type>
     <category>vcoord</category>
     <group>vcoord</group>
     <values>
       <value>5.0</value>
     </values>
-    <desc>e-folding time scale (years) for adjusting to optimized reference potential densities</desc>
+    <desc>e-folding time scale (years) for adjusting sp1 and zp2 parameters in adaption of reference potential densities</desc>
+  </entry>
+
+  <entry id="sra_param_ts2">
+    <type>real</type>
+    <category>vcoord</category>
+    <group>vcoord</group>
+    <values>
+      <value>10.0</value>
+    </values>
+    <desc>e-folding time scale (years) for adjusting sp4 and s_bot parameters in adaption of reference potential densities</desc>
   </entry>
 
   <entry id="sra_massfrac_bot">

--- a/phy/mod_vcoord.F90
+++ b/phy/mod_vcoord.F90
@@ -87,7 +87,7 @@ module mod_vcoord
       dpmin_inflation_factor = 1._r8, &
       sra_clim_ts            = 5._r8, &
       sra_param_ts1          = 5._r8, &
-      sra_param_ts2          = 5._r8, &
+      sra_param_ts2          = 10._r8, &
       sra_massfrac_bot       = .01, &
       sra_massfrac_eps       = .0001
    type(sigref_fun_spec_type) :: &

--- a/phy/mod_vcoord.F90
+++ b/phy/mod_vcoord.F90
@@ -86,7 +86,8 @@ module mod_vcoord
       dpmin_surface          = 1.5_r8, &
       dpmin_inflation_factor = 1._r8, &
       sra_clim_ts            = 5._r8, &
-      sra_param_ts           = 5._r8, &
+      sra_param_ts1          = 5._r8, &
+      sra_param_ts2          = 5._r8, &
       sra_massfrac_bot       = .01, &
       sra_massfrac_eps       = .0001
    type(sigref_fun_spec_type) :: &
@@ -353,35 +354,37 @@ contains
 
       integer, intent(in) :: m, n, mm, nn, k1m, k1n
 
-      real(r8) :: wgt_tf1, wgt_tf2, sp1_tf1, zp2_tf1, sp4_tf1, s_bot_tf1
+      real(r8) :: wgt_tf0, wgt_tf1, wgt_tf2, &
+                  sp1_tf0, zp2_tf0, sp4_tf0, s_bot_tf0
       integer :: i, j, k
 
       ! Time filter weights.
-      wgt_tf1 = ( real(nday_of_year - 1, r8) &
+      wgt_tf0 = ( real(nday_of_year - 1, r8) &
                 + real(mod(nstep, nstep_in_day), r8)/real(nstep_in_day, r8)) &
                 /real(nday_in_year, r8)
-      wgt_tf2 = baclin/(86400._r8*real(nday_in_year, r8)*sra_param_ts + baclin)
+      wgt_tf1 = baclin/(86400._r8*real(nday_in_year, r8)*sra_param_ts1 + baclin)
+      wgt_tf2 = baclin/(86400._r8*real(nday_in_year, r8)*sra_param_ts2 + baclin)
 
       ! Create signals, which vary linearly from old to new parameter values
       ! over a year, for the final time filter.
-      sp1_tf1   = (1._r8 - wgt_tf1)*sigref_fun_spec_old%sp1 &
-                +          wgt_tf1 *sigref_fun_spec_new%sp1
-      zp2_tf1   = (1._r8 - wgt_tf1)*sigref_fun_spec_old%zp2 &
-                +          wgt_tf1 *sigref_fun_spec_new%zp2
-      sp4_tf1   = (1._r8 - wgt_tf1)*sigref_fun_spec_old%sp4 &
-                +          wgt_tf1 *sigref_fun_spec_new%sp4
-      s_bot_tf1 = (1._r8 - wgt_tf1)*sigref_fun_spec_old%s_bot &
-                +          wgt_tf1 *sigref_fun_spec_new%s_bot
+      sp1_tf0   = (1._r8 - wgt_tf0)*sigref_fun_spec_old%sp1 &
+                +          wgt_tf0 *sigref_fun_spec_new%sp1
+      zp2_tf0   = (1._r8 - wgt_tf0)*sigref_fun_spec_old%zp2 &
+                +          wgt_tf0 *sigref_fun_spec_new%zp2
+      sp4_tf0   = (1._r8 - wgt_tf0)*sigref_fun_spec_old%sp4 &
+                +          wgt_tf0 *sigref_fun_spec_new%sp4
+      s_bot_tf0 = (1._r8 - wgt_tf0)*sigref_fun_spec_old%s_bot &
+                +          wgt_tf0 *sigref_fun_spec_new%s_bot
 
       ! Apply final time filter.
-      sigref_fun_spec%sp1   = (1._r8 - wgt_tf2)*sigref_fun_spec%sp1 &
-                            +          wgt_tf2 *sp1_tf1
-      sigref_fun_spec%zp2   = (1._r8 - wgt_tf2)*sigref_fun_spec%zp2 &
-                            +          wgt_tf2 *zp2_tf1
+      sigref_fun_spec%sp1   = (1._r8 - wgt_tf1)*sigref_fun_spec%sp1 &
+                            +          wgt_tf1 *sp1_tf0
+      sigref_fun_spec%zp2   = (1._r8 - wgt_tf1)*sigref_fun_spec%zp2 &
+                            +          wgt_tf1 *zp2_tf0
       sigref_fun_spec%sp4   = (1._r8 - wgt_tf2)*sigref_fun_spec%sp4 &
-                            +          wgt_tf2 *sp4_tf1
+                            +          wgt_tf2 *sp4_tf0
       sigref_fun_spec%s_bot = (1._r8 - wgt_tf2)*sigref_fun_spec%s_bot &
-                            +          wgt_tf2 *s_bot_tf1
+                            +          wgt_tf2 *s_bot_tf0
 
       ! Obtain updated reference potential densities.
       sigref(1:kdm) = sigref_fun(sigref_fun_spec, kdm)
@@ -711,17 +714,9 @@ contains
          else
             ! Adjust s_bot to balance the mass fraction of the two densest
             ! layers.
-            if (massfracdc(kdm-1) > massfracdc(kdm)) then
-               s_bot_new = &
-                  s_bot_mean &
-               - .5_r8*(massfracdc(kdm-1) - massfracdc(kdm)) &
-                      *(s_bot_mean - sigref_mean(kdm-1))/massfracdc(kdm-1)
-            else
-               s_bot_new = &
-                  s_bot_mean &
-                + (massfracdc(kdm) - massfracdc(kdm-1)) &
-                  *(sigdc(kdm) - s_bot_mean)/massfracdc(kdm)
-            endif
+            s_bot_new = s_bot_mean + (massfracdc(kdm) - massfracdc(kdm-1)) &
+                                     *(s_bot_mean - sigref_mean(kdm-1)) &
+                                     /(massfracdc(kdm) + massfracdc(kdm-1))
          endif
          s_bot_new = max(s_bot_new, sp4_new)
 
@@ -819,8 +814,8 @@ contains
       namelist /vcoord/ &
          vcoord_type, dpmin_surface, dpmin_inflation_factor, &
          sigref_spec, plevel_spec, sigref_fun_spec, sigref, plevel, &
-         sigref_adaption, sra_clim_ts, sra_param_ts, sra_massfrac_bot, &
-         sra_massfrac_eps
+         sigref_adaption, sra_clim_ts, sra_param_ts1, sra_param_ts2, &
+         sra_massfrac_bot, sra_massfrac_eps
 
       ! Read variables in the namelist group 'vcoord'.
       if (mnproc == 1) then
@@ -868,7 +863,8 @@ contains
          call xcbcst(plevel)
          call xcbcst(sigref_adaption)
          call xcbcst(sra_clim_ts)
-         call xcbcst(sra_param_ts)
+         call xcbcst(sra_param_ts1)
+         call xcbcst(sra_param_ts2)
          call xcbcst(sra_massfrac_bot)
          call xcbcst(sra_massfrac_eps)
       endif
@@ -882,7 +878,8 @@ contains
          write (lp,*) '  plevel_spec =            ', trim(plevel_spec)
          write (lp,*) '  sigref_adaption =        ', sigref_adaption
          write (lp,*) '  sra_clim_ts =            ', sra_clim_ts
-         write (lp,*) '  sra_param_ts =           ', sra_param_ts
+         write (lp,*) '  sra_param_ts1 =          ', sra_param_ts1
+         write (lp,*) '  sra_param_ts2 =          ', sra_param_ts2
          write (lp,*) '  sra_massfrac_bot =       ', sra_massfrac_bot
          write (lp,*) '  sra_massfrac_eps =       ', sra_massfrac_eps
       endif


### PR DESCRIPTION
This PR modifies the `s_bot` optimization and also introduces the possibility of using different e-folding adjustment time scales for the parameter pairs (`sp1`, `zp2`) and (`sp4`, `s_bot`). The first parameter pair controls reference density profile in the upper ocean, while the second parameter pair controls the maximum range of the reference density profile.

It was found that both modifying the optimization of `s_bot` and increasing the e-folding adjustment time scale from 5 to 10 years were beneficial to reduce oscillations in the `s_bot` parameter. However, to be able to adjust to strong surface forcing perturbations it may be desirable to keep the relatively short 5 year adjustment time scale for the (`sp1`, `zp2`) parameters. Therefore the introduction of two e-folding adjustment time scales.

The impact of modifications to reference density adaptation was tested in CPLHIST forced ocean/ice simulations and compared to https://github.com/NorESMhub/noresm3_dev_simulations/issues/269, which have pronounced oscillation in the `s_bot` parameter.

<img width="1554" height="1162" alt="blom_sra_ts_n16_cplhist_s_bot" src="https://github.com/user-attachments/assets/a2c71b54-dc53-46b1-af5e-3b8a7db829b6" />

In the first figure, circles show annual optimization of the `s_bot` parameter, while solid lines show the parameter value actually used after time filtering. In blue is the https://github.com/NorESMhub/noresm3_dev_simulations/issues/269 experiment, showing oscillations throughout the 120 years of simulation shown here. In orange is a 30 year test with a modification of the `s_bot` optimization that reduces oscillations compared to https://github.com/NorESMhub/noresm3_dev_simulations/issues/269. In green the original optimization is used, but e-folding time scale increased from 5 to 10 years. This also reduces the oscillation in the time filtered parameter value. Finally in red is a 60 year simulation combining the modification of the `s_bot` optimization and increasing the adjustment time scale as implemented in this PR. Oscillations are still present, but strongly muted compared to https://github.com/NorESMhub/noresm3_dev_simulations/issues/269. Also the annual optimizations have a much reduced range of variation.

<img width="1554" height="1162" alt="blom_sra_ts_n16_cplhist" src="https://github.com/user-attachments/assets/3c466121-8112-4f6c-84ee-1e4ccaa68e55" />

The second figure is the same as the first figure for `s_bot`, but shows all parameters participating in the density adaptation. It can be seen that the `sp1` and `zp2` parameters from the simulation using this PR (red color) follows closely https://github.com/NorESMhub/noresm3_dev_simulations/issues/269 (blue color), which is desirable since the adjustment time scale is the same. The time filtered `sp4` parameter is strongly influenced by the adjustment time scale where the simulations with 5 year time scale (blue and orange) and 10 year time scale (green and red) are grouped closely together.