### PR TITLE
Add adjustable factor to the 10 m wind of parameterized Langmuir turbulence enhancement

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1820,6 +1820,16 @@
     <desc>Fraction of surface TKE that penetrates beneath mixed layer</desc>
   </entry>
 
+  <entry id="lau10f">
+    <type>real</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>1.</value>
+    </values>
+    <desc>Factor applied to 10 m absolute wind entering parameterization of Langmuir turbulence enhancement factor</desc>
+  </entry>
+
   <entry id="smobld">
     <type>logical</type>
     <category>diffusion</category>

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -176,6 +176,8 @@
 ! NUBMIN   : Minimum background diapycnal diffusivity (m**2/s) (f)
 ! TKEPF    : Fraction of surface TKE that penetrates beneath mixed layer
 !            () (f)
+! LAU10F   : Factor applied to 10 m absolute wind entering parameterization
+!            of Langmuir turbulence enhancement factor () (f)
 ! SMOBLD   : If true, apply lateral smoothing of CVMix estimated
 !            boundary layer depth (l)
 ! LNGMTP   : Type of CVMix Langmuir turbulence parameterization. Valid

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -33,9 +33,9 @@ module mod_difest
                                    pbu, pbv, ubflxs_p, vbflxs_p, kfpla
   use mod_diffusion,         only: egc, eggam, eglsmn, egmndf, egmxdf, &
                                    egidfq, rhiscf, ri0, bdmc1, bdmc2, bdmldp, &
-                                   iwdflg, iwdfac, nubmin, tkepf, bdmtyp, &
-                                   eddf2d, edsprs, edanis, redi3d, rhsctp, &
-                                   edfsmo, smobld, lngmtp, edritp_opt, &
+                                   iwdflg, iwdfac, nubmin, tkepf, lau10f, &
+                                   bdmtyp, eddf2d, edsprs, edanis, redi3d, &
+                                   rhsctp, edfsmo, smobld, lngmtp, edritp_opt, &
                                    edritp_shear, edritp_large_scale, &
                                    edwmth_opt, edwmth_smooth, edwmth_step, &
                                    ltedtp_opt, ltedtp_neutral, &
@@ -1099,7 +1099,7 @@ contains
 
           if (wavsrc_opt == wavsrc_param) then
             lamult(i,j) = cvmix_kpp_EFactor_model( &
-                          abswnd(i,j), &
+                          lau10f*abswnd(i,j), &
                           surfFricVel, &
                           OBLdepth(i,j), &
                           CVMix_glb_params)

--- a/phy/mod_diffusion.F90
+++ b/phy/mod_diffusion.F90
@@ -55,8 +55,10 @@ module mod_diffusion
       bdmc2, &  ! Background diapycnal diffusivity [m2 s-1].
       iwdfac, & ! Internal wave dissipation factor under sea ice [].
       nubmin, & ! Minimum background diapycnal diffusivity [m2 s-1].
-      tkepf     ! Fraction of surface TKE that penetrates beneath mixed layer
+      tkepf, &  ! Fraction of surface TKE that penetrates beneath mixed layer
                 ! [].
+      lau10f    ! Factor applied to 10 m absolute wind entering parameterization
+                ! of Langmuir turbulence enhancement factor [].
    integer :: &
       bdmtyp, & ! Type of background diapycnal mixing. If bdmtyp = 1 the
                 ! background diffusivity is a constant divided by the
@@ -181,9 +183,9 @@ module mod_diffusion
 
    ! Public variables
    public :: egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-             bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, bdmtyp, &
-             eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, &
-             ndiff_surface_align, lngmtp, eitmth_opt, eitmth_intdif, &
+             bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, &
+             bdmtyp, eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, &
+             smobld, ndiff_surface_align, lngmtp, eitmth_opt, eitmth_intdif, &
              eitmth_gm, edritp_opt, edritp_shear, edritp_large_scale, &
              edwmth_opt, edwmth_smooth, edwmth_step, ltedtp_opt, ltedtp_layer, &
              ltedtp_neutral, &
@@ -211,9 +213,9 @@ contains
 
       namelist /diffusion/ &
          egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-         bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, bdmtyp, eddf2d, &
-         edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, lngmtp, &
-         eitmth, edritp, edwmth, ltedtp, ndiff_surface_align
+         bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, bdmtyp, &
+         eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, &
+         lngmtp, eitmth, edritp, edwmth, ltedtp, ndiff_surface_align
 
       ! Read variables in the namelist group 'diffusion'.
       if (mnproc == 1) then
@@ -258,6 +260,7 @@ contains
         call xcbcst(iwdfac)
         call xcbcst(nubmin)
         call xcbcst(tkepf)
+        call xcbcst(lau10f)
         call xcbcst(bdmtyp)
         call xcbcst(eddf2d)
         call xcbcst(edsprs)
@@ -291,6 +294,7 @@ contains
          write (lp,*) '  iwdfac = ', iwdfac
          write (lp,*) '  nubmin = ', nubmin
          write (lp,*) '  tkepf  = ', tkepf
+         write (lp,*) '  lau10f = ', lau10f
          write (lp,*) '  bdmtyp = ', bdmtyp
          write (lp,*) '  eddf2d = ', eddf2d
          write (lp,*) '  edsprs = ', edsprs

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -294,6 +294,8 @@
 ! NUBMIN   : Minimum background diapycnal diffusivity (m**2/s) (f)
 ! TKEPF    : Fraction of surface TKE that penetrates beneath mixed layer
 !            () (f)
+! LAU10F   : Factor applied to 10 m absolute wind entering parameterization
+!            of Langmuir turbulence enhancement factor () (f)
 ! SMOBLD   : If true, apply lateral smoothing of CVMix estimated
 !            boundary layer depth (l)
 ! LNGMTP   : Type of CVMix Langmuir turbulence parameterization. Valid
@@ -331,6 +333,7 @@
   IWDFAC   = .06
   NUBMIN   = 1.e-6
   TKEPF    = 0.
+  LAU10F   = 1.
   SMOBLD   = .true.
   LNGMTP   = 'none'
   LTEDTP   = 'layer'


### PR DESCRIPTION
The factor is adjustable as a namelist variable `lau10f`. Currently, `lau10f = 1.0`, giving bit-identical results with current master.