### PR TITLE
Alllow to run paramgen with python that does not have setuptools

### DIFF
--- a/cime_config/ParamGen/paramgen.py
+++ b/cime_config/ParamGen/paramgen.py
@@ -140,9 +140,11 @@ class ParamGen:
         """
 
         # First check whether the given xml file conforms to the entry_id_pg.xsd schema
+        # First try python's built-in shutils. As a last resort try setup tools.
         try:
             xmllint = shutil.which("xmllint")
         except:
+            from distutils.spawn import find_executable
             xmllint = find_executable("xmllint")
             
         if xmllint is None:

--- a/cime_config/ParamGen/paramgen.py
+++ b/cime_config/ParamGen/paramgen.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import re
+import shutil
 from copy import deepcopy
 import logging
 import subprocess
@@ -139,9 +140,11 @@ class ParamGen:
         """
 
         # First check whether the given xml file conforms to the entry_id_pg.xsd schema
-        from distutils.spawn import find_executable
-
-        xmllint = find_executable("xmllint")
+        try:
+            xmllint = shutil.which("xmllint")
+        except:
+            xmllint = find_executable("xmllint")
+            
         if xmllint is None:
             logger.warning("Couldn't find xmllint. Skipping schema check")
         else:


### PR DESCRIPTION
Make paramgen work when setuptools are not installed with your python.