### PR TITLE
Adjusted iHAMOCC output frequencies for CMIP7 cmorization

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6438,7 +6438,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -6534,7 +6534,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Dissolved carbon (dissic) [mol C m-3]</desc>
+    <desc>Surface dissolved carbon (srfdissic) [mol C m-3]</desc>
   </entry>
 
   <entry id="srf_phyto">
@@ -6547,7 +6547,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Phytoplankton (phyc) [mol P m-3]</desc>
+    <desc>Surface phytoplankton (srfphyc) [mol P m-3]</desc>
   </entry>
 
   <entry id="srf_ph">
@@ -6555,12 +6555,12 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>pH (ph) [-log10([h+])]</desc>
+    <desc>Surface pH (srfph) [-log10([h+])]</desc>
   </entry>
 
   <entry id="srf_export">
@@ -6573,7 +6573,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Export production (epc100) [mol C m-2 s-1]</desc>
+    <desc>Production of detritus (epc100) [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="srf_exposi">
@@ -6586,7 +6586,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Si export production (epsi100) [mol Si m-2 s-1]</desc>
+    <desc>Opal production (epsi100) [mol Si m-2 s-1]</desc>
   </entry>
 
   <entry id="srf_expoca">
@@ -6599,7 +6599,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Ca export production (epcalc100) [mol Ca m-2 s-1]</desc>
+    <desc>Ca production (epcalc100) [mol Ca m-2 s-1]</desc>
   </entry>
 
   <entry id="srf_kwco2">
@@ -6950,7 +6950,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Natural alkalinity (nattalk) [eq m-3]</desc>
+    <desc>Surface natural alkalinity (srfnattalk) [eq m-3]</desc>
   </entry>
 
   <entry id="srf_natph">
@@ -6963,7 +6963,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Natural pH (natph) [-log10([h+])]</desc>
+    <desc>Surface natural pH (srfnatph) [-log10([h+])]</desc>
   </entry>
 
   <entry id="srf_natpco2">
@@ -7127,12 +7127,12 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Surface carbonate ion concentrations [mol C -m3]</desc>
+    <desc>Surface carbonate ion concentration (srfco3) [mol C -m3]</desc>
   </entry>
 
   <entry id="srf_co3satarag">
@@ -7140,12 +7140,12 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Carbonate concentration in equil. with aragonite [mol C -m3]</desc>
+    <desc>Surface carbonate concentration in equil. with aragonite [mol C -m3]</desc>
   </entry>
 
   <entry id="co3satarag_200">
@@ -7153,7 +7153,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -7166,7 +7166,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -7179,7 +7179,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7192,7 +7192,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -7205,7 +7205,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -7218,7 +7218,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -7231,7 +7231,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>4,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
@@ -7275,7 +7275,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Primary production (pp) [mol C m-3 s-1]</desc>
+    <desc>Vertically integrated primary production (ppint) [mol C m-3 s-1]</desc>
   </entry>
 
   <entry id="int_nfix">
@@ -7288,7 +7288,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Vertically integrated nitrogen fixation</desc>
+    <desc>Vertically integrated nitrogen fixation (nfixint)</desc>
   </entry>
 
   <entry id="int_dnit">
@@ -7301,7 +7301,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Vertically integrated denitrification</desc>
+    <desc>Vertically integrated denitrification (dnitint)</desc>
   </entry>
 
   <entry id="int_exudl">
@@ -7472,7 +7472,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
     </values>
-    <desc>namelist for diagnostic iHAMOCC output</desc>
+    <desc>Flux of alkalinity by OAE into the surface ocean [mol TA m-2 s-1]</desc>
   </entry>
 
   <entry id="flx_car0100">
@@ -7792,7 +7792,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7805,7 +7805,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7818,7 +7818,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7831,7 +7831,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7844,7 +7844,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7857,7 +7857,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7870,7 +7870,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7883,7 +7883,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7896,7 +7896,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7909,7 +7909,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7922,7 +7922,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7935,7 +7935,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7948,7 +7948,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,4</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,0,4</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7961,7 +7961,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7974,7 +7974,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -7987,7 +7987,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8000,7 +8000,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8174,7 +8174,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
     </values>
-    <desc>PP consumption of NH4 [mol NH4 m-3 s-1] - ext. N cycle only </desc>
+    <desc>PP consumption of NO3 [mol NO3 m-3 s-1] - ext. N cycle only </desc>
   </entry>
 
   <entry id="lyr_remin_aerob">
@@ -8208,7 +8208,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8221,7 +8221,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8234,7 +8234,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8247,7 +8247,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8260,7 +8260,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8273,7 +8273,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8286,7 +8286,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8299,7 +8299,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8312,7 +8312,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8325,7 +8325,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8338,7 +8338,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8351,7 +8351,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8364,7 +8364,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8377,7 +8377,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8390,7 +8390,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8403,7 +8403,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8416,7 +8416,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8429,7 +8429,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8442,7 +8442,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8468,7 +8468,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8481,7 +8481,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8494,7 +8494,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8507,7 +8507,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,4</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,0,4</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8520,7 +8520,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,4</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,0,4</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8533,7 +8533,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8546,7 +8546,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,4</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8559,7 +8559,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8572,7 +8572,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8585,7 +8585,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,4,4</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8598,7 +8598,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -8611,7 +8611,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -8624,7 +8624,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -8637,7 +8637,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -8650,7 +8650,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8663,7 +8663,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8676,7 +8676,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8689,7 +8689,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8702,7 +8702,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8715,7 +8715,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8728,7 +8728,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8741,7 +8741,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8754,7 +8754,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8767,7 +8767,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8780,7 +8780,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8793,7 +8793,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8806,7 +8806,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8819,7 +8819,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8832,7 +8832,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8845,7 +8845,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8858,7 +8858,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8871,7 +8871,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8884,7 +8884,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8897,7 +8897,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8910,7 +8910,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8923,7 +8923,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8936,7 +8936,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8949,7 +8949,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">0,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -8988,7 +8988,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
     </values>
     <desc>Bromoform [mol CHBr3 m-3]</desc>
@@ -9754,7 +9754,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -9843,7 +9843,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,4,4</value>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -9882,7 +9882,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,4,4</value>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,0</value>
@@ -10272,7 +10272,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10285,7 +10285,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10298,7 +10298,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10311,7 +10311,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10324,7 +10324,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10337,7 +10337,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10350,7 +10350,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10363,7 +10363,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10376,7 +10376,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>
@@ -10389,7 +10389,7 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,0,2</value>
+      <value>0,2,2</value>
       <value is_test="yes">2,0,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">0,2</value>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -7275,7 +7275,7 @@
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value hamocc_output_size="spinup">2,2</value>
     </values>
-    <desc>Vertically integrated primary production (ppint) [mol C m-3 s-1]</desc>
+    <desc>Vertically integrated primary production (ppint) [mol C m-2 s-1]</desc>
   </entry>
 
   <entry id="int_nfix">
@@ -7296,12 +7296,12 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
-      <value hamocc_output_size="spinup">2,2</value>
+      <value hamocc_output_size="spinup">0,0</value>
     </values>
-    <desc>Vertically integrated denitrification (dnitint)</desc>
+    <desc>Vertically integrated denitrification (dnitint), currently not functional in combination with ext. N-cycle</desc>
   </entry>
 
   <entry id="int_exudl">


### PR DESCRIPTION
This PR adjust the default settings for iHAMOCC output in `namelist_definition_blom.xml`, mainly
* add daily frequency for some of the newly added outputs
* remove outputs on layers almost completely (with some exceptions for N-cycle related fields)
* add monthly outputs for diffusive fluxes between sediment and water column