### PR TITLE
Update list of expected test fails

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -44,20 +44,6 @@
     </phase>
   </test>
 
-  <test name="ERP_Ld3_P256.T62_tn14.NOINYOC.betzy_gnu">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>BLOM#501</issue>
-    </phase>
-  </test>
-
-  <test name="ERP_Ld3_P256.T62_tn14.NOINYOC.olivia_intel">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>BLOM#501</issue>
-    </phase>
-  </test>
-
   <!-- ===================================== -->
   <!-- aux_hamocc_noresm test suite failures -->
   <!-- ===================================== -->

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -28,7 +28,14 @@
   -->
 
 
+  <!-- =================================== -->
   <!-- aux_blom_noresm test suite failures -->
+  <!-- =================================== -->
+
+  <!-- ERP_Ld3_P256 fails on COMPARE_base_rest
+       platform: betzy, olivia
+       ref: https://github.com/NorESMhub/BLOM/discussions/501
+  -->
 
   <test name="ERP_Ld3_P256.T62_tn14.NOINYOC.betzy_intel">
     <phase name="COMPARE_base_rest">
@@ -44,23 +51,21 @@
     </phase>
   </test>
 
+  <test name="ERP_Ld3_P256.T62_tn14.NOINYOC.olivia_intel">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>BLOM#501</issue>
+    </phase>
+  </test>
+
+  <!-- ===================================== -->
   <!-- aux_hamocc_noresm test suite failures -->
+  <!-- ===================================== -->
 
   <test name="SMS_D_Ld1.T62_tn14.NOINYOC.betzy_intel.blom-hamocc-hamocc6">
     <phase name="RUN">
       <status>FAIL</status>
       <issue>BLOM#645</issue>
-    </phase>
-  </test>
-
-  <!-- failing outdated tests -->
-
-  <!-- The NOIIAOC20TR compset is currently not working with NorESM3.
-       This test can be re-activated if we decide to update the compset. -->
-  <test name="SMS_D_Ld1.T62_tn14.NOIIAOC20TR.betzy_intel">
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>BLOM#510</issue>
     </phase>
   </test>
 </expectedFails>

--- a/cime_config/testdefs/testlist_blom.xml
+++ b/cime_config/testdefs/testlist_blom.xml
@@ -135,8 +135,6 @@
   <test name="ERP_Ld3_P256" grid="T62_tn14" compset="NOINYOC">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_blom_noresm"/>
-      <machine name="betzy" compiler="gnu" category="aux_blom_noresm"/>
-      <machine name="olivia" compiler="intel" category="aux_blom_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>


### PR DESCRIPTION
Just a bit of clean up to keep the list of expected failing tests up to date with actual performance.

We have 3 ERP test that are failing for the same reason, at the `COMPARE_base_rest` stage. ERP is testing for difference when running with different processor counts. It is known that BLOM output is sensitive to changing processor count. I propose to leave one ERP test, to ensure that we do not have a `RUN` stage error when changing the processor count (test only on betzy), and remove 2 redundant tests.