### PR TITLE
Add possibility to set CVMix parameter Cv in BLOM namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1871,6 +1871,25 @@
     <desc>If true, layers constructed for diffusive flux computations are gradually aligned with the surface within the mixed layer</desc>
   </entry>
 
+  <entry id="cvmix_cv">
+    <type>real</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>1.2</value>
+    </values>
+    <desc>Scalar value of CVMix parameter Cv</desc>
+  </entry>
+
+  <entry id="cvmix_lscalar_cv">
+    <type>logical</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>.true.</value>
+    </values>
+    <desc>If true, pass scalar Cv parameter to CVMix</desc>
+  </entry>
 
   <!-- ========================= -->
   <!-- namelist group: cwmod -->

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1886,7 +1886,7 @@
     <category>diffusion</category>
     <group>diffusion</group>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
     </values>
     <desc>If true, pass scalar Cv parameter to CVMix</desc>
   </entry>

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -188,6 +188,8 @@
 ! NDIFF_SURFACE_ALIGN : If true, layers constructed for diffusive flux
 !                       computations are gradually aligned with the surface
 !                       within the mixed layer.
+! CVMIX_CV : Scalar value of CVMix parameter Cv () (f).
+! CVMIX_LSCALAR_CV : If true, pass scalar Cv parameter to CVMix (l)
 
 !===========================================================================
 ! NAMELIST FOR CHANNEL WIDTH MODIFICATIONS

--- a/phy/mod_ale_vdiff.F90
+++ b/phy/mod_ale_vdiff.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2021-2025 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
+! Copyright (C) 2021-2026 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !

--- a/phy/mod_blom_step.F90
+++ b/phy/mod_blom_step.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2008-2024 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
+! Copyright (C) 2008-2025 Mats Bentsen, Mehmet Ilicak, Mariana Vertenstein
 !
 ! This file is part of BLOM.
 !

--- a/phy/mod_cmnfld.F90
+++ b/phy/mod_cmnfld.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2015-2025 Mats Bentsen, Mehmet Ilicak
+! Copyright (C) 2015-2026 Mats Bentsen, Mehmet Ilicak
 !
 ! This file is part of BLOM.
 !

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -34,6 +34,7 @@ module mod_difest
   use mod_diffusion,         only: egc, eggam, eglsmn, egmndf, egmxdf, &
                                    egidfq, rhiscf, ri0, bdmc1, bdmc2, bdmldp, &
                                    iwdflg, iwdfac, nubmin, tkepf, lau10f, &
+                                   cvmix_lscalar_cv, cvmix_cv, &
                                    bdmtyp, eddf2d, edsprs, edanis, redi3d, &
                                    rhsctp, edfsmo, smobld, lngmtp, edritp_opt, &
                                    edritp_shear, edritp_large_scale, &
@@ -337,6 +338,11 @@ contains
          Langmuir_mixing_str = langmuir_mixing_opt, &
          Langmuir_entrainment_str = langmuir_entrainment_opt, &
          CVMix_kpp_params_user = KPP_params )
+
+    if (cvmix_lscalar_cv) then
+      call cvmix_put_kpp('lscalar_Cv', .true., KPP_params)
+      call cvmix_put_kpp('Cv', cvmix_cv, KPP_params)
+    endif
 
     !$omp parallel do private(l,i)
     do j = 1,jj

--- a/phy/mod_diffusion.F90
+++ b/phy/mod_diffusion.F90
@@ -1,5 +1,5 @@
 ! ------------------------------------------------------------------------------
-! Copyright (C) 2020-2025 Mats Bentsen, Mehmet Ilicak, Aleksi Nummelin
+! Copyright (C) 2020-2026 Mats Bentsen, Mehmet Ilicak, Aleksi Nummelin
 !
 ! This file is part of BLOM.
 !
@@ -57,8 +57,9 @@ module mod_diffusion
       nubmin, & ! Minimum background diapycnal diffusivity [m2 s-1].
       tkepf, &  ! Fraction of surface TKE that penetrates beneath mixed layer
                 ! [].
-      lau10f    ! Factor applied to 10 m absolute wind entering parameterization
+      lau10f, & ! Factor applied to 10 m absolute wind entering parameterization
                 ! of Langmuir turbulence enhancement factor [].
+      cvmix_cv  ! Scalar value of CVMix parameter Cv [].
    integer :: &
       bdmtyp, & ! Type of background diapycnal mixing. If bdmtyp = 1 the
                 ! background diffusivity is a constant divided by the
@@ -81,9 +82,10 @@ module mod_diffusion
                 ! according to Gregg et al. (2003).
       smobld, & ! If true, apply lateral smoothing of CVMix estimated boundary
                 ! layer depth.
-      ndiff_surface_align ! If true, layers constructed for diffusive flux
-                          ! computations are gradually aligned with the surface
-                          ! within the mixed layer.
+      ndiff_surface_align, & ! If true, layers constructed for diffusive flux
+                             ! computations are gradually aligned with the
+                             ! surface within the mixed layer.
+      cvmix_lscalar_cv       ! If true, pass scalar Cv parameter to CVMix.
    character(len = fnmlen) :: &
       tbfile    ! Name of file containing topographic beta parameter.
    character(len = 80) :: &
