### PR TITLE
Work-around for writing atmospheric CO2

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6875,10 +6875,10 @@
     <category>diabgc</category>
     <group>diabgc</group>
     <values>
-      <value>0,2,2</value>
+      <value>0,4,4</value>
       <value is_test="yes">4,2,2</value>
       <value is_test="yes" empty_hist="yes">0,0,0</value>
-      <value hamocc_output_size="spinup">2,2</value>
+      <value hamocc_output_size="spinup">4,4</value>
     </values>
     <desc>Atmospheric CO2 (atmco2) [ppm]</desc>
   </entry>


### PR DESCRIPTION
This PR does not solve the problem with writing atmco2, but provides a work-around (writing real4 instead of int2 output) so that tuning simulations may continue while we work on the underlying problem.

REF: #729 