### PR TITLE
Fix OCN_CO2_type for HIST compset

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -62,6 +62,8 @@
     <default_value>constant</default_value>
     <values>
       <value compset="_BLOM.*%ECO"           >constant</value>
+      <value compset="1850_CAM"              >constant</value>
+      <value compset="HIST_CAM"              >diagnostic</value>
       <value compset="_BLOM.*%ECO.*_BGC%BPRP">prognostic</value>
       <value compset="_BLOM.*%ECO.*_BGC%BDRD">diagnostic</value>
       <value compset="_DATM%CPLHIST.*_BLOM.*%ECO">constant</value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -62,8 +62,7 @@
     <default_value>constant</default_value>
     <values>
       <value compset="_BLOM.*%ECO"           >constant</value>
-      <value compset="1850_CAM"              >constant</value>
-      <value compset="HIST_CAM"              >diagnostic</value>
+      <value compset="_CAM"                  >diagnostic</value>
       <value compset="_BLOM.*%ECO.*_BGC%BPRP">prognostic</value>
       <value compset="_BLOM.*%ECO.*_BGC%BDRD">diagnostic</value>
       <value compset="_DATM%CPLHIST.*_BLOM.*%ECO">constant</value>


### PR DESCRIPTION
This PR fixes the setting of `OCN_CO2_TYPE` for a historical compset. This might be a preliminary fix since we will need to work further on the logic how to set this variable based on the compset (see also discussion in https://github.com/NorESMhub/NorESM/issues/782).

@mvertens, note that for the spinup (and probably also piControl) we use `OCN_CO2_TYPE=constant`, so I didn't follow the MOM6 example.