### PR TITLE
Added entries for Kuroshio Current SST pacemaker experiments

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6635,4 +6635,27 @@
     <desc>(ssster) [mol m-3]</desc>
   </entry>
 
+  <!-- Entries for Kuroshio pacemaker experiment. See
+       <NorESM>/cime_config/usermods_dirs/n1850_SST_pacemaker_Kuroshio
+  -->
+  <entry id="Kuroshio_pacemaker_SST_file" is_inputdata="yes">
+    <type>char</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>ocn/n1850_SST_pacemaker_Kuroshio</value>
+    </values>
+    <desc>Daily sea surface temperatures for the Kuroshio current pacemaker experiment</desc>
+  </entry>
+
+  <entry id="Kuroshio_pacemaker_mask_file" is_inputdata="yes">
+    <type>char</type>
+    <category>limits</category>
+    <group>limits</group>
+    <values>
+      <value>ocn/n1850_SST_pacemaker_Kuroshio</value>
+    </values>
+    <desc>SST mask file for the Kuroshio current pacemaker experiment</desc>
+  </entry>
+
 </entry_id_pg>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6635,8 +6635,8 @@
     <desc>(ssster) [mol m-3]</desc>
   </entry>
 
-  <!-- Entries for Kuroshio pacemaker experiment. See
-  <!-- Entries for pacemaker experiments. See Kuroshio current pacemaker experiment
+  <!-- Entries for pacemaker experiments.
+       See Kuroshio current pacemaker experiment at
        <NorESM>/cime_config/usermods_dirs/n1850_SST_pacemaker_Kuroshio
   -->
   <entry id="pacemaker_SST_file" is_inputdata="yes">

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6636,6 +6636,7 @@
   </entry>
 
   <!-- Entries for Kuroshio pacemaker experiment. See
+  <!-- Entries for pacemaker experiments. See Kuroshio current pacemaker experiment
        <NorESM>/cime_config/usermods_dirs/n1850_SST_pacemaker_Kuroshio
   -->
   <entry id="pacemaker_SST_file" is_inputdata="yes">
@@ -6645,7 +6646,7 @@
     <values>
       <value>ocn/n1850_SST_pacemaker_Kuroshio</value>
     </values>
-    <desc>Daily sea surface temperatures for the Kuroshio current pacemaker experiment</desc>
+    <desc>Daily sea surface temperatures for pacemaker experiment</desc>
   </entry>
 
   <entry id="pacemaker_mask_file" is_inputdata="yes">
@@ -6655,7 +6656,7 @@
     <values>
       <value>ocn/n1850_SST_pacemaker_Kuroshio</value>
     </values>
-    <desc>SST mask file for the Kuroshio current pacemaker experiment</desc>
+    <desc>SST mask file for pacemaker experiment</desc>
   </entry>
 
 </entry_id_pg>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6638,7 +6638,7 @@
   <!-- Entries for Kuroshio pacemaker experiment. See
        <NorESM>/cime_config/usermods_dirs/n1850_SST_pacemaker_Kuroshio
   -->
-  <entry id="Kuroshio_pacemaker_SST_file" is_inputdata="yes">
+  <entry id="pacemaker_SST_file" is_inputdata="yes">
     <type>char</type>
     <category>limits</category>
     <group>limits</group>
@@ -6648,7 +6648,7 @@
     <desc>Daily sea surface temperatures for the Kuroshio current pacemaker experiment</desc>
   </entry>
 
-  <entry id="Kuroshio_pacemaker_mask_file" is_inputdata="yes">
+  <entry id="pacemaker_mask_file" is_inputdata="yes">
     <type>char</type>
     <category>limits</category>
     <group>limits</group>


### PR DESCRIPTION
In order to run SST experiments in the Kurosio Current region, two input files are required. See NorESMhub/Noresm#737 for details. This PR adds namelist entries for these two files.

No tests run, however, namelist_definition_blom.xml validated against schema, cime_config/ParamGen/xml_schema/entry_id_pg.xsd