### PR TITLE
Include sanity check for input in ncpack

### DIFF
--- a/phy/mod_nctools.F90
+++ b/phy/mod_nctools.F90
@@ -1321,6 +1321,21 @@ contains
       end if
       call xcmin(fldmin)
       call xcmax(fldmax)
+
+      ! --- Sanity check
+      if( .not. fldmin >= fldmax) then
+        if( fldmin+10.0_rp*spacing(fldmin) > fldmax ) then  ! field is constant within round-off error
+          if (mnproc == 1) then
+            write(lp,*) 'ncpack: Output field for ', trim(vnm), ' is constant within round-off error.'
+            write(lp,*) 'Casting real to int2 can fall outside the range. Please use other output method.'
+            flush(lp)
+          end if
+          call xcstop('(ncpack)')
+          stop '(ncpack)'
+        end if
+      end if
+
+      ! --- Calculate scale factor and offset
       if (uvflg) then
         if (fldmin >= fldmax) then
           scf = 1.d0


### PR DESCRIPTION
I suggest to stop processing in `ncpack` if input field is close to constant, but includes round-off errors.

We could also consider allowing a tolerance of round-off errors, i.e. replacing the field with the offset value when writing the output if the field is "close enough" to constant.

Meanwhile, @matsbn  opened PR #735 , so probably this one is redundant.