### PR TITLE
Enabling BLOM CMIP7 output by default namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -3516,7 +3516,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,0,1</value>
+      <value>0,0,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -2255,7 +2255,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>4,4,0</value>
+      <value>0,4,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,0</value>
@@ -2944,7 +2944,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -3425,7 +3425,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -3438,7 +3438,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -3503,7 +3503,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,4</value>
@@ -3516,7 +3516,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,1</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -3529,7 +3529,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,4</value>
@@ -3542,7 +3542,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -3555,7 +3555,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,4</value>
@@ -3568,7 +3568,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,4</value>
@@ -3581,7 +3581,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -3594,7 +3594,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -3607,7 +3607,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -3776,7 +3776,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">0,0,4</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -3803,8 +3803,6 @@
     <group>diaphy</group>
     <values>
       <value>0,4,0</value>
-      <value is_test="yes">4,4,0</value>
-      <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,4</value>
@@ -3934,7 +3932,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -3960,7 +3958,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -3973,7 +3971,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,0,0</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,0,0</value>
@@ -4012,7 +4010,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4025,7 +4023,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4038,7 +4036,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4051,7 +4049,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4064,7 +4062,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4077,7 +4075,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4090,7 +4088,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4103,7 +4101,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4116,7 +4114,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4129,7 +4127,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4142,7 +4140,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4155,7 +4153,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4168,7 +4166,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4181,7 +4179,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4194,7 +4192,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4207,7 +4205,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4220,7 +4218,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4233,7 +4231,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4246,7 +4244,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4259,7 +4257,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4272,7 +4270,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4285,7 +4283,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4298,7 +4296,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>
@@ -4311,7 +4309,7 @@
     <category>diaphy</category>
     <group>diaphy</group>
     <values>
-      <value>0,4,0</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,4,0</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
       <value blom_output_size="spinup">0,4,4</value>


### PR DESCRIPTION
With default namelist, BLOM should now output the CMIP7 requested variables at appropriate frequencies. Tested not to change the model state in a NOIIAJRARYF8485OC on Betzy.