### PR TITLE
Pass vertical diffusivity and buoyancy frequency squared to iHAMOCC.

### DIFF
--- a/hamocc/mo_hamocc4bcm.F90
+++ b/hamocc/mo_hamocc4bcm.F90
@@ -27,7 +27,7 @@ contains
 
   subroutine hamocc4bcm(kpie,kpje,kpke,kbnd,kplyear,kplmon,kplday,kldtday,pdlxp,pdlyp,pddpo,prho,  &
                         pglat,omask, dust,rivin,ndep,oafx,pi_ph,pfswr,psicomo,ppao,pfu10,ptho,psao,&
-                        patmco2,pflxco2,pflxdms,patmbromo,pflxbromo,                               &
+                        vdiff,bfsq,patmco2,pflxco2,pflxdms,patmbromo,pflxbromo,                    &
                         patmn2o,pflxn2o,patmnh3,pflxnh3,shelfmask)
 
     !***********************************************************************************************
@@ -104,6 +104,8 @@ contains
     real(rp),intent(in)  :: pfu10  (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)      ! absolute wind speed at 10m height [m/s]
     real(rp),intent(in)  :: ptho   (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,kpke) ! potential temperature [deg C].
     real(rp),intent(in)  :: psao   (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,kpke) ! salinity [psu.].
+    real(rp),intent(in)  :: vdiff  (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,kpke) ! vertical diffusivity [m2 s-1].
+    real(rp),intent(in)  :: bfsq   (1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd,kpke) ! buoyancy frequency squared [s-2]
     real(rp),intent(in)  :: patmco2(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)      ! atmospheric CO2 concentration [ppm] used in fully coupled mode
     real(rp),intent(out) :: pflxco2(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)      ! CO2 flux [kg/m^2/s].
     real(rp),intent(out) :: pflxdms(1-kbnd:kpie+kbnd,1-kbnd:kpje+kbnd)      ! DMS flux [kg/m^2/s].

--- a/hamocc/mo_hamocc_step.F90
+++ b/hamocc/mo_hamocc_step.F90
@@ -33,6 +33,8 @@ contains
     use mod_time,       only: date,nday_of_year,nstep,nstep_in_day,nday_in_year
     use mod_grid,       only: plat
     use mod_state,      only: temp,saln
+    use mod_diffusion,  only: difdia
+    use mod_cmnfld,     only: bfsql
     use mod_forcing,    only: swa,slp,abswnd,atmco2,flxco2,flxdms,atmbrf,flxbrf, &
                               atmn2o,flxn2o,atmnh3,flxnh3,atmnhxdep,atmnoydep, &
                               dust_stream, use_stream_dust
@@ -91,7 +93,7 @@ contains
 
     call hamocc4bcm(idm,jdm,kdm,nbdy,date%year,date%month,date%day,ldtday,bgc_dx,bgc_dy,bgc_dp,    &
          &          bgc_rho,plat,omask,dust,rivflx,ndep,oafx,pi_ph,swa,ficem,slp,abswnd,           &
-         &          temp(1-nbdy,1-nbdy,1+nn),saln(1-nbdy,1-nbdy,1+nn),                             &
+         &          temp(1-nbdy,1-nbdy,1+nn),saln(1-nbdy,1-nbdy,1+nn),difdia,bfsql,                &
          &          atmco2,flxco2,flxdms,atmbrf,flxbrf,                                            &
          &          atmn2o,flxn2o,atmnh3,flxnh3,shelfmask)
 

--- a/phy/mod_ale_vdiff.F90
+++ b/phy/mod_ale_vdiff.F90
@@ -79,7 +79,7 @@ contains
               do nt = 1, ntr
                 trc_1d(k,nt) = trc(i,j,kn,nt)
               enddo
-              nutrc_1d(k) = Kdiff_t(i,j,k)
+              nutrc_1d(k) = Kdiff_s(i,j,k)
             end if
           enddo
 

--- a/phy/mod_cmnfld_routines.F90
+++ b/phy/mod_cmnfld_routines.F90
@@ -404,6 +404,14 @@ module mod_cmnfld_routines
             enddo
             bfsqi(i,j,1) = bfsqi(i,j,2)
             bfsqi(i,j,kk+1) = bfsqi(i,j,kk)
+
+            ! Compute the layer BFSQ as the arithmetic mean of the layer
+            ! interface BFSQ.
+            do k = 1, kk - 1
+               bfsql(i,j,k) = .5_r8*(bfsqi(i,j,k) + bfsqi(i,j,k+1))
+            enddo
+            bfsql(i,j,kk) = bfsqi(i,j,kk)
+
          enddo
          enddo
       enddo
@@ -414,6 +422,7 @@ module mod_cmnfld_routines
             write(lp,*) 'cmnfld_bfsqi_ale:'
          endif
          call chksum(bfsqi, kk + 1, halo_ps, 'bfsqi')
+         call chksum(bfsql, kk    , halo_ps, 'bfsql')
       endif
 
    end subroutine cmnfld_bfsqi_ale

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -1380,6 +1380,10 @@ contains
                  nonLocalTrans(k,1))
           end do
 
+          ! Save vertical salinity diffusivity, interpolated from interface to
+          ! layer, in difdia.
+          difdia(i,j,:) = .5_r8*(Ks_kpp(1:kk) + Ks_kpp(2:kk+1))
+
           ! Compute convective velocity cubed [m3 s-3].
           wstar3(i,j) = max(0.,-surfBuoyFlux)*OBLdepth(i,j)
 


### PR DESCRIPTION
For the purpose of obtaining turbulent energy dissipation, $`\epsilon`$, this PR enables passing of vertical diffusivity, $`K`$, and buoyancy frequency squared, $`N^2`$, to iHAMOCC. Then the Osborn relationship ([Osborn, 1980](https://doi.org/10.1175/1520-0485(1980)010%3C0083:EOTLRO%3E2.0.CO;2))

$$K\approx\frac{\Gamma\epsilon}{N^2}$$

can be used to compute the energy dissipation, where $`\Gamma=0.2`$ is a commonly used value.

The computation of vertical diffusivity and buoyancy frequency differs depending on which vertical coordinate is used. With the ALE method these quantities are primarily layer interface variables, while they are layer variables with isopycnic coordinate and bulk mixed layer. With the ALE method I have chosen to interpolate $`K`$ and $`N^2`$ from interfaces to layers, so that the variables passed to iHAMOCC are independent of the choice of vertical coordinate.

This PR also changes the tracer vertical diffusivity to be the same as for salinity (was same as temperature before). With the parameterization choices used so far, temperature and salinity diffusivities have been identical.

This code change does not change results, except for diagnostic variables `bfsq` and `bfsqlvl`, which will differ when the ALE method is used because layer buoyancy frequency are computed differently within a time step (more consistent now with the diffusivity computation). 