### PR TITLE
Make extNcycle support optional natDIC tracers

### DIFF
--- a/hamocc/mo_accfields.F90
+++ b/hamocc/mo_accfields.F90
@@ -199,8 +199,8 @@ contains
     real(rp) :: d13C(kpie,kpje,kpke)
     real(rp) :: d14C(kpie,kpje,kpke)
     real(rp) :: bigd14C(kpie,kpje,kpke)
-    real(rp) :: intpoc(kpie,kpje)               ! Vertically integrated detritus concentration 
-	real(rp) :: srfph(kpie,kpje)                ! Temporary variable for calculation of surface pH
+    real(rp) :: intpoc(kpie,kpje)               ! Vertically integrated detritus concentration
+    real(rp) :: srfph(kpie,kpje)                ! Temporary variable for calculation of surface pH
     real(rp) :: srfco3satarag(kpie,kpje)        ! Mole carbonate anion (CO3) for sea water in equilibrium with pure Aragonite @sfc
     real(rp) :: phyc_200(kpie,kpje)             ! phytoplankton 200m
     real(rp) :: ph_200(kpie,kpje)               ! pH 200m
@@ -208,8 +208,7 @@ contains
     real(rp) :: co3satarag_200(kpie,kpje)       ! Mole carbonate anion (CO3) for sea water in equilibrium with pure Aragonite @200m
     real(rp) :: o2_200(kpie,kpje)               ! o2 200m
     real(rp) :: o2min(kpie,kpje)                ! o2 minimum closest to surface
-	
-	real(rp),parameter :: himin = 1.0e-11       ! Minimum [H+] for calculation of pH
+    real(rp),parameter :: himin = 1.0e-11       ! Minimum [H+] for calculation of pH
 
     if (use_cisonew) then
       ! Calculation d13C, d14C and Dd14C: Delta notation for output
@@ -234,7 +233,7 @@ contains
     endif
 
     intpoc        (:,:)=0._rp
-	srfph         (:,:)=0._rp
+    srfph         (:,:)=0._rp
     srfco3satarag (:,:)=0._rp
     phyc_200      (:,:)=0._rp
     ph_200        (:,:)=0._rp
@@ -258,12 +257,12 @@ contains
             o2_200(i,j)         = ocetra(i,j,k,ioxygen)
             ph_200(i,j)         = -log10(max(hi(i,j,k),himin))
          endif
-		  
+
           ! integrated POC in kmol P m-2
           do k=1,kpke
             intpoc(i,j) = intpoc(i,j) + ocetra(i,j,k,idet)*pddpo(i,j,k)
           enddo
-          
+
           ! O2 minimum closest to surface (but below mixed layer)
           k1 = kmle(i,j)
           o2min(i,j) = ocetra(i,j,k1,ioxygen)
@@ -384,7 +383,7 @@ contains
     call accsrf(jsrfsilica,ocetra(1,1,1,isilica),omask,0)
     call accsrf(jsrfdic,ocetra(1,1,1,isco212),omask,0)
     call accsrf(jsrfphyto,ocetra(1,1,1,iphy),omask,0)
-	srfph = -log10(max(hi(:,:,1),himin))
+    srfph = -log10(max(hi(:,:,1),himin))
     call accsrf(jsrfph,srfph,omask,0)
     call accsrf(jdms,ocetra(1,1,1,idms),omask,0)
     call accsrf(jsrfpn2om,pn2om,omask,0)
@@ -413,7 +412,7 @@ contains
       call accsrf(jsrfnatdic,ocetra(1,1,1,inatsco212),omask,0)
       call accsrf(jsrfnatalk,ocetra(1,1,1,inatalkali),omask,0)
       call accsrf(jnatpco2,natpco2,omask,0)
-	  srfph = -log10(max(nathi(:,:,1),himin))
+      srfph = -log10(max(nathi(:,:,1),himin))
       call accsrf(jsrfnatph,srfph,omask,0)
     endif
     if (use_BROMO) then

