### PR TITLE
Ativate CFCs for historical; Activate nat-tracers for historical and scenarios; Activate shelf-sea residence time

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -60,6 +60,7 @@ def buildnml(case, caseroot, compname):
     din_loc_root              = case.get_value("DIN_LOC_ROOT")
     caseroot                  = case.get_value("CASEROOT")
     rundir                    = case.get_value("RUNDIR")
+    compset                   = case.get_value("COMPSET")
     continue_run              = case.get_value("CONTINUE_RUN")
     ninst_ocn                 = case.get_value("NINST_OCN")
     run_type                  = case.get_value("RUN_TYPE")
@@ -227,6 +228,8 @@ def buildnml(case, caseroot, compname):
         config['ocn_ncpl'] = str(ocn_ncpl)
         config['pio_typename_ocn'] = pio_typename_ocn
         config['pio_netcdf_format_ocn'] = pio_netcdf_format_ocn
+        config["ishist"] = "yes" if "HIST_" in compset else "no"
+        config["isscen"] = "yes" if "SCEN7" in compset else "no"  # compset naming to be confirmed!
         config["continue_run"] = "yes" if continue_run else "no"
         config['blom_vcoord'] = blom_vcoord
         config["blom_river_nutrients"] = "yes" if blom_river_nutrients else "no"

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -262,7 +262,7 @@
   <entry id="HAMOCC_SHELFSEA_RES_TIME">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+    <default_value>TRUE</default_value>
     <group>run_component_blom</group>
     <file>env_run.xml</file>
     <desc>Set namelist option to activate the shelfsea water residence time code. Requires module ecosys</desc>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -4967,8 +4967,7 @@
     <group>config_bgc</group>
     <values>
       <value>.false.</value>
-      <value compset="HIST_CAM60%NORESM.*_BLOM.*%ECO">.true.</value>
-      <value compset="20TR_DATM.*_BLOM.*%ECO">.true.</value>
+      <value ishist="yes">.true.</value>
     </values>
     <desc>activates HAMOCC CFC code</desc>
   </entry>
@@ -4979,8 +4978,8 @@
     <group>config_bgc</group>
     <values>
       <value>.false.</value>
-      <value compset="HIST_CAM60%NORESM.*">.true.</value>
-      <value compset="20TR_DATM.*_BLOM.*%ECO">.true.</value>
+      <value ishist="yes">.true.</value>
+      <value isscen="yes">.true.</value>
     </values>
     <desc>activates HAMOCC natural tracer code</desc>
   </entry>


### PR DESCRIPTION
This PR fixes #757 and also activates natural HAMOCC tracers for historical and scenarios. Shelf sea residence time is now switched on by default, which is needed for the last phase of spin-up of NorESM3-LM