### PR TITLE
Fix bug in relaxation of fe, slightly adjust default parameters

### DIFF
--- a/hamocc/mo_ocprod.F90
+++ b/hamocc/mo_ocprod.F90
@@ -543,8 +543,7 @@ contains
             endif
             ocetra(i,j,k,isilica) = ocetra(i,j,k,isilica)-delsil
             ocetra(i,j,k,iopal) = ocetra(i,j,k,iopal)+delsil
-            ocetra(i,j,k,iiron) = ocetra(i,j,k,iiron)+dtr*riron                     &
-                 &                - relaxfe*max(ocetra(i,j,k,iiron)-fesoly,0._rp)     ! This is a bug, this part should not be here, since it is done below
+            ocetra(i,j,k,iiron) = ocetra(i,j,k,iiron)+dtr*riron
 
             if (use_BROMO) then
               ! Bromo source from phytoplankton production and sink to photolysis

--- a/hamocc/mo_param_bgc.F90
+++ b/hamocc/mo_param_bgc.F90
@@ -519,10 +519,10 @@ module mo_param_bgc
   real(rp), protected :: wcal_const  = 30._rp           ! m/d   Sinking speed of CaCO3 shell material
   real(rp), protected :: wopal_const = 30._rp           ! m/d   Sinking speed of opal iris : 60
   real(rp), protected :: wdust_const                    ! m/d   Sinking speed of dust
-  real(rp), protected :: wmin        =  5.4_rp           ! m/d   minimum sinking speed
+  real(rp), protected :: wmin        =  5.75_rp         ! m/d   minimum sinking speed
   real(rp), protected :: wmax        = 60._rp           ! m/d   maximum sinking speed
 ! real(rp), protected :: wlin        = 60._rp/3120._rp  ! m/d/m constant describing incr. with depth, r/a=1.3 (r=0.025)
-  real(rp), protected :: wlin        = 0.0154762_rp     ! m/d/m constant describing incr. with depth, r/a=1.3 (r=0.025)
+  real(rp), protected :: wlin        = 0.0142_rp        ! m/d/m constant describing incr. with depth, r/a=1.3 (r=0.025)
   real(rp), protected :: dustd1      = 0.0001_rp        ! cm = 1 um, boundary between clay and silt
   real(rp), protected :: dustd2                         ! dust diameter squared
   real(rp), protected :: dustd3                         ! dust diameter cubed


### PR DESCRIPTION
This PR fixes a bug in the relaxation of iron that was applied twice. Default sinking parameter are also changed slightly. Together these changes have practically no impact on coupled model simulations. The iron fix slightly increase primary production (and thereby DMS fluxes), but this is compensated by increasing `wmin`. The latter together with a decrease in `wlin` is also an attempt to improve persistent nutrient biases throughout the water column (too high in the deep ocean to little above 2000m).