--- a/hamocc/mo_apply_ndep.F90
+++ b/hamocc/mo_apply_ndep.F90
@@ -85,13 +85,16 @@ contains
           ndepnoyflx(i,j) = ndep(i,j,idepnoy)*dtb/365._rp
           ocetra(i,j,1,iano3)=ocetra(i,j,1,iano3)+ndepnoyflx(i,j)/pddpo(i,j,1)
           ocetra(i,j,1,ialkali)=ocetra(i,j,1,ialkali)-ndepnoyflx(i,j)/pddpo(i,j,1)
-          if (use_natDIC) then
-            ocetra(i,j,1,inatalkali)=ocetra(i,j,1,inatalkali)-ndepnoyflx(i,j)/pddpo(i,j,1)
-          endif
           if (use_extNcycle) then
             ndepnhxflx(i,j)       = ndep(i,j,idepnhx)*dtb/365._rp
             ocetra(i,j,1,ianh4)   = ocetra(i,j,1,ianh4)   + ndepnhxflx(i,j)/pddpo(i,j,1)
             ocetra(i,j,1,ialkali) = ocetra(i,j,1,ialkali) + ndepnhxflx(i,j)/pddpo(i,j,1)
+          endif
+          if (use_natDIC) then
+            ocetra(i,j,1,inatalkali)=ocetra(i,j,1,inatalkali) - ndepnoyflx(i,j)/pddpo(i,j,1)
+            if (use_extNcycle) then
+                   ocetra(i,j,1,inatalkali)=ocetra(i,j,1,inatalkali) + ndepnhxflx(i,j)/pddpo(i,j,1)
+            endif
           endif
         endif
       enddo

--- a/hamocc/mo_control_bgc.F90
+++ b/hamocc/mo_control_bgc.F90
@@ -73,6 +73,7 @@ module mo_control_bgc
   character(len=64) :: ocn_co2_type                     ! indicates co2 coupling to an active atm
                                                         ! model if set to 'diagnostic'
                                                         ! or 'prognostic'
+                                                        ! otherwise 'constant' refers to atm_co2 set via namelist
   logical           :: linit_DOMclasses_sim   = .true.  ! if true, DOM classes are initialized from former simulation, else from scratch
 
   ! Logical switches set via namelist config_bgc

--- a/hamocc/mo_extNwatercol.F90
+++ b/hamocc/mo_extNwatercol.F90
@@ -50,8 +50,9 @@ module mo_extNwatercol
   use mod_xc,         only: mnproc
   use mo_kind,        only: rp
   use mo_param1_bgc,  only: ialkali,ianh4,iano2,ian2o,iano3,idet,igasnit,iiron,ioxygen,iphosph,    &
-                          & isco212
+                          & isco212,inatsco212,inatalkali
   use mo_carbch,      only: ocetra
+  use mo_control_bgc, only: use_natDIC
   use mo_param_bgc,   only: riron,rnit,rcar,rnoi,                                                  &
                           & q10ano3denit,sc_ano3denit,Trefano3denit,rano3denit,bkano3denit,        &
                           & rano2anmx,q10anmx,Trefanmx,alphaanmx,bkoxanmx,bkano2anmx,bkanh4anmx,   &
@@ -191,7 +192,11 @@ contains
                                   &                       - (0.5_rp - ro2nnit*fdetnitr)*nitr
             ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali) - (2._rp*fno2 + fn2o + rnm1*rnoi*fdetamox)*amox&
                                   &                       - rnm1*rnoi*fdetnitr*nitr
-
+            if (use_natDIC) then
+              ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212) - rc2n*(fdetamox*amox + fdetnitr*nitr)
+              ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali) - (2._rp*fno2 + fn2o + rnm1*rnoi*fdetamox)*amox&
+                                  &                               - rnm1*rnoi*fdetnitr*nitr
+            endif
             ! Output
             nitr_NH4(i,j,k)       = amox               ! kmol N/m3/dtb   - NH4 consumption for nitrification on NH4-incl. usage for biomass
             nitr_NO2(i,j,k)       = nitr               ! kmol N/m3/dtb   - NO2 consumption for nitrification on NO2
@@ -244,6 +249,11 @@ contains
             ocetra(i,j,k,iphosph) = ocetra(i,j,k,iphosph) + ano3denit*rnoxpi
             ocetra(i,j,k,iiron)   = ocetra(i,j,k,iiron)   + ano3denit*riron*rnoxpi
             ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali) + ano3denit*rnm1*rnoxpi
