### PR TITLE
Add possibility to set CVMix parameter Ri_crit in BLOM namelist

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -1871,6 +1871,16 @@
     <desc>If true, layers constructed for diffusive flux computations are gradually aligned with the surface within the mixed layer</desc>
   </entry>
 
+  <entry id="cvmix_ri_crit">
+    <type>real</type>
+    <category>diffusion</category>
+    <group>diffusion</group>
+    <values>
+      <value>.3</value>
+    </values>
+    <desc>CVMix parameter Ri_crit</desc>
+  </entry>
+
   <entry id="cvmix_cv">
     <type>real</type>
     <category>diffusion</category>

--- a/cime_config/ocn_in.readme
+++ b/cime_config/ocn_in.readme
@@ -188,8 +188,9 @@
 ! NDIFF_SURFACE_ALIGN : If true, layers constructed for diffusive flux
 !                       computations are gradually aligned with the surface
 !                       within the mixed layer.
-! CVMIX_CV : Scalar value of CVMix parameter Cv () (f).
-! CVMIX_LSCALAR_CV : If true, pass scalar Cv parameter to CVMix (l)
+! CVMIX_RI_CRIT       : CVMix parameter Ri_crit () (f).
+! CVMIX_CV            : Scalar value of CVMix parameter Cv () (f).
+! CVMIX_LSCALAR_CV    : If true, pass scalar Cv parameter to CVMix (l)
 
 !===========================================================================
 ! NAMELIST FOR CHANNEL WIDTH MODIFICATIONS

--- a/phy/mod_difest.F90
+++ b/phy/mod_difest.F90
@@ -34,7 +34,7 @@ module mod_difest
   use mod_diffusion,         only: egc, eggam, eglsmn, egmndf, egmxdf, &
                                    egidfq, rhiscf, ri0, bdmc1, bdmc2, bdmldp, &
                                    iwdflg, iwdfac, nubmin, tkepf, lau10f, &
-                                   cvmix_lscalar_cv, cvmix_cv, &
+                                   cvmix_ri_crit, cvmix_lscalar_cv, cvmix_cv, &
                                    bdmtyp, eddf2d, edsprs, edanis, redi3d, &
                                    rhsctp, edfsmo, smobld, lngmtp, edritp_opt, &
                                    edritp_shear, edritp_large_scale, &
@@ -290,7 +290,7 @@ contains
          KPP_Ri_zero = ri0, &
          KPP_exp = 3.0)
     !  CVmix_kpp_params_in => CVmix_kpp_params_user
