### PR TITLE
Include machine settings for olivia in testlist

### DIFF
--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -5,6 +5,7 @@
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
       <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -14,6 +15,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIA">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -23,24 +25,27 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOIIAOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; IAF forcing</option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="T319_tn14" compset="NOIIAJRAOC1850">
+  <test name="SMS_D_Ld1" grid="TL319_tn14" compset="NOIIAJRAOC1850">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment">debug mode; 1 degree; hybrid coordinates; hamocc; JRA forcing; 1850 clim</option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="T319_tn14" compset="NOIIAJRAOC20TR">
+  <test name="SMS_D_Ld1" grid="TL319_tn14" compset="NOIIAJRAOC20TR">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -50,6 +55,7 @@
   <test name="SMS_D_Ld1" grid="TL319_tn14" compset="NOIIAJRARYF6162OC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -60,6 +66,7 @@
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
       <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -69,6 +76,7 @@
   <test name="ERS_Ld3" grid="T62_tn21" compset="NOINY">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -78,6 +86,7 @@
   <test name="ERS_Ld3" grid="T62_tn14" compset="NOINYOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -87,6 +96,7 @@
   <test name="ERS_Ld3" grid="T62_tn14" compset="N2NOINYOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -96,6 +106,7 @@
   <test name="ERS_Ld3" grid="TL319_tn05" compset="NOIIAJRA">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
@@ -114,6 +125,7 @@
   <test name="ERI_C2" grid="TL319_tn14" compset="NOIIAJRAOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
@@ -124,6 +136,7 @@
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
       <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -135,6 +148,7 @@
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
       <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -145,6 +159,7 @@
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
       <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
@@ -155,6 +170,7 @@
   <test name="ERS_Ld5" grid="T62_tn14" compset="NOINY" testmods="blom/woa_nuopc">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -165,6 +181,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc1">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -174,6 +191,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc2">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -183,6 +201,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc3">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -192,6 +211,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc4">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -201,6 +221,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc5">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -210,6 +231,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc6">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -219,6 +241,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc7">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -228,6 +251,7 @@
   <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINYOC" testmods="blom/hamocc/hamocc8">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_hamocc_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_hamocc_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>


### PR DESCRIPTION
This PR enables running the BLOM and iHAMOCC standard tests suites on olivia.