+
+            if (use_natDIC) then
+              ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212) + ano3denit*rcar*rnoxpi
+              ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali) + ano3denit*rnm1*rnoxpi
+            endif
 
             ! Output
             denit_NO3(i,j,k) = ano3denit ! kmol NO3/m3/dtb   - NO3 usage for denit on NO3
@@ -301,6 +311,11 @@ contains
             ocetra(i,j,k,iphosph) = ocetra(i,j,k,iphosph) - ano2anmx*rno2anmxi
             ocetra(i,j,k,iiron)   = ocetra(i,j,k,iiron)   - ano2anmx*riron*rno2anmxi
             ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali) - ano2anmx*rnm1*rno2anmxi
+
+            if (use_natDIC) then
+              ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212) - ano2anmx*rcar*rno2anmxi
+              ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali) - ano2anmx*rnm1*rno2anmxi
+            endif
 
             ! Output
             anmx_N2_prod(i,j,k) = ano2anmx*(rnh4anmx-rnit)*rno2anmxi  ! kmol N2/m3/dtb - N2 prod through anammox
@@ -412,6 +427,14 @@ contains
                                   &                       + riron*rno2dnrai*ano2dnra
             ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali) + (295._rp*ano2denit + rnm1*an2odenit)*rnoxpi &
                                  &                        + (rno2dnra + rnh4dnra - 1._rp)*rno2dnrai*ano2dnra
+
+            if (use_natDIC) then
+              ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212) + rcar*rnoxpi*(ano2denit + an2odenit) &
+                                       &                          + rcar*rno2dnrai*ano2dnra
+              ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali) + (295._rp*ano2denit + rnm1*an2odenit)*rnoxpi &
+                                       &                          + (rno2dnra + rnh4dnra - 1._rp)*rno2dnrai*ano2dnra
+            endif
+
             ! Output
             denit_NO2(i,j,k) = ano2denit ! kmol NO2/m3/dtb - denitrification on NO2
             denit_N2O(i,j,k) = an2odenit ! kmol N2O/m3/dtb - denitrification on N2O

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -1932,6 +1932,10 @@ contains
                 ocetra(i,j,k,isco213) = ocetra(i,j,k,isco213)+flca13
                 ocetra(i,j,k,isco214) = ocetra(i,j,k,isco214)+flca14
               endif
+              if (use_natDIC) then
+                ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)+2._rp*flcaca
+                ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212)+flcaca
+              endif
             enddo ! k=1,kpke
 
           endif ! omask > 0.5

--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -583,7 +583,7 @@ contains
             ocetra(i,j,k,iphosph) = ocetra(i,j,k,iphosph)+dtr
             if (.not. use_extNcycle) then
               ocetra(i,j,k,iano3)   = ocetra(i,j,k,iano3)+dtr*rnit
-              ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali)-2._rp*delcar-(rnit+1)*dtr
+              ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali)-2._rp*delcar-(rnit+1._rp)*dtr
               ocetra(i,j,k,ioxygen) = ocetra(i,j,k,ioxygen)-dtr*ro2ut
             else
               ocetra(i,j,k,iano3)   = ocetra(i,j,k,iano3) - (1._rp-nh4uptfrac)*phosy*rnit
@@ -669,8 +669,14 @@ contains
             endif
             if (use_natDIC) then
               ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212)-delcar+rcar*dtr
-              ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)-2._rp*delcar-(rnit+1._rp)*dtr
               ocetra(i,j,k,inatcalc) = ocetra(i,j,k,inatcalc)+delcar
+              if (use_extNcycle) then
+                ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)- nh4uptfrac*phosy*(rnit-1._rp) &  ! NH4 + PO4 Uptake
+                                    &                   + (1._rp-nh4uptfrac)*phosy*(rnit+1._rp)    &  ! NO3 + PO4 Uptake
+                                    &                   + (dtr+phosy)*(rnit-1._rp) - 2._rp*delcar     ! Remin to (NH4 + PO4) and CaCO3 formation
+              else
+                ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)-2._rp*delcar-(rnit+1._rp)*dtr
+              endif
             endif
             if (lkwrbioz_off) then
                   opalrem = 0._rp
