### PR TITLE
Correct bug in the estimation of mixed layer depth

### DIFF
--- a/phy/mod_cmnfld_routines.F90
+++ b/phy/mod_cmnfld_routines.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2015-2025 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
+! Copyright (C) 2015-2026 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !
@@ -1039,7 +1039,7 @@ module mod_cmnfld_routines
 
               pup =  p(i,j,1) + zrefb04*onem
               zup = z(i,j,1) + zrefb04
-              dsup = sig0ref
+              dsup = 0._r8
               do
                  if (dp(i,j,km) > onecm) then
                     plo = p(i,j,k) + .5_r8*dp(i,j,km)


### PR DESCRIPTION
This PR corrects a bug in the estimation of mixed layer depth using the method by de Boyer Montégut et al. (2004). In the NorESM applications so far, this leads to answer changes restricted to the diagnostic output of `mldb04`, `mldb04mn` and `mldb04mx`.