### PR TITLE
Feature/fix pacemaker settings

### DIFF
--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6644,7 +6644,8 @@
     <category>limits</category>
     <group>limits</group>
     <values>
-      <value>ocn/n1850_SST_pacemaker_Kuroshio</value>
+      <value>unset</value>
+      <!-- <value>$DIN_LOC_ROOT/ocn/n1850_SST_pacemaker_Kuroshio</value> -->
     </values>
     <desc>Daily sea surface temperatures for pacemaker experiment</desc>
   </entry>
@@ -6654,7 +6655,8 @@
     <category>limits</category>
     <group>limits</group>
     <values>
-      <value>ocn/n1850_SST_pacemaker_Kuroshio</value>
+      <value>unset</value>
+      <!-- <value>$DIN_LOC_ROOT/ocn/n1850_SST_pacemaker_Kuroshio</value> -->
     </values>
     <desc>SST mask file for pacemaker experiment</desc>
   </entry>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6645,7 +6645,6 @@
     <group>limits</group>
     <values>
       <value>unset</value>
-      <!-- <value>$DIN_LOC_ROOT/ocn/n1850_SST_pacemaker_Kuroshio</value> -->
     </values>
     <desc>Daily sea surface temperatures for pacemaker experiment</desc>
   </entry>
@@ -6656,7 +6655,6 @@
     <group>limits</group>
     <values>
       <value>unset</value>
-      <!-- <value>$DIN_LOC_ROOT/ocn/n1850_SST_pacemaker_Kuroshio</value> -->
     </values>
     <desc>SST mask file for pacemaker experiment</desc>
   </entry>


### PR DESCRIPTION
Leave entries for "pacemaker_SST_file" and "pacemaker_mask_file" as `unset` by default.
Prevent errors in case pacemaker files are not found on the system.

Including these files only makes sense in combination with `usermods_dirs/<SST_pacemaker_experiment>`, hence the preferred solution would be to include paths to pacemaker files in a `user_nl_blom` file under a relevant `usermods_dirs` experiment.

Solves #766 