### PR TITLE
Feature/fix pacemaker setting v2

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -249,6 +249,7 @@ def buildnml(case, caseroot, compname):
         groups=['limits','diffusion','merdia','secdia','diaphy']
 
         groups.append('cwmod')
+        groups.append('pacemaker')
 
         if case.get_value("BLOM_VCOORD") == "cntiso_hybrid":
             groups.append('vcoord')

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6639,7 +6639,7 @@
        See Kuroshio current pacemaker experiment at
        <NorESM>/cime_config/usermods_dirs/n1850_SST_pacemaker_Kuroshio
   -->
-  <entry id="pacemaker_SST_file" is_inputdata="yes">
+  <entry id="pacemaker_SST_file" is_inputdata="no">
     <type>char</type>
     <category>limits</category>
     <group>limits</group>
@@ -6649,7 +6649,7 @@
     <desc>Daily sea surface temperatures for pacemaker experiment</desc>
   </entry>
 
-  <entry id="pacemaker_mask_file" is_inputdata="yes">
+  <entry id="pacemaker_mask_file" is_inputdata="no">
     <type>char</type>
     <category>limits</category>
     <group>limits</group>

--- a/cime_config/namelist_definition_blom.xml
+++ b/cime_config/namelist_definition_blom.xml
@@ -6639,20 +6639,20 @@
        See Kuroshio current pacemaker experiment at
        <NorESM>/cime_config/usermods_dirs/n1850_SST_pacemaker_Kuroshio
   -->
-  <entry id="pacemaker_SST_file" is_inputdata="no">
+  <entry id="pacemaker_SST_file" is_inputdata="yes">
     <type>char</type>
-    <category>limits</category>
-    <group>limits</group>
+    <category>pacemaker</category>
+    <group>pacemaker</group>
     <values>
       <value>unset</value>
     </values>
     <desc>Daily sea surface temperatures for pacemaker experiment</desc>
   </entry>
 
-  <entry id="pacemaker_mask_file" is_inputdata="no">
+  <entry id="pacemaker_mask_file" is_inputdata="yes">
     <type>char</type>
-    <category>limits</category>
-    <group>limits</group>
+    <category>pacemaker</category>
+    <group>pacemaker</group>
     <values>
       <value>unset</value>
     </values>


### PR DESCRIPTION
The fix in #768 was incomplete, since it left two variables in the `limits` namelist group that is not defined by default in BLOM.

I suggest to solve this issue by creating a separate `pacemaker` namelist group, that will be defined but not read in by default. I'm not sure if we should include the `pacemaker` entry in the `cime_config/buildnml`. I don't think it is a problem to have extra group entries in the `ocn_in` file that we do not use on a regular basis, but perhaps there is a better way to solve this?

Tested with `NorESM2.0.10` code base, `N1850frc2esm` compset.