-    !       call CVMix_init_kpp(Ri_crit=0.3, &
+    !       call CVMix_init_kpp(Ri_crit=cvmix_ri_crit, &
     !             minOBLdepth=minOBLdepth, &
     !             minVtsqr=1e-10, &
     !             vonKarman=0.4, &
@@ -306,7 +306,7 @@ contains
     !             Langmuir_mixing_str=Langmuir_mixing_str, &
     !             Langmuir_entrainment_str=Langmuir_entrainment_str, &
     !             CVMix_kpp_params_user=KPP_params )
-    !       call CVMix_init_kpp(Ri_crit=0.3, &
+    !       call CVMix_init_kpp(Ri_crit=cvmix_ri_crit, &
     !             minOBLdepth=minOBLdepth, &
     !             minVtsqr=1e-10, &
     !             vonKarman=0.4, &
@@ -322,7 +322,7 @@ contains
     !             Langmuir_mixing_str=Langmuir_mixing_str, &
     !             Langmuir_entrainment_str=Langmuir_entrainment_str, &
     !             CVMix_kpp_params_user=KPP_params )
-    call CVMix_init_kpp(Ri_crit = 0.3, &
+    call CVMix_init_kpp(Ri_crit = cvmix_ri_crit, &
          minOBLdepth = minOBLdepth, &
          minVtsqr = 1e-10, &
          vonKarman = 0.4, &

--- a/phy/mod_diffusion.F90
+++ b/phy/mod_diffusion.F90
@@ -59,6 +59,7 @@ module mod_diffusion
                 ! [].
       lau10f, & ! Factor applied to 10 m absolute wind entering parameterization
                 ! of Langmuir turbulence enhancement factor [].
+      cvmix_ri_crit, &  ! CVMix parameter Ri_crit [].
       cvmix_cv  ! Scalar value of CVMix parameter Cv [].
    integer :: &
       bdmtyp, & ! Type of background diapycnal mixing. If bdmtyp = 1 the
@@ -186,8 +187,9 @@ module mod_diffusion
    ! Public variables
    public :: egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
              bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, &
-             cvmix_cv, bdmtyp, eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, &
-             edfsmo, smobld, ndiff_surface_align, cvmix_lscalar_cv, lngmtp, &
+             cvmix_ri_crit, cvmix_cv, bdmtyp, eddf2d, edsprs, edanis, redi3d, &
+             rhsctp, tbfile, edfsmo, smobld, &
+             ndiff_surface_align, cvmix_lscalar_cv, lngmtp, &
              eitmth_opt, eitmth_intdif, eitmth_gm, edritp_opt, edritp_shear, &
              edritp_large_scale, edwmth_opt, edwmth_smooth, edwmth_step, &
              ltedtp_opt, ltedtp_layer, ltedtp_neutral, &
@@ -216,9 +218,9 @@ contains
       namelist /diffusion/ &
          egc, eggam, eglsmn, egmndf, egmxdf, egidfq, rhiscf, ri0, &
          bdmc1, bdmc2, bdmldp, iwdflg, iwdfac, nubmin, tkepf, lau10f, &
-         cvmix_cv, bdmtyp, eddf2d, edsprs, edanis, redi3d, rhsctp, tbfile, &
-         edfsmo, smobld, lngmtp, eitmth, edritp, edwmth, ltedtp, &
-         ndiff_surface_align, cvmix_lscalar_cv
+         cvmix_ri_crit, cvmix_cv, bdmtyp, eddf2d, edsprs, edanis, redi3d, &
+         rhsctp, tbfile, edfsmo, smobld, lngmtp, eitmth, edritp, edwmth, &
+         ltedtp, ndiff_surface_align, cvmix_lscalar_cv
 
       ! Read variables in the namelist group 'diffusion'.
       if (mnproc == 1) then
@@ -264,6 +266,7 @@ contains
         call xcbcst(nubmin)
         call xcbcst(tkepf)
         call xcbcst(lau10f)
+        call xcbcst(cvmix_ri_crit)
         call xcbcst(cvmix_cv)
         call xcbcst(bdmtyp)
         call xcbcst(eddf2d)
@@ -300,7 +303,8 @@ contains
          write (lp,*) '  nubmin = ', nubmin
          write (lp,*) '  tkepf  = ', tkepf
          write (lp,*) '  lau10f = ', lau10f
-         write (lp,*) '  cvmix_cv = ', cvmix_cv
+         write (lp,*) '  cvmix_ri_crit = ', cvmix_ri_crit
+         write (lp,*) '  cvmix_cv      = ', cvmix_cv
          write (lp,*) '  bdmtyp = ', bdmtyp
          write (lp,*) '  eddf2d = ', eddf2d
          write (lp,*) '  edsprs = ', edsprs

--- a/tests/fuk95/limits
+++ b/tests/fuk95/limits
@@ -306,8 +306,9 @@
 ! NDIFF_SURFACE_ALIGN : If true, layers constructed for diffusive flux
 !                       computations are gradually aligned with the surface
 !                       within the mixed layer.
-! CVMIX_CV : Scalar value of CVMix parameter Cv () (f).
-! CVMIX_LSCALAR_CV : If true, pass scalar Cv parameter to CVMix (l)
+! CVMIX_RI_CRIT       : CVMix parameter Ri_crit () (f).
+! CVMIX_CV            : Scalar value of CVMix parameter Cv () (f).
+! CVMIX_LSCALAR_CV    : If true, pass scalar Cv parameter to CVMix (l)
 
 &DIFFUSION
   EITMTH   = 'gm'
@@ -341,8 +342,9 @@
   LNGMTP   = 'none'
   LTEDTP   = 'layer'
   NDIFF_SURFACE_ALIGN = .false.
-  CVMIX_CV = 1.2
-  CVMIX_LSCALAR_CV = .false.
+  CVMIX_RI_CRIT       = .3
+  CVMIX_CV            = 1.2
+  CVMIX_LSCALAR_CV    = .false.
 /
 
 ! NAMELIST FOR CHANNEL WIDTH MODIFICATIONS


### PR DESCRIPTION
With default settings, this PR does not change results, but is necessary to be able to replicate the SourceMod used in https://github.com/NorESMhub/noresm3_dev_simulations/issues/461 with namelist variables.