@@ -968,7 +974,7 @@ contains
 
             if (.not. use_extNcycle) then
               ocetra(i,j,k,iano3) = ocetra(i,j,k,iano3)+remin*rnit
-              ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali)-(rnit+1)*remin
+              ocetra(i,j,k,ialkali) = ocetra(i,j,k,ialkali)-(rnit+1._rp)*remin
               ocetra(i,j,k,ioxygen) = ocetra(i,j,k,ioxygen)-ro2ut*remin
             else
               ocetra(i,j,k,ianh4) = ocetra(i,j,k,ianh4) + remin*rnit
@@ -1006,7 +1012,11 @@ contains
                  &             -relaxfe*max(ocetra(i,j,k,iiron)-fesoly,0._rp)
             if (use_natDIC) then
               ocetra(i,j,k,inatsco212) = ocetra(i,j,k,inatsco212)+rcar*remin
-              ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)-(rnit+1._rp)*remin
+              if (use_extNcycle) then
+                ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)+(rnit-1._rp)*remin
+              else
+                ocetra(i,j,k,inatalkali) = ocetra(i,j,k,inatalkali)-(rnit+1._rp)*remin
+              endif
             endif
             if (use_cisonew) then
               ocetra(i,j,k,idet13) = ocetra(i,j,k,idet13)-pocrem13+sterph13+sterzo13

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -227,7 +227,7 @@ module mo_param_bgc
   real(rp), protected :: atm_n2o     = 270.1e3_rp ! atmosphere N2O conc. pre-industrial: 270.1 (+-6ppb) IPCC 2021, p708, provided in ppt,300ppb = 300e3ppt = 3e-7 mol/mol
   real(rp), protected :: atm_nh3     = 0._rp      ! Six & Mikolajewicz 2022: less than 1nmol m-3
   real(rp), protected :: atm_o2      = 196800._rp ! atmosphere oxygen concentration
-  real(rp), protected :: atm_co2_nat = 284.32_rp  ! atmosphere CO2 concentration CMIP6 pre-industrial reference
+  real(rp), protected :: atm_co2_nat = 284.7_rp   ! atmosphere CO2 concentration CAM pre-industrial reference
   real(rp), protected :: atm_bromo   = 3.4_rp     ! atmosphere bromophorme concentration
                                            ! For now use 3.4ppt from Hense and Quack (2009; Biogeosciences) NEED TO
                                            ! BE UPDATED WITH Ziska et al. (2013) climatology database

--- a/hamocc/mo_profile_gd.F90
+++ b/hamocc/mo_profile_gd.F90
@@ -70,7 +70,7 @@ contains
     integer,  parameter :: nread_ciso = 2 ! Number of fields to read
     integer,  parameter :: nread_dom  = 4 ! Number of fields to read
     integer,  parameter :: nread_pdom = 4 ! Number of fields to read
-    integer,  parameter :: maxflds    = nread_base+nread_ndic+nread_ciso+nread_dom
+    integer,  parameter :: maxflds    = nread_base+nread_ndic+nread_ciso+nread_dom+nread_pdom
     integer             :: nflds, no
     integer             :: ifld(maxflds)
     character(len=3)    :: vname(maxflds)


### PR DESCRIPTION
Hi @JorgSchwinger an @tjiputra , with this PR, the extended nitrogen cycle now supports the natural DIC tracers. I haven't much tested it (compiles and runs in 1D vertical water column, but untested on betzy/olivia). I stayed with the shortcut for sediment biogeochemistry (I might look into it later). 

@TimotheeBrgs , in case that you also want to use the natDIC tracers, it seems as if they're currently not fully supported by the `river2OMIP` setting (e.g. in `mo_ocprod.F90`) 

Remaining issues after merging this branch:
- run in `OCN_CO2_TYPE=diagnostic` mode, CAM seems to feature an atmospheric CO2 concentration of about 284.957ppm (for the 1st month) 
- natDIC still isn't supported in the sediment   (see issue #730)
- not sure, how to proceed with the new `>=beta13` version; there was no preference within our group on this matter  
- river2omip not fully supported (see issue #731) 

Closes #726.