@@ -184,11 +186,11 @@ module mod_diffusion
    ! Public variables
    public :: egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
              bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, &
-             bdmtyp, eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, &
-             smobld, ndiff_surface_align, lngmtp, eitmth_opt, eitmth_intdif, &
-             eitmth_gm, edritp_opt, edritp_shear, edritp_large_scale, &
-             edwmth_opt, edwmth_smooth, edwmth_step, ltedtp_opt, ltedtp_layer, &
-             ltedtp_neutral, &
+             cvmix_cv, bdmtyp, eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, &
+             edfsmo, smobld, ndiff_surface_align, cvmix_lscalar_cv, lngmtp, &
+             eitmth_opt, eitmth_intdif, eitmth_gm, edritp_opt, edritp_shear, &
+             edritp_large_scale, edwmth_opt, edwmth_smooth, edwmth_step, &
+             ltedtp_opt, ltedtp_layer, ltedtp_neutral, &
              difint, difiso, difdia, difmxp, difmxq, difwgt, &
              umfltd, vmfltd, umflsm, vmflsm, utfltd, vtfltd, &
              utflsm, vtflsm, utflld, vtflld, usfltd, vsfltd, &
@@ -213,9 +215,10 @@ contains
 
       namelist /diffusion/ &
          egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
-         bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, bdmtyp, &
-         eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, edfsmo, smobld, &
-         lngmtp, eitmth, edritp, edwmth, ltedtp, ndiff_surface_align
+         bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, &
+         cvmix_cv, bdmtyp, eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, &
+         edfsmo, smobld, lngmtp, eitmth, edritp, edwmth, ltedtp, &
+         ndiff_surface_align, cvmix_lscalar_cv
 
       ! Read variables in the namelist group 'diffusion'.
       if (mnproc == 1) then
@@ -261,6 +264,7 @@ contains
         call xcbcst(nubmin)
         call xcbcst(tkepf)
         call xcbcst(lau10f)
+        call xcbcst(cvmix_cv)
         call xcbcst(bdmtyp)
         call xcbcst(eddf2d)
         call xcbcst(edsprs)
@@ -276,6 +280,7 @@ contains
         call xcbcst(edwmth)
         call xcbcst(ltedtp)
         call xcbcst(ndiff_surface_align)
+        call xcbcst(cvmix_lscalar_cv)
       endif
       if (mnproc == 1) then
          write (lp,*) 'readnml_diffusion: diffusion variables:'
@@ -295,6 +300,7 @@ contains
          write (lp,*) '  nubmin = ', nubmin
          write (lp,*) '  tkepf  = ', tkepf
          write (lp,*) '  lau10f = ', lau10f
+         write (lp,*) '  cvmix_cv = ', cvmix_cv
          write (lp,*) '  bdmtyp = ', bdmtyp
          write (lp,*) '  eddf2d = ', eddf2d
          write (lp,*) '  edsprs = ', edsprs
@@ -310,6 +316,7 @@ contains
          write (lp,*) '  edwmth = ', trim(edwmth)
          write (lp,*) '  ltedtp = ', trim(ltedtp)
          write (lp,*) '  ndiff_surface_align = ', ndiff_surface_align
+         write (lp,*) '  cvmix_lscalar_cv    = ', cvmix_lscalar_cv
       endif
 
       ! Resolve options.

--- a/phy/mod_xc.F90
+++ b/phy/mod_xc.F90
@@ -1,6 +1,6 @@
 ! ------------------------------------------------------------------------------
 ! Copyright (C) 2005 HYCOM Consortium and contributors
-! Copyright (C) 2006-2025 Lars Inge Enstad, Mats Bentsen, Alok Kumar Gupta,
+! Copyright (C) 2006-2026 Lars Inge Enstad, Mats Bentsen, Alok Kumar Gupta,
 !                         Mariana Vertenstein
 !
 ! This file is part of BLOM.

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -306,6 +306,8 @@
 ! NDIFF_SURFACE_ALIGN : If true, layers constructed for diffusive flux
 !                       computations are gradually aligned with the surface
 !                       within the mixed layer.
+! CVMIX_CV : Scalar value of CVMix parameter Cv () (f).
+! CVMIX_LSCALAR_CV : If true, pass scalar Cv parameter to CVMix (l)
 
 &DIFFUSION
   EITMTH   = 'gm'
@@ -339,6 +341,8 @@
   LNGMTP   = 'none'
   LTEDTP   = 'layer'
   NDIFF_SURFACE_ALIGN = .false.
+  CVMIX_CV = 1.2
+  CVMIX_LSCALAR_CV = .false.
 /
 
 ! NAMELIST FOR CHANNEL WIDTH MODIFICATIONS


### PR DESCRIPTION
Variables `cvmix_lscalar_cv` and `cvmix_cv` have been added to BLOM namelist so they can be passed to CVMix. With default settings there are no change in results.