### PR TITLE
Make variable wlin accesible through user namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -5050,8 +5050,8 @@
     <group>bgcparams</group>
     <values>
       <value>None</value>
-      <value use_wlin="yes">0.7</value>
-      <value use_agg="yes">0.5</value>
+      <value use_wlin="yes">None</value>
+      <value use_agg="yes">None</value>
     </values>
     <desc>zooplankton parameter: dimensionless fraction -assimilation efficiency</desc>
   </entry>
@@ -6063,17 +6063,15 @@
     <desc>Half-saturation constant for NO2 for nitrification on NO2 (kmol/m3)</desc>
   </entry>
 
-
-  <!-- TODO: how to handle mathematical expressions like below -->
-  <!-- <entry id="wlin"> -->
-  <!--   <type>real</type> -->
-  <!--   <category>bgcparams</category> -->
-  <!--   <group>bgcparams</group> -->
-  <!--   <values> -->
-  <!--     <value>60./2400.</value> -->
-  <!--   </values> -->
-  <!--   <desc>Sinking parameter: m/d/m constant describing incr. with depth, r/a=1.0</desc> -->
-  <!-- </entry> -->
+  <entry id="wlin">
+    <type>real</type>
+    <category>bgcparams</category>
+    <group>bgcparams</group>
+    <values>
+      <value>None</value>
+    </values>
+    <desc>Sinking parameter: m/d/m constant describing increase with depth</desc>
+  </entry>
 
   <!-- ========================= -->
   <!-- namelist group: diabgc -->


### PR DESCRIPTION
This PR is needed to make it possible to use wlin in `user_nml_blom` as a tuning variable. It has no effect on anything else, and it would be good to include it into a NorESM3 tag as soon as possible. It might be needed when re-coupling the BLOM CPLHIST spinup .